### PR TITLE
Specify memory reqs as string (resolves #172)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author='Benedict Paten',
     author_email='benedict@soe.usc.edu',
     url="https://github.com/BD2KGenomics/toil",
-    install_requires=[ ],
+    install_requires=['bd2k-python-lib>=1.7.dev1'],
     extras_require={
         'mesos': [
             'mesos.interface==0.22.0',

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -27,6 +27,7 @@ import cPickle
 from argparse import ArgumentParser
 from optparse import OptionContainer, OptionGroup
 
+from bd2k.util.humanize import human2bytes
 from toil.lib.bioio import addLoggingOptions, getLogLevelString, system, absSymPath
 from toil.batchSystems.parasol import ParasolBatchSystem
 from toil.batchSystems.gridengine import GridengineBatchSystem
@@ -218,13 +219,13 @@ def createConfig(options):
     config.attrib["max_job_duration"] = str(float(options.maxJobDuration))
     config.attrib["batch_system"] = options.batchSystem
     config.attrib["job_time"] = str(float(options.jobTime))
-    config.attrib["max_log_file_size"] = str(int(options.maxLogFileSize))
-    config.attrib["default_memory"] = str(int(options.defaultMemory))
+    config.attrib["max_log_file_size"] = human2bytes(options.maxLogFileSize)
+    config.attrib["default_memory"] = human2bytes(options.defaultMemory)
     config.attrib["default_cpu"] = str(int(options.defaultCpu))
-    config.attrib["default_disk"] = str(int(options.defaultDisk))
+    config.attrib["default_disk"] = human2bytes(options.defaultDisk)
     config.attrib["max_cpus"] = str(int(options.maxCpus))
-    config.attrib["max_memory"] = str(int(options.maxMemory))
-    config.attrib["max_disk"] = str(int(options.maxDisk))
+    config.attrib["max_memory"] = human2bytes(options.maxMemory)
+    config.attrib["max_disk"] = human2bytes(options.maxDisk)
     config.attrib["scale"] = str(float(options.scale))
     if options.bigBatchSystem is not None:
         config.attrib["big_batch_system"] = options.bigBatchSystem

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -219,13 +219,13 @@ def createConfig(options):
     config.attrib["max_job_duration"] = str(float(options.maxJobDuration))
     config.attrib["batch_system"] = options.batchSystem
     config.attrib["job_time"] = str(float(options.jobTime))
-    config.attrib["max_log_file_size"] = human2bytes(options.maxLogFileSize)
-    config.attrib["default_memory"] = human2bytes(options.defaultMemory)
+    config.attrib["max_log_file_size"] = str(human2bytes(str(options.maxLogFileSize)))
+    config.attrib["default_memory"] = str(human2bytes(str(options.defaultMemory)))
     config.attrib["default_cpu"] = str(int(options.defaultCpu))
-    config.attrib["default_disk"] = human2bytes(options.defaultDisk)
+    config.attrib["default_disk"] = str(human2bytes(str(options.defaultDisk)))
     config.attrib["max_cpus"] = str(int(options.maxCpus))
-    config.attrib["max_memory"] = human2bytes(options.maxMemory)
-    config.attrib["max_disk"] = human2bytes(options.maxDisk)
+    config.attrib["max_memory"] = str(human2bytes(str(options.maxMemory)))
+    config.attrib["max_disk"] = str(human2bytes(str(options.maxDisk)))
     config.attrib["scale"] = str(float(options.scale))
     if options.bigBatchSystem is not None:
         config.attrib["big_batch_system"] = options.bigBatchSystem

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -60,9 +60,12 @@ class Job(object):
         Memory is the maximum number of bytes of memory the job will
         require to run. Cpu is the number of cores required. 
         """
-        self.memory = human2bytes(str(memory))
         self.cpu = cpu
-        self.disk = human2bytes(str(disk))
+        # passing sys.maxint to human2bytes seems to result in some float imprecision, and returns a value 1
+        # larger than sys.maxint. We later assume that any value here not equal to sys.maxint must be the user's value
+        # so it is passed to the batch system, which cannot allocate that many resources.
+        self.memory = human2bytes(str(memory)) if memory!=sys.maxint else sys.maxint
+        self.disk = human2bytes(str(disk)) if disk!=sys.maxint else sys.maxint
         #Private class variables
         
         #See Job.addChild

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -30,6 +30,7 @@ import tempfile
 import uuid
 import time
 from toil.resource import ModuleDescriptor
+from bd2k.util.humanize import human2bytes
 
 try:
     import cPickle 
@@ -59,9 +60,9 @@ class Job(object):
         Memory is the maximum number of bytes of memory the job will
         require to run. Cpu is the number of cores required. 
         """
-        self.memory = memory
+        self.memory = human2bytes(str(memory))
         self.cpu = cpu
-        self.disk = disk
+        self.disk = human2bytes(str(disk))
         #Private class variables
         
         #See Job.addChild


### PR DESCRIPTION
Byte-based resource requirements can be specified as various byte-based units in addition to just bytes. Adds this functionality to Job's resource requirements as well as the max_log_size and default/max memory/disk toil options. Adds bd2k-python-lib 1.7 as a dependency, and uses the human2byte method provided within that library.