### PR TITLE
Fix gridEngine (resolves #213)

### DIFF
--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -191,7 +191,7 @@ class SingleMachineBatchSystem(AbstractBatchSystem):
 
     def killBatchJobs(self, jobIDs):
         """
-        As jobs are already run, this method has no effect.
+        Kills jobs by ID
         """
         logger.debug('Killing jobs: {}'.format(jobIDs))
         for id in jobIDs:

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -410,4 +410,5 @@ def setupToil(options, userScript=None):
         serialiseEnvironment(jobStore)
         yield (config, batchSystem, jobStore)
     finally:
+        logger.debug('Shutting down batch system')
         batchSystem.shutdown()


### PR DESCRIPTION
Added maxDisk to the gridEngineBatchSystem constructor

replaced undefined values in __str__ with self.values

Fixed typo (curline -> currline)

Added disk to issueBatchJob and self.checkResourceRequest

maxWait not defined in killBatchJobs method, replaced with standard killedJobsQueue.get()

Added shutdown method to gridEngine

Replaced getFromQueueSafely with standard .get() call

Changed "p=str(cpu)" to specify cores to:  ["-pe", "smp", str(cpu)]

CPU only accepts integers. Since TOIL handles floats, the values supplied to cpu will be rounded up.

Added debug messages for logging.

Added explanatory docstring for overridden shutdown() (+19 squashed commits)