### PR TITLE
Change behavior of Job.Runner.startToil (resolves #277)

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -351,7 +351,10 @@ class Job(object):
             """
             Runs the toil workflow using the given options 
             (see Job.Runner.getDefaultOptions and Job.Runner.addToilOptions) 
-            starting with this job.
+            starting with this job. 
+            
+            :raises: toil.leader.FailedJobsException if at the end of function their remain
+    failed jobs
             """
             setLoggingFromOptions(options)
             with setupToil(options, userScript=job.getUserScript()) as (config, batchSystem, jobStore):
@@ -362,7 +365,7 @@ class Job(object):
                     #Setup the first wrapper.
                     rootJob = job._serialiseFirstJob(jobStore)
                 return mainLoop(config, batchSystem, jobStore, rootJob)
-        
+
     class FileStore:
         """
         Class used to manage temporary files and log messages, 

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -310,9 +310,18 @@ class ToilState( object ):
                     #but we add back a predecessor link
                     self.successorJobStoreIDToPredecessorJobs[successorJobStoreID].append(job)
 
+class FailedJobsException( Exception ):
+    def __init__( self, jobStoreString, numberOfFailedJobs ):
+        super( FailedJobsException, self ).__init__( "The job store '%s' contains %i failed jobs" % (jobStoreString, numberOfFailedJobs))
+        self.jobStoreString = jobStoreString
+        self.numberOfFailedJobs = numberOfFailedJobs
+        
 def mainLoop(config, batchSystem, jobStore, rootJob):
     """
     This is the main loop from which jobs are issued and processed.
+    
+    :raises: toil.leader.FailedJobsException if at the end of function their remain
+    failed jobs
     """
 
     ##########################################
@@ -496,5 +505,6 @@ def mainLoop(config, batchSystem, jobStore, rootJob):
         clean = config.clean
         if clean=="always" or clean == "onError" and totalFailedJobs>0 or clean == "onSuccess" and totalFailedJobs==0:
             jobStore.deleteJobStore()
-
-    return totalFailedJobs #Returns number of failed jobs
+    
+    if totalFailedJobs > 0:
+        raise FailedJobsException( config.jobStore, totalFailedJobs )

--- a/src/toil/test/dependencies/dependenciesTest.py
+++ b/src/toil/test/dependencies/dependenciesTest.py
@@ -82,11 +82,9 @@ class DependenciesTest(ToilTest):
             options.maxCpus = maxCpus
 
             baseJob = FirstJob(tree, "Anc00", sleepTime, startTime, int(cpusPerJob))
-            i = Job.Runner.startToil(baseJob, options)
+            Job.Runner.startToil(baseJob, options)
 
             checkLog(logName, maxCpus, maxThreads, cpusPerJob, sleepTime)
-
-            self.assertEquals(i, 0)
 
             os.close(logFd)
 

--- a/src/toil/test/mesos/stress.py
+++ b/src/toil/test/mesos/stress.py
@@ -58,8 +58,7 @@ def main(numJobs):
 
     # Launch first toil Job
     i = LongTestJob( numJobs )
-    j = Job.Runner.startToil(i,  options )
-    assert(j==0) # confirm that no jobs failed
+    Job.Runner.startToil(i,  options )
 
 if __name__=="__main__":
     main(numJobs=5)

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -18,6 +18,7 @@ from toil.test.sort.lib import merge, sort, copySubRangeOfFile, getMidPoint
 from toil.test.sort.sort import setup
 from toil.test import ToilTest, needs_aws, needs_mesos
 from toil.jobStores.abstractJobStore import JobStoreCreationException
+from toil.leader import FailedJobsException
 
 log = logging.getLogger(__name__)
 
@@ -78,7 +79,11 @@ class SortTest(ToilTest, MesosTestSupport):
             options.restart = False
 
             # Now actually run the workflow
-            i = Job.Runner.startToil(firstJob, options)
+            try:
+                Job.Runner.startToil(firstJob, options)
+                i = 0
+            except FailedJobsException as e:
+                i = e.numberOfFailedJobs
 
             # Check we get an exception if we try to run without restart on an existing job store
             try:
@@ -92,7 +97,11 @@ class SortTest(ToilTest, MesosTestSupport):
             # This loop tests the restart behavior
             while i != 0:
                 options.useExistingOptions = random.random() > 0.5
-                i = Job.Runner.startToil(firstJob, options)
+                try:
+                    Job.Runner.startToil(firstJob, options)
+                    i = 0
+                except FailedJobsException as e:
+                    i = e.numberOfFailedJobs
 
             # Now check that if you try to restart from here it will raise an exception
             # indicating that there are no jobs remaining in the workflow.

--- a/src/toil/test/src/jobEncapsulationTest.py
+++ b/src/toil/test/src/jobEncapsulationTest.py
@@ -36,7 +36,7 @@ class JobEncapsulationTest(ToilTest):
             options.jobStore = self._getTestJobStorePath()
             options.logLevel = "INFO"
             # Run the workflow, the return value being the number of failed jobs
-            self.assertEquals(T.Runner.startToil(a, options), 0)
+            T.Runner.startToil(a, options)
             # Check output
             self.assertEquals(open(outFile, 'r').readline(), "ABCDE")
         finally:

--- a/src/toil/test/src/jobServiceTest.py
+++ b/src/toil/test/src/jobServiceTest.py
@@ -52,7 +52,7 @@ class JobServiceTest(ToilTest):
             options.logLevel = "INFO"
             options.jobStore = self._getTestJobStorePath()
             # Run the workflow, the return value being the number of failed jobs
-            self.assertEquals(Job.Runner.startToil(t, options), 0)
+            Job.Runner.startToil(t, options)
             # Check output
             self.assertEquals(open(outFile, 'r').readline(), "123")
         finally:

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -49,7 +49,7 @@ class JobTest(ToilTest):
             options.jobStore = self._getTestJobStorePath()
             options.logLevel = "INFO"
             # Run the workflow, the return value being the number of failed jobs
-            self.assertEquals(Job.Runner.startToil(A, options), 0)
+            Job.Runner.startToil(A, options)
 
             # Check output
             self.assertEquals(open(outFile, 'r').readline(), "ABCDEF")
@@ -174,8 +174,7 @@ class JobTest(ToilTest):
             # Run the job  graph
             options = Job.Runner.getDefaultOptions()
             options.jobStore = "%s.%i" % (jobStore, test)
-            failedJobs = Job.Runner.startToil(rootJob, options)
-            self.assertEquals(failedJobs, 0)
+            Job.Runner.startToil(rootJob, options)
             # Get the ordering add the implied ordering to the graph
             with open(outFile, 'r') as fH:
                 ordering = map(int, fH.readline().split())

--- a/src/toil/utils/toilRestart.py
+++ b/src/toil/utils/toilRestart.py
@@ -64,7 +64,7 @@ def main():
     options.restart = True
     with setupToil(options) as (config, batchSystem, jobStore):
         jobStore.clean()
-        return mainLoop(config, batchSystem, jobStore, Job._loadRootJob(jobStore))
+        mainLoop(config, batchSystem, jobStore, Job._loadRootJob(jobStore))
     
 def _test():
     import doctest      


### PR DESCRIPTION
Change behavior of Job.Runner.startToil to raise an exception if there are failed jobs at the end of a run.

Resolves #277 