### PR TITLE
Setup Parasol unit tests for continuous integration (resolves #258, resolves #282)

### DIFF
--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -93,8 +93,8 @@ def getUpdatedJob(parasolResultsFile, outputQueue1, outputQueue2):
 class ParasolBatchSystem(AbstractBatchSystem):
     """The interface for Parasol.
     """
-    def __init__(self, config, maxCores, maxMemory):
-        AbstractBatchSystem.__init__(self, config, maxCores, maxMemory) #Call the parent constructor
+    def __init__(self, config, maxCores, maxMemory, maxDisk):
+        AbstractBatchSystem.__init__(self, config, maxCores, maxMemory, maxDisk) #Call the parent constructor
         if maxMemory != sys.maxint:
             logger.warn("A max memory has been specified for the parasol batch system class of %i, but currently "
                         "this batchsystem interface does not support such limiting" % maxMemory)
@@ -128,12 +128,13 @@ class ParasolBatchSystem(AbstractBatchSystem):
         self.usedCpus = 0
         self.jobIDsToCpu = {}
          
-    def issueBatchJob(self, command, memory, cores):
+    def issueBatchJob(self, command, memory, cores, disk):
         """Issues parasol with job commands.
         """
-        self.checkResourceRequest(memory, cores)
+        self.checkResourceRequest(memory, cores, disk)
         pattern = re.compile("your job ([0-9]+).*")
-        parasolCommand = "%s -verbose -ram=%i -cores=%i -results=%s add job '%s'" % (self.parasolCommand, memory, cores, self.parasolResultsFile, command)
+        parasolCommand = "%s -verbose -ram=%i -cpu=%i -results=%s add job '%s'" % (self.parasolCommand, memory, cores, self.parasolResultsFile, command)
+
         #Deal with the cpus
         self.usedCpus += cores
         while True: #Process finished results with no wait
@@ -222,6 +223,8 @@ class ParasolBatchSystem(AbstractBatchSystem):
         making it expensive. 
         """
         return 5400 #Once every 90 minutes
+    def shutdown(self):
+        pass
         
 def main():
     pass

--- a/src/toil/batchSystems/parasolTestSupport.py
+++ b/src/toil/batchSystems/parasolTestSupport.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import
+from abc import ABCMeta, abstractmethod
+import logging
+import shutil
+import threading
+import time
+import subprocess
+import multiprocessing
+import os
+from toil.lib.bioio import getTempFile
+
+log = logging.getLogger(__name__)
+
+
+class ParasolTestSupport(object):
+    """
+    For test cases that need a running Parasol leader and worker on the local host
+    """
+    def _startParasol(self, numCores=None):
+        if numCores is None:
+            numCores = multiprocessing.cpu_count()
+        self.machineList = os.path.join(os.getcwd(), "machineList.txt")
+        with open(self.machineList, "w") as out:
+            out.write("localhost 4 3000 /tmp /scratch 36000 r1")
+
+        self.leader = self.ParasolLeaderThread(numCores)
+        self.leader.start()
+        self.worker = self.ParasolWorkerThread(numCores)
+        self.worker.start()
+        while self.leader.popen is None or self.worker.popen is None:
+            log.info("Waiting for leader and worker processes")
+            time.sleep(.1)
+
+    def _stopParasol(self):
+        self.worker.popen.kill()
+        self.worker.join()
+        self.leader.popen.kill()
+        self.leader.join()
+        os.remove(self.machineList)
+        if os.path.exists("para.results"):
+            os.remove("para.results")
+        if os.path.exists("parasol.jid"):
+            os.remove("parasol.jid")
+
+    class ParasolThread(threading.Thread):
+        __metaclass__ = ABCMeta
+
+        # Lock is used because subprocess is NOT thread safe: http://tinyurl.com/pkp5pgq
+        lock = threading.Lock()
+
+        def __init__(self, numCores):
+            threading.Thread.__init__(self)
+            self.numCores = numCores
+            self.popen = None
+            
+
+        @abstractmethod
+        def parasolCommand(self):
+            raise NotImplementedError
+
+        def run(self):
+            with self.lock:
+                self.popen = subprocess.Popen(self.parasolCommand())
+            self.popen.wait()
+            log.info('Exiting %s', self.__class__.__name__)
+
+    class ParasolLeaderThread(ParasolThread):
+        def parasolCommand(self):
+            return ['paraHub',
+                    '-debug',
+                    os.path.join(os.getcwd(), "machineList.txt")]
+
+    class ParasolWorkerThread(ParasolThread):
+        def parasolCommand(self):
+            return ['paraNode',
+                    '-cpu=4',
+                    '-debug',
+                    'start']

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -19,6 +19,7 @@ import tempfile
 import unittest
 import shutil
 import re
+import subprocess
 
 from bd2k.util.files import mkdir_p
 
@@ -165,6 +166,20 @@ def needs_mesos(test_item):
         import mesos.native
     except ImportError:
         return unittest.skip("Skipping test. Install Mesos to include this test.")(test_item)
+    except:
+        raise
+    else:
+        return test_item
+
+
+def needs_parasol(test_item):
+    """
+    Use as decorator so tests are only run if Parasol is installed.
+    """
+    try:
+        subprocess.Popen("parasol")
+    except OSError:
+        return unittest.skip("Skipping test. Install Parasol to include this test.")(test_item)
     except:
         raise
     else:


### PR DESCRIPTION
All the unit tests pass, but I had to increase the memory limits to 1 GB because parasol apparently needs at least 100 MB for each job. The problems from before were all due to the memory limits being set too low for parasol. paraHub/paraNode don't need to be run as root. 