### PR TITLE
Make jobStore argument positional (resolves #329)

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -19,7 +19,6 @@ import os
 import sys
 import cPickle
 from argparse import ArgumentParser
-from optparse import OptionContainer, OptionGroup
 
 from toil.lib.bioio import addLoggingOptions, getLogLevelString, absSymPath
 from toil.batchSystems.parasol import ParasolBatchSystem
@@ -84,13 +83,13 @@ class Config(object):
     def setOptions(self, options):
         """
         Creates a config object from the options object.
-        """ 
+        """
         from bd2k.util.humanize import human2bytes #This import is used to convert
         #from human readable quantites to integers 
         def setOption(varName, parsingFn=None, checkFn=None):
             #If options object has the option "varName" specified
             #then set the "varName" attrib to this value in the config object
-            x = getattr(options, varName)
+            x = getattr(options, varName, None)
             if x != None:
                 if parsingFn != None:
                     x = parsingFn(x)
@@ -163,14 +162,13 @@ def _addOptions(addGroupFn, config):
     addOptionFn = addGroupFn("toil core options", "Options to specify the \
     location of the toil and turn on stats collation about the performance of jobs.")
     #TODO - specify how this works when path is AWS
-    addOptionFn("--jobStore", dest="jobStore", default=None,
+    addOptionFn('jobStore', type=str,
                       help=("Store in which to place job management files \
                       and the global accessed temporary files"
-                            "(If this is a file path this needs to be globally accessible "
-                            "by all machines running jobs).\n"
-                            "If the store already exists and restart is false an"
-                            " ExistingJobStoreException exception will be thrown."
-                            " The default=%s" % config.jobStore))
+                      "(If this is a file path this needs to be globally accessible "
+                      "by all machines running jobs).\n"
+                      "If the store already exists and restart is false an"
+                      " ExistingJobStoreException exception will be thrown."))
     addOptionFn("--workDir", dest="workDir", default=None,
                 help="Absolute path to directory where temporary files generated during the Toil run should be placed. "
                      "Default is determined by environmental variables (TMPDIR, TEMP, TMP) via mkdtemp")
@@ -268,14 +266,7 @@ def addOptions(parser, config=Config()):
     # Wrapper function that allows toil to be used with both the optparse and
     # argparse option parsing modules
     addLoggingOptions(parser) # This adds the logging stuff.
-    if isinstance(parser, OptionContainer):
-        def addGroup(headingString, bodyString):
-            group = OptionGroup(parser, headingString, bodyString)
-            parser.add_option_group(group)
-            return group.add_option
-        _addOptions(addGroup, config)
-        #parser.add_option_group(group)
-    elif isinstance(parser, ArgumentParser):
+    if isinstance(parser, ArgumentParser):
         def addGroup(headingString, bodyString):
             return parser.add_argument_group(headingString, bodyString).add_argument
         _addOptions(addGroup, config)

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 import os
 import sys
 import importlib
-from optparse import OptionParser
+from argparse import ArgumentParser
 import xml.etree.cElementTree as ET
 from abc import ABCMeta, abstractmethod
 import tempfile
@@ -316,15 +316,14 @@ class Job(object):
         """
     
         @staticmethod
-        def getDefaultOptions():
+        def getDefaultOptions(jobStore):
             """
             Returns an optparse.Values object of the 
             options used by a toil.
             """
-            parser = OptionParser()
+            parser = ArgumentParser()
             Job.Runner.addToilOptions(parser)
-            options, args = parser.parse_args(args=[])
-            assert len(args) == 0
+            options = parser.parse_args(args=[jobStore])
             return options
             
         @staticmethod

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -244,13 +244,13 @@ class TestStatus:
         return os.environ["SON_TRACE_DATASETS"]
     getPathToDataSets = staticmethod(getPathToDataSets)
 
-def getBasicOptionParser(usage="usage: %prog [options]", version="%prog 0.1", parser=None):
+def getBasicOptionParser( parser=None):
     if parser is None:
-        parser = OptionParser(usage=usage, version=version)
+        parser = ArgumentParser()
 
     addLoggingOptions(parser)
 
-    parser.add_option("--tempDirRoot", dest="tempDirRoot", type="string",
+    parser.add_argument("--tempDirRoot", dest="tempDirRoot", type=str,
                       help="Path to where temporary directory containing all temp files are created, by default uses the current working directory as the base.",
                       default=tempfile.gettempdir())
 
@@ -259,7 +259,7 @@ def getBasicOptionParser(usage="usage: %prog [options]", version="%prog 0.1", pa
 def parseBasicOptions(parser):
     """Setups the standard things from things added by getBasicOptionParser.
     """
-    (options, args) = parser.parse_args()
+    options = parser.parse_args()
 
     setLoggingFromOptions(options)
 
@@ -267,7 +267,7 @@ def parseBasicOptions(parser):
     if options.tempDirRoot == "None": # FIXME: Really, a string containing the word None?
         options.tempDirRoot = tempfile.gettempdir()
 
-    return options, args
+    return options
 
 def getRandomAlphaNumericString(length=10):
     """Returns a random alpha numeric string of the given length.

--- a/src/toil/test/dependencies/dependenciesTest.py
+++ b/src/toil/test/dependencies/dependenciesTest.py
@@ -79,8 +79,7 @@ class DependenciesTest(ToilTest):
             else:
                 tree = combTree(size)
 
-            options = Job.Runner.getDefaultOptions()
-            options.jobStore = self.jobStore
+            options = Job.Runner.getDefaultOptions(self.jobStore)
             options.maxThreads = maxThreads
             options.batchSystem = batchSystem
             options.logFile = logName

--- a/src/toil/test/mesos/helloWorld.py
+++ b/src/toil/test/mesos/helloWorld.py
@@ -16,7 +16,7 @@ A simple user script for Toil
 """
 
 from __future__ import absolute_import
-from optparse import OptionParser
+import argparse
 import os
 from toil.job import Job
 
@@ -52,16 +52,17 @@ def hello_world_child(job, hw):
 
 def main():
     # Boilerplate -- startToil requires options
-    parser = OptionParser()
+
+    parser = argparse.ArgumentParser()
     Job.Runner.addToilOptions(parser)
-    options, args = parser.parse_args()
+    args = parser.parse_args()
 
     # Create object that contains our FileStoreIDs
 
-
+    print args.jobStore
     # Launch first toil Job
     i = Job.wrapJobFn(hello_world, memory=100, cores=0.5, disk=2000)
-    j = Job.Runner.startToil(i, options)
+    j = Job.Runner.startToil(i, args)
 
 
 if __name__ == '__main__':

--- a/src/toil/test/mesos/mesosTest.py
+++ b/src/toil/test/mesos/mesosTest.py
@@ -57,7 +57,7 @@ class MesosTest(ToilTest, MesosTestSupport):
 
     def test_hello_world(self):
         dirPath = os.path.dirname(os.path.abspath(__file__))
-        subprocess.check_call("python {dirPath}/helloWorld.py "
+        subprocess.check_call("python {dirPath}/helloWorld.py ./toilTest "
                               "--batchSystem=mesos "
                               "--logLevel={logLevel}".format(dirPath=dirPath,
                                                              logLevel=getLogLevelString()),

--- a/src/toil/test/mesos/stress.py
+++ b/src/toil/test/mesos/stress.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import absolute_import
 import sys
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 from toil.job import Job
 
@@ -60,15 +60,11 @@ class HelloWorldFollowOn(Job):
         touchFile( fileStore)
 
 def main(numJobs):
-    args = list( sys.argv )
-    args.append('--batchSystem=mesos')
-    args.append('--retryCount=3')
-
     # Boilerplate -- startToil requires options
-    parser = OptionParser()
+    parser = ArgumentParser()
     Job.Runner.addToilOptions(parser)
-    options, args = parser.parse_args( args )
-
+    options = parser.parse_args( args=["./toilTest"] )
+    options.batchSystem="mesos"
     # Launch first toil Job
     i = LongTestJob( numJobs )
     Job.Runner.startToil(i,  options )

--- a/src/toil/test/sort/sort.py
+++ b/src/toil/test/sort/sort.py
@@ -17,7 +17,7 @@
 """A demonstration of toil. Sorts the lines of a file into ascending order by doing a parallel merge sort.
 """
 from __future__ import absolute_import
-from optparse import OptionParser
+from argparse import ArgumentParser
 import os
 import random
 
@@ -95,18 +95,18 @@ def cleanup(job, tempOutputFileStoreID, outputFile):
     #sort(outputFile)
 
 def main():
-    parser = OptionParser()
+    parser = ArgumentParser()
     Job.Runner.addToilOptions(parser)
     
-    parser.add_option("--fileToSort", dest="fileToSort",
+    parser.add_argument("--fileToSort", dest="fileToSort",
                       help="The file you wish to sort")
     
-    parser.add_option("--N", dest="N",
+    parser.add_argument("--N", dest="N",
                       help="The threshold below which a serial sort function is"
                       "used to sort file. All lines must of length less than or equal to N or program will fail", 
                       default=10000)
     
-    options, args = parser.parse_args()
+    options = parser.parse_args()
     
     if options.fileToSort is None:
         raise RuntimeError("No file to sort given")
@@ -116,9 +116,6 @@ def main():
     
     if int(options.N) <= 0:
         raise RuntimeError("Invalid value of N: %s" % options.N)
-    
-    if len(args) != 0:
-        raise RuntimeError("Unrecognised input arguments: %s" % " ".join(args))
     
     #Now we are ready to run
     Job.Runner.startToil(Job.wrapJobFn(setup, options.fileToSort, int(options.N)), options)

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -51,8 +51,7 @@ class SortTest(ToilTest, MesosTestSupport):
 
             try:
                 # Specify options
-                options = Job.Runner.getDefaultOptions()
-                options.jobStore = jobStore
+                options = Job.Runner.getDefaultOptions(jobStore)
                 options.logLevel = getLogLevelString()
                 options.retryCount = 2
                 options.batchSystem = batchSystem
@@ -118,8 +117,7 @@ class SortTest(ToilTest, MesosTestSupport):
                     l2 = fileHandle.readlines()
                     checkEqual(l, l2)
             finally:
-                subprocess.check_call([self._getUtilScriptPath('toilMain'), 'clean',
-                                       '--jobStore', jobStore])
+                subprocess.check_call([self._getUtilScriptPath('toilMain'), 'clean', jobStore])
 
     @needs_aws
     def testToilSortOnAWS(self):

--- a/src/toil/test/src/jobEncapsulationTest.py
+++ b/src/toil/test/src/jobEncapsulationTest.py
@@ -45,8 +45,7 @@ class JobEncapsulationTest(ToilTest):
             a.addChild(d)
             a.addFollowOn(e)
             # Create the runner for the workflow.
-            options = T.Runner.getDefaultOptions()
-            options.jobStore = self._getTestJobStorePath()
+            options = T.Runner.getDefaultOptions(self._getTestJobStorePath())
             options.logLevel = "INFO"
             # Run the workflow, the return value being the number of failed jobs
             T.Runner.startToil(a, options)

--- a/src/toil/test/src/jobServiceTest.py
+++ b/src/toil/test/src/jobServiceTest.py
@@ -34,9 +34,8 @@ class JobServiceTest(ToilTest):
             t = Job.wrapFn(f, "1", outFile)
             t.addChildFn(f, t.addService(TestService("2", "3", outFile)), outFile)
             # Create the runner for the workflow.
-            options = Job.Runner.getDefaultOptions()
+            options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
             options.logLevel = "INFO"
-            options.jobStore = self._getTestJobStorePath()
             # Run the workflow, the return value being the number of failed jobs
             Job.Runner.startToil(t, options)
             # Check output

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -58,8 +58,7 @@ class JobTest(ToilTest):
             A.addFollowOn(F)
 
             # Create the runner for the workflow.
-            options = Job.Runner.getDefaultOptions()
-            options.jobStore = self._getTestJobStorePath()
+            options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
             options.logLevel = "INFO"
             # Run the workflow, the return value being the number of failed jobs
             Job.Runner.startToil(A, options)
@@ -185,8 +184,7 @@ class JobTest(ToilTest):
             # Make the job graph
             rootJob = self.makeJobGraph(nodeNumber, childEdges, followOnEdges, outFile)
             # Run the job  graph
-            options = Job.Runner.getDefaultOptions()
-            options.jobStore = "%s.%i" % (jobStore, test)
+            options = Job.Runner.getDefaultOptions("%s.%i" % (jobStore, test))
             Job.Runner.startToil(rootJob, options)
             # Get the ordering add the implied ordering to the graph
             with open(outFile, 'r') as fH:

--- a/src/toil/test/src/jobWrapperTest.py
+++ b/src/toil/test/src/jobWrapperTest.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 import unittest
 import os
 from toil.lib.bioio import system
-from optparse import OptionParser
+from argparse import ArgumentParser
 from toil.common import setupToil
 from toil.job import Job
 from toil.test import ToilTest
@@ -29,10 +29,9 @@ class JobWrapperTest(ToilTest):
     def setUp(self):
         super( JobWrapperTest, self ).setUp( )
         self.jobStorePath = self._getTestJobStorePath()
-        parser = OptionParser()
+        parser = ArgumentParser()
         Job.Runner.addToilOptions(parser)
-        options, args = parser.parse_args()
-        options.jobStore = self.jobStorePath
+        options = parser.parse_args(args=[self.jobStorePath])
         self.contextManager = setupToil(options)
         config, batchSystem, self.jobStore = self.contextManager.__enter__()
 

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -63,7 +63,7 @@ class UtilsTest(ToilTest):
         """
         # Get the sort command to run
         toilCommandString = ("{self.sort} "
-                             "--jobStore {self.toilDir} "
+                             "{self.toilDir} "
                              "--logLevel=DEBUG "
                              "--fileToSort={self.tempFile} "
                              "--N {self.N} --stats "
@@ -76,7 +76,7 @@ class UtilsTest(ToilTest):
 
         # Status command
         toilStatusCommandString = ("{self.toilMain} status "
-                                   "--jobStore {self.toilDir} "
+                                   "{self.toilDir} "
                                    "--failIfNotComplete".format(**locals()))
 
         # Run the script for the first time
@@ -107,7 +107,7 @@ class UtilsTest(ToilTest):
 
         # Check we can run 'toil stats'
         toilStatsString = ("{self.toilMain} stats "
-                           "--jobStore {self.toilDir} "
+                           "{self.toilDir} "
                            "--pretty".format(**locals()))
         system(toilStatsString)
 
@@ -118,7 +118,7 @@ class UtilsTest(ToilTest):
 
         # Check we can run 'toil clean'
         toilCleanString = ("{self.toilMain} clean "
-                           "--jobStore {self.toilDir}".format(**locals()))
+                           "{self.toilDir}".format(**locals()))
         system(toilCleanString)
             
     def testUtilsStatsSort(self):
@@ -127,7 +127,7 @@ class UtilsTest(ToilTest):
         """
         # Get the sort command to run
         toilCommandString = ("{self.sort} "
-                             "--jobStore {self.toilDir} "
+                             "{self.toilDir} "
                              "--logLevel=DEBUG "
                              "--fileToSort={self.tempFile} "
                              "--N {self.N} --stats "
@@ -140,7 +140,7 @@ class UtilsTest(ToilTest):
         # Check we can run 'toil stats'
         rootPath = os.path.join(toilPackageDirPath(), "utils")
         toilStatsString = ("{self.toilMain} stats "
-                           "--jobStore {self.toilDir} --pretty".format(**locals()))
+                           "{self.toilDir} --pretty".format(**locals()))
         system(toilStatsString)
 
         # Check the file is properly sorted

--- a/src/toil/utils/toilClean.py
+++ b/src/toil/utils/toilClean.py
@@ -34,30 +34,22 @@ def main():
     #Construct the arguments.
     ##########################################
 
-    parser = getBasicOptionParser("usage: %prog clean [--jobStore] JOB_STORE", "%prog "+version)
-
-    parser.add_option("--jobStore", dest="jobStore",
-                      help="Job store path. Can also be specified as the single argument to the script.\
-                       default=%default", default=os.path.abspath("./toil"))
-
-    options, args = parseBasicOptions(parser)
+    parser = getBasicOptionParser()
+    parser.add_argument("jobStore", type=str,
+                      help=("Store in which to place job management files \
+                      and the global accessed temporary files"
+                      "(If this is a file path this needs to be globally accessible "
+                      "by all machines running jobs).\n"
+                      "If the store already exists and restart is false an"
+                      " ExistingJobStoreException exception will be thrown."))
+    parser.add_argument("--version", action='version', version=version)
+    options = parseBasicOptions(parser)
     logger.info("Parsed arguments")
-
-    # the JobStore may also be passed as an argument directly to the script
-    assert len(args) <= 1
-    if len(args) == 1:
-        options.jobStore = args[0]
-
-    ##########################################
-    #Do some checks.
-    ##########################################
-
-    logger.info("Checking if we have files for toil")
-    assert options.jobStore != None
 
     ##########################################
     #Survey the status of the job and report.
     ##########################################
+    logger.info("Checking if we have files for toil")
     try:
         jobStore = loadJobStore(options.jobStore)
     except JobStoreCreationException:

--- a/src/toil/utils/toilKill.py
+++ b/src/toil/utils/toilKill.py
@@ -26,24 +26,17 @@ from toil.version import version
 logger = logging.getLogger( __name__ )
 
 def main():
-    parser = getBasicOptionParser("usage: %prog kill [--jobStore] JOB_TREE_DIR [more options]", "%prog "+version)
-    
-    parser.add_option("--jobStore", dest="jobStore",
-                      help="Job store path. Can also be specified as the single argument to the script.")
-    
-    options, args = parseBasicOptions(parser)
-    
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(0)
-    
-    assert len(args) <= 1 #Only toil may be specified as argument
-    if len(args) == 1: #Allow toil directory as arg
-        options.jobStore = args[0]
-        
-    logger.info("Parsed arguments")
-    if options.jobStore == None:
-        parser.error("Specify --jobStore")
+    parser = getBasicOptionParser()
+
+    parser.add_argument("jobStore", type=str,
+              help=("Store in which to place job management files \
+              and the global accessed temporary files"
+              "(If this is a file path this needs to be globally accessible "
+              "by all machines running jobs).\n"
+              "If the store already exists and restart is false an"
+              " ExistingJobStoreException exception will be thrown."))
+    parser.add_argument("--version", action='version', version=version)
+    options = parseBasicOptions(parser)
 
     jobStore = loadJobStore(options.jobStore)
     

--- a/src/toil/utils/toilRestart.py
+++ b/src/toil/utils/toilRestart.py
@@ -35,24 +35,20 @@ def main():
     ##########################################
     #Construct the arguments.
     ##########################################  
-    
-    parser = getBasicOptionParser("usage: %prog restart [--jobStore] JOB_TREE_DIR [more options]", "%prog "+version)
 
-    parser.add_option("--jobStore", dest="jobStore",
-                      help="Job store path. Can also be specified as the single argument to the script.")
+    parser = getBasicOptionParser()
 
-    options, args = parseBasicOptions(parser)
-    
-    if len(args) != 0:
-        parser.error("Unrecognised input arguments: %s" % " ".join(args))
-        
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(0)
-    
-    assert len(args) <= 1 #Only toil may be specified as argument
-    if len(args) == 1: #Allow toil directory as arg
-        options.jobStore = args[0]
+    parser.add_argument("--version", action='version', version=version)
+
+    parser.add_argument("jobStore", type=str,
+          help=("Store in which to place job management files \
+          and the global accessed temporary files"
+          "(If this is a file path this needs to be globally accessible "
+          "by all machines running jobs).\n"
+          "If the store already exists and restart is false an"
+          " ExistingJobStoreException exception will be thrown."))
+
+    options = parseBasicOptions(parser)
         
     ##########################################
     #Now run the toil construction/leader

--- a/src/toil/utils/toilStats.py
+++ b/src/toil/utils/toilStats.py
@@ -89,42 +89,42 @@ def initializeOptions(parser):
     ##########################################
     # Construct the arguments.
     ##########################################
-    parser.add_option("--jobStore", dest="jobStore", default=os.path.abspath("./toil"),
-                      help="Job store path. Can also be specified as the single argument to the script. Default=%default")
-    parser.add_option("--outputFile", dest="outputFile", default=None,
+    parser.add_argument("jobStore", type=str,
+              help=("Store in which to place job management files \
+              and the global accessed temporary files"
+              "(If this is a file path this needs to be globally accessible "
+              "by all machines running jobs).\n"
+              "If the store already exists and restart is false an"
+              " ExistingJobStoreException exception will be thrown."))
+    parser.add_argument("--outputFile", dest="outputFile", default=None,
                       help="File in which to write results")
-    parser.add_option("--raw", action="store_true", default=False,
+    parser.add_argument("--raw", action="store_true", default=False,
                       help="output the raw xml data.")
-    parser.add_option("--pretty", "--human", action="store_true", default=False,
+    parser.add_argument("--pretty", "--human", action="store_true", default=False,
                       help=("if not raw, prettify the numbers to be "
                             "human readable."))
-    parser.add_option("--categories",
+    parser.add_argument("--categories",
                       help=("comma separated list from [time, clock, wait, "
                             "memory]"))
-    parser.add_option("--sortCategory", default="time",
+    parser.add_argument("--sortCategory", default="time",
                       help=("how to sort Job list. may be from [alpha, "
                             "time, clock, wait, memory, count]. "
                             "default=%(default)s"))
-    parser.add_option("--sortField", default="med",
+    parser.add_argument("--sortField", default="med",
                       help=("how to sort Job list. may be from [min, "
                             "med, ave, max, total]. "
                             "default=%(default)s"))
-    parser.add_option("--sortReverse", "--reverseSort", default=False,
+    parser.add_argument("--sortReverse", "--reverseSort", default=False,
                       action="store_true",
                       help="reverse sort order.")
+    parser.add_argument("--version", action='version', version=version)
     #parser.add_option("--cache", default=False, action="store_true",
     #                  help="stores a cache to speed up data display.")
 
-def checkOptions(options, args, parser):
+def checkOptions(options, parser):
     """ Check options, throw parser.error() if something goes wrong
     """
     logger.info("Parsed arguments")
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(0)
-    assert len(args) <= 1  # Only toil may be specified as argument
-    if len(args) == 1:  # Allow toil directory as arg
-        options.jobStore = args[0]
     logger.info("Checking if we have files for toil")
     if options.jobStore == None:
         parser.error("Specify --jobStore")
@@ -726,11 +726,10 @@ def main():
     """ Reports stats on the job-tree, use with --stats option to toil.
     """
 
-    parser = getBasicOptionParser(
-        "usage: %prog stats [--jobStore] JOB_TREE_DIR [options]", "%prog "+version)
+    parser = getBasicOptionParser()
     initializeOptions(parser)
-    options, args = parseBasicOptions(parser)
-    checkOptions(options, args, parser)
+    options = parseBasicOptions(parser)
+    checkOptions(options, parser)
     jobStore = loadJobStore(options.jobStore)
     #collatedStatsTag = cacheAvailable(options)
     #if collatedStatsTag is None:

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -37,31 +37,31 @@ def main():
     #Construct the arguments.
     ##########################################  
     
-    parser = getBasicOptionParser("usage: %prog status [--jobStore] JOB_TREE_DIR [options]", "%prog "+version)
+    parser = getBasicOptionParser()
     
-    parser.add_option("--jobStore", dest="jobStore",
-                      help="Job store path. Can also be specified as the single argument to the script.\
-                       default=%default", default=os.path.abspath("./toil"))
+    parser.add_argument("jobStore", type=str,
+              help=("Store in which to place job management files \
+              and the global accessed temporary files"
+              "(If this is a file path this needs to be globally accessible "
+              "by all machines running jobs).\n"
+              "If the store already exists and restart is false an"
+              " ExistingJobStoreException exception will be thrown."))
     
-    parser.add_option("--verbose", dest="verbose", action="store_true",
+    parser.add_argument("--verbose", dest="verbose", action="store_true",
                       help="Print loads of information, particularly all the log files of \
                       jobs that failed. default=%default",
                       default=False)
     
-    parser.add_option("--failIfNotComplete", dest="failIfNotComplete", action="store_true",
+    parser.add_argument("--failIfNotComplete", dest="failIfNotComplete", action="store_true",
                       help="Return exit value of 1 if toil jobs not all completed. default=%default",
                       default=False)
-    
-    options, args = parseBasicOptions(parser)
+    parser.add_argument("--version", action='version', version=version)
+    options = parseBasicOptions(parser)
     logger.info("Parsed arguments")
     
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(0)
-    
-    assert len(args) <= 1 #Only toil may be specified as argument
-    if len(args) == 1: #Allow toil directory as arg
-        options.jobStore = args[0]
     
     ##########################################
     #Do some checks.


### PR DESCRIPTION
Includes the toil utils, removes the deprecated optparse since it offers very limited positional support.