### PR TITLE
Client-side encryption for Azure job store (resolves #308)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ kwargs = dict(
     author='Benedict Paten',
     author_email='benedict@soe.usc.edu',
     url="https://github.com/BD2KGenomics/toil",
-    install_requires=[ 'bd2k-python-lib==1.7.dev1' ],
+    install_requires=[ 'bd2k-python-lib==1.7.dev1', 'pynacl==0.3.0' ],
     tests_require=[ 'mock==1.0.1', 'pytest==2.7.2' ],
     test_suite='toil',
     extras_require={

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -373,7 +373,7 @@ def serialiseEnvironment(jobStore):
     """
     #Dump out the environment of this process in the environment pickle file.
     with jobStore.writeSharedFileStream("environment.pickle") as fileHandle:
-        cPickle.dump(os.environ, fileHandle)
+        cPickle.dump(os.environ, fileHandle, cPickle.HIGHEST_PROTOCOL)
     logger.info("Written the environment for the jobs to the environment file")
 
 @contextmanager

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -79,6 +79,7 @@ class Config(object):
         #Misc
         self.maxLogFileSize=50120
         self.sseKey = None
+        self.cseKey = None
         
     def setOptions(self, options):
         """
@@ -154,6 +155,7 @@ class Config(object):
             with open(sseKey) as f:
                 assert(len(f.readline().rstrip()) == 32)
         setOption("sseKey", checkFn=checkSse)
+        setOption("cseKey", checkFn=checkSse)
 
 def _addOptions(addGroupFn, config):
     #
@@ -258,6 +260,9 @@ def _addOptions(addGroupFn, config):
     addOptionFn("--sseKey", dest="sseKey", default=None,
             help="Path to file containing 32 character key to be used for server-side encryption on awsJobStore. SSE will "
                  "not be used if this flag is not passed.")
+    addOptionFn("--cseKey", dest="cseKey", default=None,
+                help="Path to file containing 256-bit key to be used for client-side encryption on "
+                "azureJobStore. By default, no encryption is used.")
 
 def addOptions(parser, config=Config()):
     """

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -35,6 +35,7 @@ from ConfigParser import RawConfigParser, NoOptionError
 from toil.jobWrapper import JobWrapper
 from toil.jobStores.abstractJobStore import AbstractJobStore, NoSuchJobException, \
     ConcurrentFileModificationException, NoSuchFileException
+from toil.lib.encryption import encrypt, decrypt, encryptionOverhead
 
 log = logging.getLogger(__name__)
 
@@ -71,6 +72,7 @@ class AzureJobStore(AbstractJobStore):
 
     def __init__(self, accountName, namePrefix, config=None, jobChunkSize=65535):
         self.jobChunkSize = jobChunkSize
+        self.keyPath = None
 
         account_key = _fetchAzureAccountKey(accountName)
 
@@ -103,6 +105,9 @@ class AzureJobStore(AbstractJobStore):
         self.statsFileIDs = self._getOrCreateTable(self.qualify('statsFileIDs'))
 
         super(AzureJobStore, self).__init__(config=config)
+
+        if self.config.cseKey is not None:
+            self.keyPath = self.config.cseKey
 
     # tables must be alphanumeric
     nameSeparator = 'xx'
@@ -159,19 +164,26 @@ class AzureJobStore(AbstractJobStore):
 
     def writeFile(self, jobStoreID, localFilePath):
         jobStoreFileID = self._newFileID()
-        self.files.put_block_blob_from_path(blob_name=jobStoreFileID,
-                                            file_path=localFilePath)
+        self.updateFile(jobStoreFileID, localFilePath)
         self._associateJobWithFile(jobStoreID, jobStoreFileID)
         return jobStoreFileID
 
     def updateFile(self, jobStoreFileID, localFilePath):
-        self.files.put_block_blob_from_path(blob_name=jobStoreFileID,
-                                            file_path=localFilePath)
+        with open(localFilePath) as read_fd:
+            with self._uploadStream(jobStoreFileID, self.files,
+                                    encrypted=self.keyPath is not None) as write_fd:
+                while True:
+                    buf = read_fd.read(self._maxAzureBlockBytes)
+                    write_fd.write(buf)
+                    if len(buf) == 0:
+                        break
 
     def readFile(self, jobStoreFileID, localFilePath):
         try:
-            self.files.get_blob_to_path(blob_name=jobStoreFileID,
-                                        file_path=localFilePath)
+            with self._downloadStream(jobStoreFileID, self.files,
+                                      encrypted=self.keyPath is not None) as read_fd:
+                with open(localFilePath, 'w') as write_fd:
+                    write_fd.write(read_fd.read(self._maxAzureBlockBytes))
         except WindowsAzureMissingResourceError:
             raise NoSuchFileException(jobStoreFileID)
 
@@ -198,13 +210,15 @@ class AzureJobStore(AbstractJobStore):
         # Append Blob type, but that is not currently supported by the
         # Azure Python API.
         jobStoreFileID = self._newFileID()
-        with self._uploadStream(jobStoreFileID, self.files) as fd:
+        with self._uploadStream(jobStoreFileID, self.files,
+                                encrypted=self.keyPath is not None) as fd:
             yield fd, jobStoreFileID
         self._associateJobWithFile(jobStoreID, jobStoreFileID)
 
     @contextmanager
     def updateFileStream(self, jobStoreFileID):
-        with self._uploadStream(jobStoreFileID, self.files, checkForModification=True) as fd:
+        with self._uploadStream(jobStoreFileID, self.files, checkForModification=True,
+                                encrypted=self.keyPath is not None) as fd:
             yield fd
 
     def getEmptyFileStoreID(self, jobStoreID):
@@ -218,13 +232,15 @@ class AzureJobStore(AbstractJobStore):
     def readFileStream(self, jobStoreFileID):
         if not self.fileExists(jobStoreFileID):
             raise NoSuchFileException(jobStoreFileID)
-        with self._downloadStream(jobStoreFileID, self.files) as fd:
+        with self._downloadStream(jobStoreFileID, self.files,
+                                  encrypted=self.keyPath is not None) as fd:
             yield fd
 
     @contextmanager
     def writeSharedFileStream(self, sharedFileName, isProtected=True):
         sharedFileID = self._newFileID(sharedFileName)
-        with self._uploadStream(sharedFileID, self.files) as fd:
+        with self._uploadStream(sharedFileID, self.files,
+                                encrypted=isProtected and self.keyPath is not None) as fd:
             yield fd
 
     @contextmanager
@@ -232,7 +248,8 @@ class AzureJobStore(AbstractJobStore):
         sharedFileID = self._newFileID(sharedFileName)
         if not self.fileExists(sharedFileID):
             raise NoSuchFileException(sharedFileID)
-        with self._downloadStream(sharedFileID, self.files) as fd:
+        with self._downloadStream(sharedFileID, self.files,
+                                  encrypted=isProtected and self.keyPath is not None) as fd:
             yield fd
 
     def writeStatsAndLogging(self, statsAndLoggingString):
@@ -320,7 +337,7 @@ class AzureJobStore(AbstractJobStore):
     _maxAzureBlockBytes = 4194000
 
     @contextmanager
-    def _uploadStream(self, jobStoreFileID, container, multipart=True, checkForModification=False):
+    def _uploadStream(self, jobStoreFileID, container, checkForModification=False, encrypted=False):
         # This is a straightforward transliteration into Azure of the
         # _uploadStream method of AWSJobStore.
         if checkForModification:
@@ -330,6 +347,14 @@ class AzureJobStore(AbstractJobStore):
             except WindowsAzureMissingResourceError:
                 expectedVersion = None
 
+        if encrypted and self.keyPath is None:
+            encrypted = False
+            log.warning("Encryption requested but no key available, not encrypting")
+
+        maxBlockSize = self._maxAzureBlockBytes
+        if encrypted:
+            # There is a small overhead for encrypted data.
+            maxBlockSize -= encryptionOverhead
         readable_fh, writable_fh = os.pipe()
         with os.fdopen(readable_fh, 'r') as readable:
             with os.fdopen(writable_fh, 'w') as writable:
@@ -338,11 +363,13 @@ class AzureJobStore(AbstractJobStore):
                         blockIDs = []
                         try:
                             while True:
-                                buf = readable.read(self._maxAzureBlockBytes)
+                                buf = readable.read(maxBlockSize)
                                 if len(buf) == 0:
                                     # We're safe to break here even if we never read anything, since
                                     # putting an empty block list creates an empty blob.
                                     break
+                                if encrypted:
+                                    buf = encrypt(buf, self.keyPath)
                                 blockID = self._newFileID()
                                 container.put_block(blob_name=jobStoreFileID, block=buf,
                                                     blockid=blockID)
@@ -378,14 +405,7 @@ class AzureJobStore(AbstractJobStore):
                     except:
                         log.exception("Multipart reader thread encountered an exception")
 
-                def simpleReader():
-                    try:
-                        container.put_block_blob_from_file(blob_name=jobStoreFileID,
-                                                           stream=readable)
-                    except:
-                        log.exception("Exception encountered in simple single-part reader thread")
-
-                thread = Thread(target=reader if multipart else simpleReader)
+                thread = Thread(target=reader)
                 thread.start()
                 yield writable
             # The writable is now closed. This will send EOF to the readable and cause that
@@ -393,14 +413,28 @@ class AzureJobStore(AbstractJobStore):
             thread.join()
 
     @contextmanager
-    def _downloadStream(self, jobStoreFileID, container):
+    def _downloadStream(self, jobStoreFileID, container, encrypted=False):
         # Transliteration of _downloadStream method in AWSJobStore.
+        if encrypted and self.keyPath is None:
+            encrypted = False
+            log.warning("Encryption requested but no key available, not decrypting")
+
         readable_fh, writable_fh = os.pipe()
         with os.fdopen(readable_fh, 'r') as readable:
             with os.fdopen(writable_fh, 'w') as writable:
                 def writer():
                     try:
-                        container.get_blob_to_file(blob_name=jobStoreFileID, stream=writable)
+                        chunkStartPos = 0
+                        fileSize = int(self.files.get_blob_properties(blob_name=jobStoreFileID)['Content-Length'])
+                        while chunkStartPos < fileSize:
+                            chunkEndPos = chunkStartPos + self._maxAzureBlockBytes - 1
+                            buf = self.files.get_blob(blob_name=jobStoreFileID,
+                                                      x_ms_range="bytes=%d-%d" % (chunkStartPos,
+                                                                                  chunkEndPos))
+                            if encrypted:
+                                buf = decrypt(buf, self.keyPath)
+                            writable.write(buf)
+                            chunkStartPos = chunkEndPos + 1
                     except:
                         log.exception("Exception encountered in writer thread")
                     finally:

--- a/src/toil/lib/encryption.py
+++ b/src/toil/lib/encryption.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2015 UCSC Computational Genomics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nacl
+from nacl.exceptions import CryptoError
+from nacl.secret import SecretBox
+
+# 16-byte MAC plus a nonce is added to every message.
+encryptionOverhead = 16 + SecretBox.NONCE_SIZE
+
+def encrypt(message, keyPath):
+    """
+    Encrypts a message given a path to a local file containing a key.
+
+    :param message: The message to be encrypted.
+    :param keyPath: A path to a file containing a 256-bit key (and nothing else).
+    :type message: str
+    :type keyPath: str
+    :rtype: str
+
+    A constant overhead is added to every encrypted message (for the nonce and MAC).
+    >>> import tempfile
+    >>> k = tempfile.mktemp()
+    >>> with open(k, 'w') as f:
+    ...     f.write(nacl.utils.random(SecretBox.KEY_SIZE))
+    >>> message = 'test'
+    >>> len(encrypt(message, k)) == encryptionOverhead + len(message)
+    True
+    """
+    with open(keyPath) as f:
+        key = f.read()
+    if len(key) != SecretBox.KEY_SIZE:
+        raise ValueError("Key is %d bytes, but must be exactly %d bytes" % (len(key),
+                                                                            SecretBox.KEY_SIZE))
+    sb = SecretBox(key)
+    # We generate the nonce using secure random bits. For long enough
+    # nonce size, the chance of a random nonce collision becomes
+    # *much* smaller than the chance of a subtle coding error causing
+    # a nonce reuse. Currently the nonce size is 192 bits--the chance
+    # of a collision is astronomically low. (This approach is
+    # recommended in the libsodium documentation.)
+    nonce = nacl.utils.random(SecretBox.NONCE_SIZE)
+    assert len(nonce) == SecretBox.NONCE_SIZE
+    return str(sb.encrypt(message, nonce))
+
+def decrypt(ciphertext, keyPath):
+    """
+    Decrypts a given message that was encrypted with the encrypt() method.
+
+    :param ciphertext: The encrypted message (as a string).
+    :param keyPath: A path to a file containing a 256-bit key (and nothing else).
+    :type keyPath: str
+    :rtype: str
+
+    Raises an error if ciphertext was modified
+    >>> import tempfile
+    >>> k = tempfile.mktemp()
+    >>> with open(k, 'w') as f:
+    ...     f.write(nacl.utils.random(SecretBox.KEY_SIZE))
+    >>> ciphertext = encrypt("testMessage", k)
+    >>> ciphertext = chr(ord(ciphertext[0]) ^ 1) + ciphertext[1:]
+    >>> decrypt(ciphertext, k)
+    Traceback (most recent call last):
+    ...
+    CryptoError: Decryption failed. Ciphertext failed verification
+
+    Otherwise works correctly
+    >>> decrypt(encrypt("testMessage", k), k)
+    'testMessage'
+    """
+    with open(keyPath) as f:
+        key = f.read()
+    if len(key) != SecretBox.KEY_SIZE:
+        raise ValueError("Key is %d bytes, but must be exactly %d bytes" % (len(key),
+                                                                            SecretBox.KEY_SIZE))
+    sb = SecretBox(key)
+    # The nonce is kept with the message.
+    return sb.decrypt(ciphertext)

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -387,11 +387,13 @@ class hidden:
 
         def setUp(self):
             self.sseKeyDir = tempfile.mkdtemp()
+            self.cseKeyDir = tempfile.mkdtemp()
             super(hidden.AbstractEncryptedJobStoreTest, self).setUp()
 
         def tearDown(self):
             super(hidden.AbstractEncryptedJobStoreTest, self).tearDown()
             shutil.rmtree(self.sseKeyDir)
+            shutil.rmtree(self.cseKeyDir)
 
         def _createConfig(self):
             config = super(hidden.AbstractEncryptedJobStoreTest, self)._createConfig()
@@ -400,6 +402,11 @@ class hidden:
                 f.write("01234567890123456789012345678901")
             config.sseKey = sseKeyFile
             # config.attrib["sse_key"] = sseKeyFile
+
+            cseKeyFile = os.path.join(self.cseKeyDir, "keyFile")
+            with open(cseKeyFile, 'w') as f:
+                f.write("i am a fake key, so don't use me")
+            config.cseKey = cseKeyFile
             return config
 
 
@@ -431,4 +438,9 @@ class EncryptedFileJobStoreTest(FileJobStoreTest, hidden.AbstractEncryptedJobSto
 
 @needs_aws
 class EncryptedAWSJobStoreTest(AWSJobStoreTest, hidden.AbstractEncryptedJobStoreTest):
+    pass
+
+
+@needs_azure
+class EncryptedAzureJobStoreTest(AzureJobStoreTest, hidden.AbstractEncryptedJobStoreTest):
     pass


### PR DESCRIPTION
Currently it uses only one key. Having a separate key for each file is certainly possible, but it involves some key distribution which would be slightly trickier.

Only the path to the key file is ever stored in the jobStore, because I was a bit paranoid about stuff getting pickled and passed around so often. If the job store never, ever gets pickled, maybe we could save a bit of I/O and read it in at job store creation.

This client side encryption should work fine for the file job store too.