### PR TITLE
Make Parasol batch system create a separate batch for each set of ram and cpu requirements (resolves #396, resolves #429, resolves #456)

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import
 from Queue import Empty
+import os
 
 
 class AbstractBatchSystem:
@@ -125,6 +126,8 @@ class AbstractBatchSystem:
             return queue.get(timeout=maxWait)
         except Empty:
             return None
+    def _getResultsFileName(self, toilPath):
+        return os.path.join(toilPath, "results.txt")
 
 
 class InsufficientSystemResources(Exception):

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -108,25 +108,10 @@ class AbstractBatchSystem:
         """
         raise NotImplementedError('Abstract method: getRescueBatchJobFrequency')
 
-    # FIXME: Add a link to the issue tracker for this bug in multiprocessing
-
-    # FIXME: Should be a no-op unless queue is a multiprocessing.Queue
-    
-    def getFromQueueSafely(self, queue, maxWait):
-        """
-        Returns an object from the given queue, avoiding a nasty bug in some versions of the
-        multiprocessing queue python
-        """
-        if maxWait <= 0:
-            try:
-                return queue.get(block=False)
-            except Empty:
-                return None
-        try:
-            return queue.get(timeout=maxWait)
-        except Empty:
-            return None
     def _getResultsFileName(self, toilPath):
+        """Get a path for the batch systems to store results. GridEngine
+        and LSF currently use this.
+        """
         return os.path.join(toilPath, "results.txt")
 
 

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -22,7 +22,6 @@ from Queue import Queue, Empty
 from threading import Thread
 
 from toil.batchSystems.abstractBatchSystem import AbstractBatchSystem
-from toil.batchSystems.parasol import getParasolResultsFileName
 
 logger = logging.getLogger(__name__)
 
@@ -242,7 +241,7 @@ class GridengineBatchSystem(AbstractBatchSystem):
 
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         AbstractBatchSystem.__init__(self, config, maxCores, maxMemory, maxDisk)
-        self.gridengineResultsFile = getParasolResultsFileName(config.jobStore)
+        self.gridengineResultsFile = self._getResultsFileName(config.jobStore)
         # Reset the job queue and results (initially, we do this again once we've killed the jobs)
         self.gridengineResultsFileHandle = open(self.gridengineResultsFile, 'w')
         # We lose any previous state in this file, and ensure the files existence

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -301,10 +301,11 @@ class GridengineBatchSystem(AbstractBatchSystem):
         return self.worker.getRunningJobIDs()
 
     def getUpdatedBatchJob(self, maxWait):
-        i = self.getFromQueueSafely(self.updatedJobsQueue, maxWait)
-        logger.debug('UpdatedJobsQueue Item: %s', i)
-        if i is None:
+        try:
+            i = self.updatedJobsQueue.get(timeout=maxWait)
+        except Empty:
             return None
+        logger.debug('UpdatedJobsQueue Item: %s', i)
         jobID, retcode = i
         self.updatedJobsQueue.task_done()
         self.currentJobs.remove(jobID)

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -28,7 +28,6 @@ from threading import Thread
 from datetime import date
 
 from toil.batchSystems.abstractBatchSystem import AbstractBatchSystem
-from toil.batchSystems.parasol import getParasolResultsFileName
 
 
 logger = logging.getLogger( __name__ )
@@ -159,7 +158,7 @@ class LSFBatchSystem(AbstractBatchSystem):
     """
     def __init__(self, config, maxCores, maxMemory):
         AbstractBatchSystem.__init__(self, config, maxCores, maxMemory) #Call the parent constructor
-        self.lsfResultsFile = getParasolResultsFileName(config.jobStore)
+        self.lsfResultsFile = self._getResultsFileName(config.jobStore)
         #Reset the job queue and results (initially, we do this again once we've killed the jobs)
         self.lsfResultsFileHandle = open(self.lsfResultsFile, 'w')
         self.lsfResultsFileHandle.close() #We lose any previous state in this file, and ensure the files existence

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 import os
 import time
 import pickle
-from Queue import Queue
+from Queue import Queue, Empty
 import logging
 import sys
 
@@ -181,8 +181,9 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
         Gets a job that has updated its status, according to the job manager. Max wait gives the number of seconds to
         pause waiting for a result. If a result is available returns (jobID, exitValue) else it returns None.
         """
-        i = self.getFromQueueSafely(self.updatedJobsQueue, maxWait)
-        if i is None:
+        try:
+            i = self.updatedJobsQueue.get(timeout=maxWait)
+        except Empty:
             return None
         jobID, retcode = i
         self.updatedJobsQueue.task_done()

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -23,18 +23,13 @@ import subprocess
 import time
 
 from Queue import Empty
-from multiprocessing import Process
-from multiprocessing import JoinableQueue as Queue
-
-#from threading import Thread
-#from Queue import Queue, Empty
+from Queue import Queue
+from threading import Thread
 
 from toil.batchSystems.abstractBatchSystem import AbstractBatchSystem
+from toil.lib.bioio import getTempFile, getTempDirectory
 
 logger = logging.getLogger( __name__ )
-
-def getParasolResultsFileName(toilPath):
-    return os.path.join(toilPath, "results.txt")
 
 def popenParasolCommand(command, runUntilSuccessful=True):
     """Issues a parasol command using popen to capture the output.
@@ -58,37 +53,7 @@ def popenParasolCommand(command, runUntilSuccessful=True):
         time.sleep(10)
         logger.warn("Waited for a few seconds, will try again")
 
-def getUpdatedJob(parasolResultsFile, outputQueue1, outputQueue2):
-    """We use the parasol results to update the status of jobs, adding them
-    to the list of updated jobs.
-    
-    Results have the following structure.. (thanks Mark D!)
-    
-    int status;    /* Job status - wait() return format. 0 is good. */
-    char *host;    /* Machine job ran on. */
-    char *jobId;    /* Job queuing system job ID */
-    char *exe;    /* Job executable file (no path) */
-    int usrTicks;    /* 'User' CPU time in ticks. */
-    int sysTicks;    /* 'System' CPU time in ticks. */
-    unsigned submitTime;    /* Job submission time in seconds since 1/1/1970 */
-    unsigned startTime;    /* Job start time in seconds since 1/1/1970 */
-    unsigned endTime;    /* Job end time in seconds since 1/1/1970 */
-    char *user;    /* User who ran job */
-    char *errFile;    /* Location of stderr file on host */
-    
-    plus you finally have the command name..
-    """
-    parasolResultsFileHandle = open(parasolResultsFile, 'r')
-    while True:
-        line = parasolResultsFileHandle.readline()
-        if line != '':
-            results = line.split()
-            result = int(results[0])
-            jobID = int(results[2])
-            outputQueue1.put(jobID)
-            outputQueue2.put((jobID, result))
-        else:
-            time.sleep(0.01) #Go to sleep to avoid churning
+
 
 class ParasolBatchSystem(AbstractBatchSystem):
     """The interface for Parasol.
@@ -100,31 +65,37 @@ class ParasolBatchSystem(AbstractBatchSystem):
                         "this batchsystem interface does not support such limiting" % maxMemory)
         #Keep the name of the results file for the pstat2 command..
         self.parasolCommand = config.parasolCommand
-        self.parasolResultsFile = getParasolResultsFileName(config.jobStore)
-        #Reset the job queue and results (initially, we do this again once we've killed the jobs)
+        self.parasolResultsDir = getTempDirectory(rootDir=config.jobStore)
+
         self.queuePattern = re.compile("q\s+([0-9]+)")
         self.runningPattern = re.compile("r\s+([0-9]+)\s+[\S]+\s+[\S]+\s+([0-9]+)\s+[\S]+")
-        self.killBatchJobs(self.getIssuedBatchJobIDs()) #Kill any jobs on the current stack
+
         logger.info("Going to sleep for a few seconds to kill any existing jobs")
         time.sleep(5) #Give batch system a second to sort itself out.
         logger.info("Removed any old jobs from the queue")
-        #Reset the job queue and results
-        exitValue = popenParasolCommand("%s -results=%s clear sick" % (self.parasolCommand, self.parasolResultsFile), False)[0]
-        if exitValue is not None:
-            logger.warn("Could not clear sick status of the parasol batch %s" % self.parasolResultsFile)
-        exitValue = popenParasolCommand("%s -results=%s flushResults" % (self.parasolCommand, self.parasolResultsFile), False)[0]
-        if exitValue is not None:
-            logger.warn("Could not flush the parasol batch %s" % self.parasolResultsFile)
-        open(self.parasolResultsFile, 'w').close()
-        logger.info("Reset the results queue")
-        #Stuff to allow max cpus to be work
-        self.outputQueue1 = Queue()
-        self.outputQueue2 = Queue()
-        #worker = Thread(target=getUpdatedJob, args=(self.parasolResultsFileHandle, self.outputQueue1, self.outputQueue2))
-        #worker.setDaemon(True)
-        worker = Process(target=getUpdatedJob, args=(self.parasolResultsFile, self.outputQueue1, self.outputQueue2))
-        worker.daemon = True
-        worker.start()
+
+        #In Parasol, each results file corresponds to a separate batch, and all
+        #jobs in a batch have the same cpu and memory requirements. The keys to this
+        #dictionary are the (cpu, memory) tuples for each batch. A new batch
+        #is created whenever a job has a new unique combination of cpu and memory
+        #requirements.
+        self.resultsFiles = dict()
+        self.maxBatches = config.maxParasolBatches
+
+        #Allows the worker process to send back the IDs of
+        #jobs that have finished, so the batch system can
+        #decrease its used cpus counter
+        self.cpuUsageQueue = Queue()
+
+        #Also stores finished job IDs, but is read
+        #by getUpdatedJobIDs().
+        self.updatedJobsQueue = Queue()
+
+        #Use this to stop the worker when shutting down
+        self.running = True
+
+        self.worker = Thread(target=self.updatedJobWorker, args=())
+        self.worker.start()
         self.usedCpus = 0
         self.jobIDsToCpu = {}
 
@@ -133,28 +104,45 @@ class ParasolBatchSystem(AbstractBatchSystem):
         #by themselves are removed in getUpdatedJob, and jobs
         #that are killed are removed in killBatchJobs.
         self.runningJobs = set()
-         
+
     def issueBatchJob(self, command, memory, cores, disk):
         """Issues parasol with job commands.
         """
         self.checkResourceRequest(memory, cores, disk)
-        pattern = re.compile("your job ([0-9]+).*")
-        parasolCommand = "%s -verbose -ram=%i -cpu=%i -results=%s add job '%s'" % (self.parasolCommand, memory, cores, self.parasolResultsFile, command)
 
+        MiB = 1 << 20
+        truncatedMemory = (memory/MiB) * MiB
+        #Look for a batch for jobs with these resource requirements, with
+        #the memory rounded down to the nearest megabyte. Rounding down
+        #meams the new job can't ever decrease the memory requirements
+        #of jobs already in the batch.
+        if (truncatedMemory, cores) in self.resultsFiles.keys():
+            results = self.resultsFiles[(truncatedMemory, cores)]
+        else:
+            results = getTempFile(rootDir=self.parasolResultsDir)
+            self.resultsFiles[(truncatedMemory, cores)] = results
+        if len(self.resultsFiles.values()) > self.maxBatches:
+            raise RuntimeError("Number of parasol batches exceeded the limit of %i" % self.maxBatches)
+
+        pattern = re.compile("your job ([0-9]+).*")
+        parasolCommand = "%s -verbose -ram=%i -cpu=%i -results=%s add job '%s'" % (self.parasolCommand, memory, cores, results, command)
         #Deal with the cpus
         self.usedCpus += cores
         while True: #Process finished results with no wait
             try:
-               jobID = self.outputQueue1.get_nowait()
-               self.usedCpus -= self.jobIDsToCpu.pop(jobID)
-               assert self.usedCpus >= 0
-               self.outputQueue1.task_done()
+               jobID = self.cpuUsageQueue.get_nowait()
             except Empty:
                 break
-        while self.usedCpus > self.maxCores: #If we are still waiting
-            self.usedCpus -= self.jobIDsToCpu.pop(self.outputQueue1.get())
+            if jobID in self.jobIDsToCpu.keys():
+                self.usedCpus -= self.jobIDsToCpu.pop(jobID)
             assert self.usedCpus >= 0
-            self.outputQueue1.task_done()
+            self.cpuUsageQueue.task_done()
+        while self.usedCpus > self.maxCores: #If we are still waiting
+            jobID = self.cpuUsageQueue.get()
+            if jobID in self.jobIDsToCpu.keys():
+                self.usedCpus -= self.jobIDsToCpu.pop(jobID)
+            assert self.usedCpus >= 0
+            self.cpuUsageQueue.task_done()
         #Now keep going
         while True:
             #time.sleep(0.1) #Sleep to let parasol catch up #Apparently unnecessary
@@ -171,7 +159,7 @@ class ParasolBatchSystem(AbstractBatchSystem):
         logger.debug("Got the parasol job id: %s from line: %s" % (jobID, line))
         logger.debug("Issued the job command: %s with (parasol) job id: %i " % (parasolCommand, jobID))
         return jobID
-    
+
     def killBatchJobs(self, jobIDs):
         """Kills the given jobs, represented as Job ids, then checks they are dead by checking
         they are not in the list of issued jobs.
@@ -184,24 +172,30 @@ class ParasolBatchSystem(AbstractBatchSystem):
                 logger.info("Tried to remove jobID: %i, with exit value: %i" % (jobID, exitValue))
             runningJobs = self.getIssuedBatchJobIDs()
             if set(jobIDs).difference(set(runningJobs)) == set(jobIDs):
-                return
+                break
             time.sleep(5)
             logger.warn("Tried to kill some jobs, but something happened and they are still going, so I'll try again")
-    
+        #update the CPU usage, because killed jobs aren't
+        #written to the results file.
+        for jobID in jobIDs:
+            if jobID in self.jobIDsToCpu.keys():
+                self.usedCpus -= self.jobIDsToCpu.pop(jobID)
+
     def getIssuedBatchJobIDs(self):
         """Gets the list of jobs issued to parasol.
         """
         #Example issued job, first field is jobID, last is the results file
         #31816891 localhost  benedictpaten 2009/07/23 10:54:09 python ~/Desktop/out.txt
+
         issuedJobs = set()
         for line in popenParasolCommand("%s -extended list jobs" % self.parasolCommand)[1]:
             if line != '':
                 tokens = line.split()
-                if tokens[-1] == self.parasolResultsFile:
+                if tokens[-1] in self.resultsFiles.values():
                     jobID = int(tokens[0])
                     issuedJobs.add(jobID)
         return list(issuedJobs)
-    
+
     def getRunningBatchJobIDs(self):
         """Returns map of running jobIDs and the time they have been running.
         """
@@ -210,7 +204,7 @@ class ParasolBatchSystem(AbstractBatchSystem):
         #r 5410324 benedictpaten worker 1247030076 localhost
         runningJobs = {}
         issuedJobs = self.getIssuedBatchJobIDs()
-        for line in popenParasolCommand("%s -results=%s pstat2 " % (self.parasolCommand, self.parasolResultsFile))[1]:
+        for line in popenParasolCommand("%s pstat2 " % self.parasolCommand)[1]:
             if line != '':
                 match = self.runningPattern.match(line)
                 if match != None:
@@ -221,9 +215,9 @@ class ParasolBatchSystem(AbstractBatchSystem):
         return runningJobs
     
     def getUpdatedBatchJob(self, maxWait):
-        jobID = self.getFromQueueSafely(self.outputQueue2, maxWait)
+        jobID = self.getFromQueueSafely(self.updatedJobsQueue, maxWait)
         if jobID != None:
-            self.outputQueue2.task_done()
+            self.updatedJobsQueue.task_done()
             if jobID[0] not in self.runningJobs:
                 #we tried to kill this job, but it ended by itself
                 #instead, so skip it.
@@ -238,9 +232,70 @@ class ParasolBatchSystem(AbstractBatchSystem):
         making it expensive. 
         """
         return 5400 #Once every 90 minutes
+    def updatedJobWorker(self):
+        """We use the parasol results to update the status of jobs, adding them
+        to the list of updated jobs.
+
+        Results have the following structure.. (thanks Mark D!)
+
+        int status;    /* Job status - wait() return format. 0 is good. */
+        char *host;    /* Machine job ran on. */
+        char *jobId;    /* Job queuing system job ID */
+        char *exe;    /* Job executable file (no path) */
+        int usrTicks;    /* 'User' CPU time in ticks. */
+        int sysTicks;    /* 'System' CPU time in ticks. */
+        unsigned submitTime;    /* Job submission time in seconds since 1/1/1970 */
+        unsigned startTime;    /* Job start time in seconds since 1/1/1970 */
+        unsigned endTime;    /* Job end time in seconds since 1/1/1970 */
+        char *user;    /* User who ran job */
+        char *errFile;    /* Location of stderr file on host */
+
+        plus you finally have the command name..
+        """
+        resultsFiles = set()
+        resultsFileHandles = []
+        try:
+            while self.running:
+                #Look for any new results files that have been created, and open them
+                newResultsFiles = set(os.listdir(self.parasolResultsDir)).difference(resultsFiles)
+                for newFile in newResultsFiles:
+                    resultsFiles.add(newFile)
+                    newFilePath = os.path.join(self.parasolResultsDir, newFile)
+                    resultsFileHandles.append(open(newFilePath, 'r'))
+
+                for fileHandle in resultsFileHandles:
+                    line = fileHandle.readline()
+                    if line:
+                        assert line[-1] == '\n'
+                        results = line.split()
+                        result = int(results[0])
+                        jobID = int(results[2])
+                        self.cpuUsageQueue.put(jobID)
+                        self.updatedJobsQueue.put((jobID, result))
+                time.sleep(0.01) #Go to sleep to avoid churning
+        except:
+            logger.warn("Error occurred while parsing parasol results files.")
+            raise
+        finally:
+            for fileHandle in resultsFileHandles:
+                fileHandle.close()
+
+
     def shutdown(self):
-        pass
-        
+        self.killBatchJobs(self.getIssuedBatchJobIDs()) #cleanup jobs
+        for results in self.resultsFiles.values():
+            exitValue = popenParasolCommand("%s -results=%s clear sick" % (self.parasolCommand, results), False)[0]
+            if exitValue is not None:
+                logger.warn("Could not clear sick status of the parasol batch %s" % results)
+            exitValue = popenParasolCommand("%s -results=%s flushResults" % (self.parasolCommand, results), False)[0]
+            if exitValue is not None:
+                logger.warn("Could not flush the parasol batch %s" % results)
+        self.running = False
+        self.worker.join()
+        for results in self.resultsFiles.values():
+            os.remove(results)
+        os.rmdir(self.parasolResultsDir)
+
 def main():
     pass
 

--- a/src/toil/batchSystems/parasolTestSupport.py
+++ b/src/toil/batchSystems/parasolTestSupport.py
@@ -73,6 +73,6 @@ class ParasolTestSupport(object):
     class ParasolWorkerThread(ParasolThread):
         def parasolCommand(self):
             return ['paraNode',
-                    '-cpu=4',
+                    '-cpu=%i' % self.numCores,
                     '-debug',
                     'start']

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -62,6 +62,7 @@ class Config(object):
         self.scale = 1
         self.masterIP = '127.0.0.1:5050'
         self.parasolCommand = "parasol"
+        self.maxParasolBatches = 10000
         
         #Resource requirements
         self.defaultMemory = 2147483648
@@ -140,6 +141,7 @@ class Config(object):
         setOption("scale", float) 
         setOption("masterIP") 
         setOption("parasolCommand")
+        setOption("maxParasolBatches", int, iC(1))
         
         #Resource requirements
         setOption("defaultMemory", h2b, iC(1))
@@ -218,6 +220,9 @@ def _addOptions(addGroupFn, config):
                 help=("The master node's ip and port number. Used in mesos batch system. default=%s" % config.masterIP))
     addOptionFn("--parasolCommand", dest="parasolCommand", default=None,
                       help="The command to run the parasol program default=%s" % config.parasolCommand)
+    addOptionFn("--maxParasolBatches", dest="maxParasolBatches", default=None,
+                help="Maximum number of batches Parasol is allowed to create - a batch \
+                is created for each job that has a unique set of resource requirements. Default=%i" % config.maxParasolBatches)
 
     #
     #Resource requirements


### PR DESCRIPTION
- Create a new results file each time a job is issued with a new unique combination of ram and CPU requirements. 
- Switch the updated jobs worker to a thread instead of a daemon process.
- When shutting down, make the batch system clean up all the jobs it issued, and clear sick jobs.
- Use "parasol -results=<resultsForBatch> pstat2" on each batch to list issued jobs, instead of "parasol list jobs." This avoids listing all jobs on the cluster, which is slow when other users have created many jobs.
- Eliminate getFromQueueSafely in abstractBatchSystem because it was only necessary for multiprocessing.Queue, not Queue.Queue. 