### PR TITLE
Ship the environment in the Mesos task data

### DIFF
--- a/src/toil/batchSystems/mesos/__init__.py
+++ b/src/toil/batchSystems/mesos/__init__.py
@@ -40,4 +40,6 @@ ToilJob = namedtuple('ToilJob', (
     # The resource object representing the user script
     'userScript',
     # The resource object representing the toil source tarball
-    'toilDistribution'))
+    'toilDistribution',
+    # The environment, which we need to set up some JobStores
+    'environment'))

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -107,7 +107,8 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
                          resources=ResourceRequirement(memory=memory, cores=cores, disk=disk),
                          command=command,
                          userScript=self.userScript,
-                         toilDistribution=self.toilDistribution)
+                         toilDistribution=self.toilDistribution,
+                         environment=os.environ) # Send the environment, in case it describes how to access the job store
         job_type = job.resources
 
         log.debug("Queueing the job command: %s with job id: %s ..." % (command, str(jobID)))

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -125,6 +125,14 @@ class MesosExecutor(mesos.interface.Executor):
             """
             if job.userScript:
                 job.userScript.register()
+                
+            for envKey, envValue in job.environment.iteritems():
+                # Copy the environment from the master, which may have variables
+                # (like AZURE_ACCOUNT_KEY) needed to access the job store.
+                if envKey not in ("TMPDIR", "TMP", "HOSTNAME", "HOSTTYPE",
+                    "PYTHONPATH"):
+                    os.environ[envKey] = envValue
+                
             log.debug("Invoking command: '%s'", job.command)
             with self.popenLock:
                 return subprocess.Popen(job.command, shell=True)


### PR DESCRIPTION
This allows the `azureJobStore` to work on Mesos even when `.toilAzureCredentials` and/or `AZURE_ACCOUNT_KEY` haven't been pre-distributed to all the nodes. Just set `AZURE_ACCOUNT_KEY` on the master and it will be available on the nodes when the worker attempts to connect to the job store.

Works around the secondary issues described in #421 that require storage key pre-distribution or a shared file system.