### PR TITLE
Unicode-encode log messages (resolves #427)

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -896,11 +896,11 @@ class Job(object):
         #Finish up the stats
         if stats != None:
             stats = ET.SubElement(stats, "job")
-            stats.attrib["time"] = str(time.time() - startTime)
+            stats.attrib["time"] = unicode(time.time() - startTime)
             totalCpuTime, totalMemoryUsage = getTotalCpuTimeAndMemoryUsage()
-            stats.attrib["clock"] = str(totalCpuTime - startClock)
-            stats.attrib["class"] = self._jobName()
-            stats.attrib["memory"] = str(totalMemoryUsage)
+            stats.attrib["clock"] = unicode(totalCpuTime - startClock)
+            stats.attrib["class"] = unicode(self._jobName())
+            stats.attrib["memory"] = unicode(totalMemoryUsage)
         #Return any logToMaster logging messages + the files that should be deleted
         #from the job store once the job has been registered as complete
         return fileStore.loggingMessages, fileStore.deletedJobStoreFileIDs.union(promiseFilesToDelete)


### PR DESCRIPTION
ElementTree tries to encode the log messages with XML entities, and it
can be unable to do this if bytes >128 are present in `str` values in
the tree.

I have solved this by converting all the relevant strings to `unicode`
objects, assuming that the user script output being collected is
actually UTF-8. In the event of a UTF-8 decoding error, the offending
characters are replaced with placeholders, but the Toil code should keep
going (and ElementTree should still be able to serialize the logs).

Fixes #427, while we wait for #125.