### PR TITLE
Prevent batch systems from returning killed jobs in getUpdatedBatchJobs (resolves #460)

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -90,7 +90,7 @@ class AbstractBatchSystem:
         """Gets a job that has updated its status,
         according to the job manager. Max wait gives the number of seconds to pause
         waiting for a result. If a result is available returns (jobID, exitValue)
-        else it returns None.
+        else it returns None. Does not return anything for jobs that were killed.
         """
         raise NotImplementedError('Abstract method: getUpdatedBatchJob')
 

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -302,7 +302,7 @@ class GridengineBatchSystem(AbstractBatchSystem):
         return self.worker.getRunningJobIDs()
 
     def getUpdatedBatchJob(self, maxWait):
-        i = self.updatedJobsQueue.get()
+        i = self.getFromQueueSafely(self.updatedJobsQueue, maxWait)
         logger.debug('UpdatedJobsQueue Item: %s', i)
         if i is None:
             return None

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -131,7 +131,8 @@ class SingleMachineBatchSystem(AbstractBatchSystem):
             finally:
                 log.debug('Finished job. self.coreFractions ~ %s and self.memory ~ %s',
                           self.coreFractions.value, self.memory.value)
-                self.outputQueue.put((jobID, statusCode))
+                if not info.killIntended:
+                    self.outputQueue.put((jobID, statusCode))
         log.debug('Exiting worker thread normally.')
 
     def issueBatchJob(self, command, memory, cores, disk):

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -137,6 +137,12 @@ class hidden:
             # self.assertEqual([0], self.batchSystem.getRunningJobIDs().keys())
             self.batchSystem.killBatchJobs([jobID])
             self.assertEqual({}, self.batchSystem.getRunningBatchJobIDs())
+
+            #Make sure the batch system doesn't add killed jobs
+            #to the updated jobs queue if they were killed.
+            updatedJobID = self.batchSystem.getUpdatedBatchJob(5);
+            self.assertEqual(updatedJobID, None)
+
             # Make sure that killJob doesn't hang / raise KeyError on unknown job IDs
             self.batchSystem.killBatchJobs([0])
 


### PR DESCRIPTION
- In all batch systems, getUpdatedBatchJob now returns (jobID, exitValue) tuples only for jobs on which killBatchJobs was not called. This prevents killed jobs from being processed twice in the leader.
- batchSystemTest.testKillJobs updated to enforce this behavior.