### PR TITLE
Issues/467 fix file store methods (resolves #467, resolves #468)

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -429,41 +429,45 @@ class Job(object):
 
         def getLocalTempDir(self):
             """
-            Get a new local temporary directory. This directory will exist for the 
+            Get the absolute path to a new local temporary directory. 
+            This directory will exist for the 
             duration of the job only, and is guaranteed to be deleted once
             the job terminates, removing all files it contains recursively. 
             """
-            return tempfile.mkdtemp(prefix="t", dir=self.localTempDir)
+            return os.path.abspath(tempfile.mkdtemp(prefix="t", dir=self.localTempDir))
         
         def getLocalTempFile(self):
             """
-            Get a local temporary file. This file will exist for the duration of the job only, and
+            Get an absolute path to a local temporary file. 
+            This file will exist for the duration of the job only, and
             is guaranteed to be deleted once the job terminates.
             """
             handle, tmpFile = tempfile.mkstemp(prefix="tmp", 
                                                suffix=".tmp", dir=self.localTempDir)
             os.close(handle)
-            return tmpFile
+            return os.path.abspath(tmpFile)
 
         def writeGlobalFile(self, localFileName, cleanup=False):
             """
-            Takes a file (as a path) and uploads it to to the global file store, returns
-            an ID that can be used to retrieve the file. 
+            Takes a file (as a path) and uploads it to to the global file store, 
+            returns an ID that can be used to retrieve the file. 
             
             If cleanup is True then the global file will be deleted once the job
-            and all its successors have completed running. If not the global file must be deleted
-            manually.
+            and all its successors have completed running. If not the global file 
+            must be deleted manually.
             
-            The write is asynchronous, so further modifications to the file pointed by
-            localFileName will result in undetermined behavior. The local file is safely removed 
-            at the end of the job by placing it in a location returned 
-            by getLocalTempDir.
+            The write is asynchronous, so further modifications during execution 
+            to the file pointed by localFileName will result in undetermined behavior. 
             """
             jobStoreFileID = self.jobStore.getEmptyFileStoreID(None 
                             if not cleanup else self.jobWrapper.jobStoreID)
             self.queue.put((open(localFileName, 'r'), jobStoreFileID))
-            #Now put the file into the cache
-            self.jobStoreFileIDToCacheLocation[jobStoreFileID] = localFileName
+            #Now put the file into the cache if it is a path within localTempDir
+            absLocalFileName = os.path.abspath(localFileName)
+            if absLocalFileName.startswith(self.localTempDir):
+                #Chmod to make file read only
+                os.chmod(absLocalFileName, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+                self.jobStoreFileIDToCacheLocation[jobStoreFileID] = absLocalFileName
             return jobStoreFileID
         
         def writeGlobalFileStream(self, cleanup=False):

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -489,7 +489,7 @@ class Job(object):
             
             *The returned file will be read only (have permissions 444).* 
             
-            userPath is a path to the name of file to which the global file will be 
+            :param userPath: a path to the name of file to which the global file will be 
             copied or hard-linked (see below). userPath must either be: (1) a 
             file path contained within a directory or, recursively, a subdirectory 
             of a temporary directory returned by Job.FileStore.getLocalTempDir(), 

--- a/src/toil/test/src/jobFileStoreTest.py
+++ b/src/toil/test/src/jobFileStoreTest.py
@@ -58,7 +58,17 @@ def fileTestJob(job, inputFileStoreIDs, testStrings, chainLength):
         #Load the input jobStoreFileIDs and check that they map to the 
         #same set of random input strings
         if random.random() > 0.666:
-            tempFile = job.fileStore.readGlobalFile(fileStoreID)
+            #Check we get an exception if we try a file out side of the file path
+            try:
+                job.fileStore.readGlobalFile(fileStoreID, userPath="THIS/IS/NOT/A/REAL/PATH")
+            except RuntimeError:
+                pass
+            if random.random() > 0.5:
+                tempFile = job.fileStore.readGlobalFile(fileStoreID)
+            else:
+                userPath = job.fileStore.getLocalTempFile()
+                tempFile = job.fileStore.readGlobalFile(fileStoreID, userPath)
+                assert userPath == tempFile
             with open(tempFile, 'r') as fH:
                 string = fH.readline()
                 assert testStrings[string[:PREFIX_LENGTH]] == string


### PR DESCRIPTION
Fixed Job.FileStore.readGlobalFile to allow a user specified location with the job's temporary directory structure. Fixed Job.FileStore.writeGlobalFile to not put files in the cache and subsequently delete files which are not within the job's temporary directory structure. 