### PR TITLE
Removed bioio.getTempDirectory() and enforce 755 for localWorkerTempDir (resolves #480, resolves #446) 

### DIFF
--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -289,33 +289,6 @@ def getTempFile(suffix="", rootDir=None):
         os.chmod(tmpFile, 0777) #Ensure everyone has access to the file.
         return tmpFile
 
-def getTempDirectory(rootDir=None):
-    """
-    returns a temporary directory that must be manually deleted. rootDir will be
-    created if it does not exist.
-    """
-    if rootDir is None:
-        return tempfile.mkdtemp()
-    else:
-        if not os.path.exists(rootDir):
-            try:
-                os.makedirs(rootDir)
-            except OSError:
-                # Maybe it got created between the test and the makedirs call?
-                pass
-            
-        while True:
-            # Keep trying names until we find one that doesn't exist. If one
-            # does exist, don't nest inside it, because someone else may be
-            # using it for something.
-            tmpDir = os.path.join(rootDir, "tmp_" + getRandomAlphaNumericString())
-            if not os.path.exists(tmpDir):
-                break
-                
-        os.mkdir(tmpDir)
-        os.chmod(tmpDir, 0777) #Ensure everyone has access to the file.
-        return tmpDir
-
 def main():
     pass
 

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -16,7 +16,7 @@ import unittest
 import os
 import random
 
-from toil.lib.bioio import getTempFile, getTempDirectory
+from toil.lib.bioio import getTempFile
 from toil.job import Job, JobGraphDeadlockException
 from toil.test import ToilTest
 

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -26,6 +26,7 @@ if __name__ == "__main__":
     toilSrcDir = os.path.dirname(os.path.realpath(__file__))
     sys.path = [directory for directory in sys.path if not os.path.realpath(directory) == toilSrcDir]
 
+import tempfile
 import traceback
 import time
 import socket
@@ -86,7 +87,6 @@ def main():
     from toil.lib.bioio import setLogLevel
     from toil.lib.bioio import getTotalCpuTime
     from toil.lib.bioio import getTotalCpuTimeAndMemoryUsage
-    from toil.lib.bioio import getTempDirectory
     from toil.lib.bioio import makePublicDir
     from toil.lib.bioio import system
     from toil.common import loadJobStore
@@ -148,8 +148,9 @@ def main():
         
     #Dir to put all the temp files in. If tempRootDir is None, tempdir looks at environment variables to determine
     # where to put the tempDir.
-    localWorkerTempDir = getTempDirectory(tempRootDir)
-    
+    localWorkerTempDir = tempfile.mkdtemp(dir=tempRootDir)
+    os.chmod(localWorkerTempDir, 0755)
+
     ##########################################
     #Setup the logging
     ##########################################


### PR DESCRIPTION
bioio.getTempDirectory was redundant so instead tempfile.mkdtemp() is
used. 0755 is enforced for localWorkerTempDir in worker.py 

Resolves #480 and #446.