### PR TITLE
Ability to communicate environment variables from leader to worker (resolves #441, resolves #421)

### DIFF
--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -27,6 +27,23 @@ def toilPackageDirPath():
     assert result.endswith('/toil')
     return result
 
-def resolveEntryPoint(entryPoint):
-    return os.path.join(os.path.dirname(sys.executable),entryPoint)
 
+def resolveEntryPoint(entryPoint):
+    """
+    Returns the path to the given entry point (see setup.py) that *should* work on a worker. The
+    return value may be an absolute or a relative path.
+    """
+    if hasattr(sys, 'real_prefix'):
+        # Inside a virtualenv we will use absolute paths to the entrypoints. For clusters this
+        # means that if Toil is installed in a virtualenv on the leader, it must be installed in
+        # a virtualenv located at the same path on the worker.
+        path = os.path.join(os.path.dirname(sys.executable), entryPoint)
+        assert os.path.isfile(path)
+        assert os.access(path, os.X_OK)
+        return path
+    else:
+        # Outside a virtualenv it is hard to predict where the entry points got installed. It is
+        # the reponsibility of the user to ensure that they are present on PATH and point to the
+        # correct version of Toil. This is still better than an absolute path because it gives
+        # the user control over Toil's location on both leader and workers.
+        return entryPoint

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -99,6 +99,14 @@ class AbstractBatchSystem:
         """
         raise NotImplementedError('Abstract Method: shutdown')
 
+    def setEnv(self, name, value=None):
+        """
+        Sets environment variables for the process of a given job so that an arbitrary
+        environment variable can be passed to a worker node running a job. If no value
+        is provided it will be looked up from the current environment.
+        """
+        pass
+
     @classmethod
     def getRescueBatchJobFrequency(cls):
         """Gets the period of time to wait (floating point, in seconds) between checking for 

--- a/src/toil/batchSystems/mesos/__init__.py
+++ b/src/toil/batchSystems/mesos/__init__.py
@@ -40,4 +40,6 @@ ToilJob = namedtuple('ToilJob', (
     # The resource object representing the user script
     'userScript',
     # The resource object representing the toil source tarball
-    'toilDistribution'))
+    'toilDistribution',
+    # The environment, which we need to set up some JobStores
+    'environment'))

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -124,7 +124,7 @@ class MesosExecutor(mesos.interface.Executor):
                 job.userScript.register()
             log.debug("Invoking command: '%s'", job.command)
             with self.popenLock:
-                return subprocess.Popen(job.command, shell=True)
+                return subprocess.Popen(job.command, shell=True, env=dict(os.environ, **job.environment))
 
         def sendUpdate(taskState, message=''):
             log.debug("Sending status update ...")

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -114,6 +114,13 @@ class AbstractJobStore(object):
         """
         raise NotImplementedError()
 
+    def getEnv(self):
+        """
+        Returns a dictionary of relevant environment variables such as authentication credentials
+        for job stores.
+        """
+        return {}
+
     ##Cleanup functions
 
     def clean(self, rootJobWrapper):

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -77,15 +77,15 @@ class AzureJobStore(AbstractJobStore):
         self.jobChunkSize = jobChunkSize
         self.keyPath = None
 
-        account_key = _fetchAzureAccountKey(accountName)
+        self.account_key = _fetchAzureAccountKey(accountName)
 
         # Table names have strict requirements in Azure
         self.namePrefix = self._sanitizeTableName(namePrefix)
         log.debug("Creating job store with name prefix '%s'" % self.namePrefix)
 
         # These are the main API entrypoints.
-        self.tableService = TableService(account_key=account_key, account_name=accountName)
-        self.blobService = BlobService(account_key=account_key, account_name=accountName)
+        self.tableService = TableService(account_key=self.account_key, account_name=accountName)
+        self.blobService = BlobService(account_key=self.account_key, account_name=accountName)
 
         # Register our job-store in the global table for this storage account
         self.registryTable = self._getOrCreateTable('toilRegistry')
@@ -167,6 +167,9 @@ class AzureJobStore(AbstractJobStore):
         self.files.delete_container()
         self.statsFiles.delete_container()
         self.statsFileIDs.delete_table()
+
+    def getEnv(self):
+        return {'AZURE_ACCOUNT_KEY': self.account_key}
 
     def writeFile(self, localFilePath, jobStoreID=None):
         jobStoreFileID = self._newFileID()

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -338,6 +338,11 @@ def mainLoop(config, batchSystem, jobStore, rootJobWrapper):
     logger.info("Found %s jobs to start and %i jobs with successors to run",
                 len(toilState.updatedJobs), len(toilState.successorCounts))
 
+    #Set proper environment variables
+    envVars = jobStore.getEnv()
+    for k,v in envVars.iteritems():
+        batchSystem.setEnv(k,v)
+
     ##########################################
     #Start the stats/logging aggregation process
     ##########################################

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -117,6 +117,25 @@ class hidden:
             #Make sure killBatchJobs can handle jobs that don't exist
             self.batchSystem.killBatchJobs([10])
 
+            # Kill job3
+            self.batchSystem.killBatchJobs([job3])
+
+            self.batchSystem.setEnv("TESTVAR", "testval")
+
+            #Testing environment variable for correct value
+            job4 = self.batchSystem.issueBatchJob("if [ -z ${TESTVAR+x} ]; then exit 1; else exit 0; fi",
+                                                  memory=memoryForJobs, cores=1, disk=diskForJobs)
+            updatedID, exitStatus = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
+
+            self.assertEqual(exitStatus, 0)
+            self.batchSystem.killBatchJobs([job4])
+
+            #Environment Variable negative test
+            job5 = self.batchSystem.issueBatchJob("if [ -z ${TESTVAR2+x} ]; then exit 1; else exit 0; fi",
+                                                  memory=memoryForJobs, cores=1, disk=diskForJobs)
+            updatedID, exitStatus = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
+            self.assertEqual(exitStatus, 1)
+
         def testCheckResourceRequest(self):
             self.assertRaises(InsufficientSystemResources,
                               self.batchSystem.checkResourceRequest,
@@ -239,7 +258,7 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
         # We'll use fractions to avoid rounding errors. Remember that only certain, discrete
         # fractions can be represented as a floating point number.
         F = Fraction
-        # This test isn't general enought to cover every possible value of minCores in
+        # This test isn't general enough to cover every possible value of minCores in
         # SingleMachineBatchSystem. Instead we hard-code a value and assert it.
         minCores = F(1, 10)
         self.assertEquals(float(minCores), SingleMachineBatchSystem.minCores)


### PR DESCRIPTION
Implemented setEnv in mesos, and single machine batch systems. Added command line option for setEnv. Added getEnv in abstractJobStore and called it from leader.py to iterate and set variables in batch system,

Resolves #441 and #421