### PR TITLE
Ability to communicate environment variables from leader to worker (resolves #441, resolves #421)

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -43,7 +43,11 @@ class AbstractBatchSystem:
         self.maxCores = maxCores
         self.maxMemory = maxMemory
         self.maxDisk = maxDisk
-        
+        self.environment = {}
+        """
+        :type dict[str,str]
+        """
+
     def checkResourceRequest(self, memory, cores, disk):
         """Check resource request is not greater than that available.
         """
@@ -56,7 +60,7 @@ class AbstractBatchSystem:
             raise InsufficientSystemResources('memory', memory, self.maxMemory)
         if disk > self.maxDisk:
             raise InsufficientSystemResources('disk', disk, self.maxDisk)
-        
+
     def issueBatchJob(self, command, memory, cores, disk):
         """Issues the following command returning a unique jobID. Command
         is the string to run, memory is an int giving
@@ -78,13 +82,13 @@ class AbstractBatchSystem:
         be depended upon.
         """
         raise NotImplementedError('Abstract method: getIssuedBatchJobIDs')
-    
+
     def getRunningBatchJobIDs(self):
         """Gets a map of jobs (as jobIDs) currently running (not just waiting)
         and a how long they have been running for (in seconds).
         """
         raise NotImplementedError('Abstract method: getRunningBatchJobIDs')
-    
+
     def getUpdatedBatchJob(self, maxWait):
         """Gets a job that has updated its status,
         according to the job manager. Max wait gives the number of seconds to pause
@@ -98,6 +102,29 @@ class AbstractBatchSystem:
         Should cleanly terminate all worker threads.
         """
         raise NotImplementedError('Abstract Method: shutdown')
+
+    def setEnv(self, name, value=None):
+        """
+        Set an environment variable for the worker process before it is launched. The worker
+        process will typically inherit the environment of the machine it is running on but this
+        method makes it possible to override specific variables in that inherited environment
+        before the worker is launched. Note that this mechanism is different to the one used by
+        the worker internally to set up the environment of a job. A call to this method affects
+        all jobs issued after this method returns. Note to implementors: This means that you
+        would typically need to copy the variables before enqueuing a job.
+
+        If no value is provided it will be looked up from the current environment.
+
+        NB: Only the Mesos and single-machine batch systems support passing environment
+        variables. On other batch systems, this method has no effect. See
+        https://github.com/BD2KGenomics/toil/issues/547.
+        """
+        if value is None:
+            try:
+                value = os.environ[name]
+            except KeyError:
+                raise RuntimeError("%s does not exist in current environment", name)
+        self.environment[name] = value
 
     @classmethod
     def getRescueBatchJobFrequency(cls):

--- a/src/toil/batchSystems/mesos/__init__.py
+++ b/src/toil/batchSystems/mesos/__init__.py
@@ -40,4 +40,6 @@ ToilJob = namedtuple('ToilJob', (
     # The resource object representing the user script
     'userScript',
     # The resource object representing the toil source tarball
-    'toilDistribution'))
+    'toilDistribution',
+    # A dictionary with additional environment variables to be set on the worker process
+    'environment'))

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -81,7 +81,7 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
         # Queue of jobs whose status has been updated, according to mesos. Req'd by toil
         self.updatedJobsQueue = Queue()
 
-        # Wether to use implicit/explicit acknowledgments
+        # Whether to use implicit/explicit acknowledgments
         self.implicitAcknowledgements = self.getImplicit()
 
         # Reference to the Mesos driver used by this scheduler, to be instantiated in run()
@@ -111,10 +111,11 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
         self.nextJobID += 1
 
         job = ToilJob(jobID=jobID,
-                         resources=ResourceRequirement(memory=memory, cores=cores, disk=disk),
-                         command=command,
-                         userScript=self.userScript,
-                         toilDistribution=self.toilDistribution)
+                      resources=ResourceRequirement(memory=memory, cores=cores, disk=disk),
+                      command=command,
+                      userScript=self.userScript,
+                      toilDistribution=self.toilDistribution,
+                      environment=self.environment.copy())
         job_type = job.resources
 
         log.debug("Queueing the job command: %s with job id: %s ..." % (command, str(jobID)))

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -124,7 +124,8 @@ class MesosExecutor(mesos.interface.Executor):
                 job.userScript.register()
             log.debug("Invoking command: '%s'", job.command)
             with self.popenLock:
-                return subprocess.Popen(job.command, shell=True)
+                return subprocess.Popen(job.command,
+                                        shell=True, env=dict(os.environ, **job.environment))
 
         def sendUpdate(taskState, message=''):
             log.debug("Sending status update ...")

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -114,6 +114,15 @@ class AbstractJobStore(object):
         """
         raise NotImplementedError()
 
+    def getEnv(self):
+        """
+        Returns a dictionary of environment variables that this job store requires to be set in
+        order to function properly on a worker.
+
+        :rtype: dict[str,str]
+        """
+        return {}
+
     ##Cleanup functions
 
     def clean(self, rootJobWrapper):

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -77,15 +77,15 @@ class AzureJobStore(AbstractJobStore):
         self.jobChunkSize = jobChunkSize
         self.keyPath = None
 
-        account_key = _fetchAzureAccountKey(accountName)
+        self.account_key = _fetchAzureAccountKey(accountName)
 
         # Table names have strict requirements in Azure
         self.namePrefix = self._sanitizeTableName(namePrefix)
         log.debug("Creating job store with name prefix '%s'" % self.namePrefix)
 
         # These are the main API entrypoints.
-        self.tableService = TableService(account_key=account_key, account_name=accountName)
-        self.blobService = BlobService(account_key=account_key, account_name=accountName)
+        self.tableService = TableService(account_key=self.account_key, account_name=accountName)
+        self.blobService = BlobService(account_key=self.account_key, account_name=accountName)
 
         # Register our job-store in the global table for this storage account
         self.registryTable = self._getOrCreateTable('toilRegistry')
@@ -167,6 +167,9 @@ class AzureJobStore(AbstractJobStore):
         self.files.delete_container()
         self.statsFiles.delete_container()
         self.statsFileIDs.delete_table()
+
+    def getEnv(self):
+        return dict(AZURE_ACCOUNT_KEY=self.account_key)
 
     def writeFile(self, localFilePath, jobStoreID=None):
         jobStoreFileID = self._newFileID()

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -38,9 +38,8 @@ log = logging.getLogger(__name__)
 #
 numCores = 2
 
-memoryForJobs = 100e6
+defaultRequirements = dict(memory=100e6, cores=1, disk=1000)
 
-diskForJobs = 1000
 
 class hidden:
     """
@@ -81,10 +80,8 @@ class hidden:
         def testRunJobs(self):
             testPath = os.path.join(self.tempDir, "test.txt")
 
-            job1 = self.batchSystem.issueBatchJob("sleep 1000",
-                                                  memory=memoryForJobs, cores=1, disk=diskForJobs)
-            job2 = self.batchSystem.issueBatchJob("sleep 1000",
-                                                  memory=memoryForJobs, cores=1, disk=diskForJobs)
+            job1 = self.batchSystem.issueBatchJob("sleep 1000", **defaultRequirements)
+            job2 = self.batchSystem.issueBatchJob("sleep 1000", **defaultRequirements)
 
             issuedIDs = self._waitForJobsToIssue(2)
             self.assertEqual(set(issuedIDs), {job1, job2})
@@ -101,8 +98,7 @@ class hidden:
             # Issue a job and then allow it to finish by itself, causing
             # it to be added to the updated jobs queue.
             self.assertFalse(os.path.exists(testPath))
-            job3 = self.batchSystem.issueBatchJob("touch %s" % testPath,
-                                                  memory=memoryForJobs, cores=1, disk=diskForJobs)
+            job3 = self.batchSystem.issueBatchJob("touch %s" % testPath, **defaultRequirements)
 
             updatedID, exitStatus = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
 
@@ -154,6 +150,7 @@ class hidden:
                 runningIDs = self.batchSystem.getRunningBatchJobIDs().keys()
             return runningIDs
 
+
 @needs_mesos
 class MesosBatchSystemTest(hidden.AbstractBatchSystemTest, MesosTestSupport):
     """
@@ -163,7 +160,8 @@ class MesosBatchSystemTest(hidden.AbstractBatchSystemTest, MesosTestSupport):
     def createBatchSystem(self):
         from toil.batchSystems.mesos.batchSystem import MesosBatchSystem
         self._startMesos(numCores)
-        return MesosBatchSystem(config=self.config, maxCores=numCores, maxMemory=1e9, maxDisk=1001,
+        return MesosBatchSystem(config=self.config,
+                                maxCores=numCores, maxMemory=1e9, maxDisk=1001,
                                 masterAddress='127.0.0.1:5050')
 
     def tearDown(self):
@@ -173,8 +171,9 @@ class MesosBatchSystemTest(hidden.AbstractBatchSystemTest, MesosTestSupport):
 
 class SingleMachineBatchSystemTest(hidden.AbstractBatchSystemTest):
     def createBatchSystem(self):
-        return SingleMachineBatchSystem(config=self.config, maxCores=numCores, maxMemory=1e9,
-                                        maxDisk=1001)
+        return SingleMachineBatchSystem(config=self.config,
+                                        maxCores=numCores, maxMemory=1e9, maxDisk=1001)
+
 
 class MaxCoresSingleMachineBatchSystemTest(ToilTest):
     """
@@ -239,7 +238,7 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
         # We'll use fractions to avoid rounding errors. Remember that only certain, discrete
         # fractions can be represented as a floating point number.
         F = Fraction
-        # This test isn't general enought to cover every possible value of minCores in
+        # This test isn't general enough to cover every possible value of minCores in
         # SingleMachineBatchSystem. Instead we hard-code a value and assert it.
         minCores = F(1, 10)
         self.assertEquals(float(minCores), SingleMachineBatchSystem.minCores)
@@ -288,6 +287,7 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
                             f.seek(0)
                             f.truncate(0)
                             f.write('0,0')
+
 
 @needs_parasol
 class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport):
@@ -346,6 +346,7 @@ class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport)
         from toil.batchSystems.parasol import popenParasolCommand
         exitStatus, batchLines = popenParasolCommand("parasol list batches")
         return [self._parseBatchString(line) for line in batchLines[1:] if not line == ""]
+
 
 @needs_gridengine
 class GridEngineTest(hidden.AbstractBatchSystemTest):

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -113,6 +113,22 @@ class hidden:
             #Make sure killBatchJobs can handle jobs that don't exist
             self.batchSystem.killBatchJobs([10])
 
+        def testSetEnv(self):
+            # https://github.com/BD2KGenomics/toil/issues/547
+            if isinstance(self, (MesosBatchSystemTest, SingleMachineBatchSystemTest)):
+                # First, ensure that the test fails if the variable is *not* set
+                command = 'test "$FOO" = bar'
+                job4 = self.batchSystem.issueBatchJob(command, **defaultRequirements)
+                updatedID, exitStatus = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
+                self.assertNotEqual(exitStatus, 0)
+                self.assertEqual(updatedID, job4)
+                # Now set the variable and ensure that it is present
+                self.batchSystem.setEnv('FOO', 'bar')
+                job5 = self.batchSystem.issueBatchJob(command, **defaultRequirements)
+                updatedID, exitStatus = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
+                self.assertEqual(exitStatus, 0)
+                self.assertEqual(updatedID, job5)
+
         def testCheckResourceRequest(self):
             self.assertRaises(InsufficientSystemResources,
                               self.batchSystem.checkResourceRequest,


### PR DESCRIPTION
This will allow setting LD_LIBRARY_PATH which wouldn't work with the environment.pickle mechanism. Use that ability to distribute Azure credentials

Partially addresses #473, but see #547.