### PR TITLE
Include sibling modules of user scripts when deploying them to workers (resolves #565)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /docs/_build
 __pycache__
 .eggs/
+.cache/
 test-report.xml
 venv/

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ kwargs = dict(
         'bd2k-python-lib==1.10.dev5'],
     tests_require=[
         'mock==1.0.1',
-        'pytest==2.7.2'],
+        'pytest==2.8.3'],
     test_suite='toil',
     extras_require={
         'mesos': [

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ kwargs = dict(
         'encryption': [
             'pynacl==0.3.0'],
         'cwl': [
-            'cwltool>=1.0.20150918080732']},
+            'cwltool==1.0.20151112194920']},
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=['*.test']),
     entry_points={

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -911,7 +911,11 @@ class Job(object):
             userModule = userModule.localize()
         if userModule.dirPath not in sys.path:
             sys.path.append(userModule.dirPath)
-        return importlib.import_module(userModule.name)
+        try:
+            return importlib.import_module(userModule.name)
+        except ImportError:
+            logger.error('Failed to import user module %r from sys.path=%r', userModule, sys.path)
+            raise
 
     @classmethod
     def _loadJob(cls, command, jobStore):

--- a/src/toil/test/src/resourceTest.py
+++ b/src/toil/test/src/resourceTest.py
@@ -11,48 +11,93 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import absolute_import
+import importlib
+import os
 
 import sys
+from zipfile import ZipFile
+from bd2k.util.files import mkdir_p
+from io import BytesIO
 
 from mock import MagicMock, patch
 
-from toil.resource import ModuleDescriptor, Resource
+from toil.resource import ModuleDescriptor, Resource, ResourceException
 from toil.test import ToilTest
 
 
-class ResourceTest( ToilTest ):
-    def test( self ):
+class ResourceTest(ToilTest):
+    """
+    Test module descriptors and resources derived from them.
+    """
+
+    def testStandAlone(self):
+        self._testExternal(moduleName='userScript', pyFiles=('userScript.py',
+                                                             'helper.py'))
+
+    def testPackage(self):
+        self._testExternal(moduleName='foo.userScript', pyFiles=('foo/__init__.py',
+                                                                 'foo/userScript.py',
+                                                                 'foo/bar/__init__.py',
+                                                                 'foo/bar/helper.py'))
+
+    def testStandAloneInPackage(self):
+        self.assertRaises(ResourceException,
+                          self._testExternal,
+                          moduleName='userScript',
+                          pyFiles=('__init__.py', 'userScript.py', 'helper.py'))
+
+    def _testExternal(self, moduleName, pyFiles):
+        dirPath = self._createTempDir()
+        pycFiles = set(pyFile + 'c' for pyFile in pyFiles)
+        for relPath in pyFiles:
+            path = os.path.join(dirPath, relPath)
+            mkdir_p(os.path.dirname(path))
+            with open(path, 'w') as f:
+                f.write('pass\n')
+        sys.path.append(dirPath)
+        try:
+            userScript = importlib.import_module(moduleName)
+            try:
+                self._test(userScript.__name__, expectedContents=pycFiles)
+            finally:
+                del userScript
+                del sys.modules[moduleName]
+            self.assertFalse(moduleName in sys.modules)
+        finally:
+            sys.path.remove(dirPath)
+
+    def testBuiltIn(self):
         # Create a ModuleDescriptor for the module containing ModuleDescriptor, i.e. toil.resource
         module_name = ModuleDescriptor.__module__
-        self.assertEquals( module_name, 'toil.resource' )
-        module = ModuleDescriptor.forModule( module_name )
+        self.assertEquals(module_name, 'toil.resource')
+        self._test(module_name, shouldBelongToToil=True)
 
+    def _test(self, module_name, shouldBelongToToil=False, expectedContents=None):
+        module = ModuleDescriptor.forModule(module_name)
         # Assert basic attributes and properties
-        self.assertTrue( module.belongsToToil )
-        self.assertEquals( module.name, module_name )
-        self.assertEquals( module.filePath, sys.modules[ module_name ].__file__ )
-        self.assertTrue( module.filePath.startswith( module.dirPath ) )
-        self.assertTrue( module.dirPath.endswith( '/src' ) )
+        self.assertEqual(module.belongsToToil, shouldBelongToToil)
+        self.assertEquals(module.name, module_name)
+        if shouldBelongToToil:
+            self.assertTrue(module.dirPath.endswith('/src'))
 
         # Before the module is saved as a resource, localize() and globalize() are identity
         # methods. This should log warnings.
-        self.assertIs( module.localize( ), module )
-        self.assertIs( module.globalize( ), module )
-
+        self.assertIs(module.localize(), module)
+        self.assertIs(module.globalize(), module)
         # Create a mock job store ...
-        jobStore = MagicMock( )
+        jobStore = MagicMock()
         # ... to generate a fake URL for the resource ...
         url = 'file://foo.zip'
         jobStore.getSharedPublicUrl.return_value = url
         # ... and save the resource to it.
-        resource = module.saveAsResourceTo( jobStore )
+        resource = module.saveAsResourceTo(jobStore)
         # Ensure that the URL generation method is actually called, ...
-        jobStore.getSharedPublicUrl.assert_called_once_with( resource.pathHash )
+        jobStore.getSharedPublicUrl.assert_called_once_with(resource.pathHash)
         # ... and that ensure that writeSharedFileStream is called.
-        jobStore.writeSharedFileStream.assert_called_once_with( resource.pathHash,
-                                                                isProtected=False )
-
+        jobStore.writeSharedFileStream.assert_called_once_with(resource.pathHash,
+                                                               isProtected=False)
         # Now it gets a bit complicated: Ensure that the context manager returned by the
         # jobStore's writeSharedFileStream() method is entered and that the file handle yielded
         # by the context manager is written to once with the zipped source tree from which
@@ -63,34 +108,36 @@ class ResourceTest( ToilTest ):
         # instead of keyword arguments, and the third 0 selects the first positional, i.e. the
         # contents. This is a bit brittle since it assumes that all the data is written in a
         # single call to write(). If more calls are made we can easily concatenate them.
-        zipFile = file_handle.write.call_args_list[ 0 ][ 0 ][ 0 ]
-        self.assertTrue( zipFile.startswith( 'PK' ) ) # the magic header for ZIP files
-        self.assertEquals( resource.url, url )
+        zipFile = file_handle.write.call_args_list[0][0][0]
+        self.assertTrue(zipFile.startswith('PK'))  # the magic header for ZIP files
 
+        # Check contents if requested
+        if expectedContents is not None:
+            with ZipFile(BytesIO(zipFile)) as _zipFile:
+                self.assertEqual(set(_zipFile.namelist()), expectedContents)
+
+        self.assertEquals(resource.url, url)
         # Now we're on the worker. Prepare the storage for localized resources
-        Resource.prepareSystem( )
+        Resource.prepareSystem()
         # Register the resource for subsequent lookup.
-        resource.register( )
+        resource.register()
         # Lookup the resource and ensure that the result is equal to but not the same as the
         # original resource. Lookup will also be used when we localize the module that was
         # originally used to create the resource.
-        localResource = Resource.lookup( module._resourcePath )
-        self.assertEquals( resource, localResource )
-        self.assertIsNot( resource, localResource )
-
+        localResource = Resource.lookup(module._resourcePath)
+        self.assertEquals(resource, localResource)
+        self.assertIsNot(resource, localResource)
         # Now show that we can localize the module using the registered resource. Set up a mock
         # urlopen() that yields the zipped tree ...
-        mock_urlopen = MagicMock( )
+        mock_urlopen = MagicMock()
         mock_urlopen.return_value.read.return_value = zipFile
-        with patch( 'toil.resource.urlopen', mock_urlopen ):
+        with patch('toil.resource.urlopen', mock_urlopen):
             # ... and use it to download and unpack the resource
-            localModule = module.localize( )
-        # Name and extension should be equal between original and localized resource ...
-        self.assertEquals( module.name, localModule.name )
-        self.assertEquals( module.extension, localModule.extension )
+            localModule = module.localize()
+        # The name should be equal between original and localized resource ...
+        self.assertEquals(module.name, localModule.name)
         # ... but the directory should be different.
-        self.assertNotEquals( module.dirPath, localModule.dirPath )
-
+        self.assertNotEquals(module.dirPath, localModule.dirPath)
         # Show that we can 'undo' localization. This is necessary when the user script's jobs are
         # invoked on the worker where they generate more child jobs.
-        self.assertEquals( localModule.globalize( ), module )
+        self.assertEquals(localModule.globalize(), module)

--- a/src/toil/test/src/userDefinedJobArgTypeTest.py
+++ b/src/toil/test/src/userDefinedJobArgTypeTest.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 import sys
 from subprocess import check_call
-
 from toil.job import Job
 from toil.test import ToilTest
 
@@ -54,7 +53,7 @@ class UserDefinedJobArgTypeTest(ToilTest):
     def _testFromMain(self):
         testMethodName = self.id().split('.')[-1]
         self.assertTrue(testMethodName.endswith('FromMain'))
-        check_call([sys.executable, __file__, testMethodName[:-8]])
+        check_call([sys.executable, '-m', self.__module__, testMethodName[:-8]])
 
 
 class JobClass(Job):
@@ -90,7 +89,3 @@ def main():
     test.setUpClass()
     test.debug()
     test.tearDownClass()
-
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
- Extend tests a bit
- Eliminate unnecessary warnings in localize() and globalize()

Resolves #565 