### PR TITLE
Azure Patches

### DIFF
--- a/contrib/azure/README.md
+++ b/contrib/azure/README.md
@@ -20,7 +20,7 @@ The following image is an example of a cluster with 1 jumpbox, 3 masters, and 3 
 
 You can see the following parts:
 
-1. **Mesos on port 5050** - Mesos is the distributed systems kernel that abstracts cpu, memory and other resources, and offers these to services named "frameworks" for scheduling of workloads. **Note that Mesos masters only listen on the 10.0.0.0/18 subnet**. In particular, **note that Mesos does not listen on localhost**. If you run a Toil job on the master, you will want to pass `--batchSystem mesos --masterAddress 10.0.0.5:5050`.
+1. **Mesos on port 5050** - Mesos is the distributed systems kernel that abstracts cpu, memory and other resources, and offers these to services named "frameworks" for scheduling of workloads. **Note that Mesos masters only listen on the 10.0.0.0/18 subnet**. In particular, **note that Mesos does not listen on localhost**. If you run a Toil job on the master, you will want to pass `--batchSystem mesos --mesosMaster 10.0.0.5:5050`.
 2. **Docker on port 2375** - The Docker engine runs containerized workloads and each Master and Agent run the Docker engine. Mesos runs Docker workloads, and examples on how to do this are provided in the Marathon and Chronos walkthrough sections of this readme.
 3. **(Optional) Marathon on port 8080** - Marathon is a scheduler for Mesos that is equivalent to init on a single linux machine: it schedules long running tasks for the whole cluster. The Swarm framework is disabled by default.
 4. **(Optional) Chronos on port 4400** - Chronos is a scheduler for Mesos that is equivalent to cron on a single linux machine: it schedules periodic tasks for the whole cluster. The Swarm framework is disabled by default.

--- a/contrib/azure/agent-0.json
+++ b/contrib/azure/agent-0.json
@@ -128,6 +128,18 @@
         "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
       }
     },
+    "githubSource": {
+      "type": "string",
+      "metadata": {
+        "description": "User and repo name on Github to pull cluster setup scripts and Toil from."
+      }
+    },
+    "githubBranch": {
+      "type": "string",
+      "metadata": {
+        "description": "Branch on Github to pull cluster setup scripts and Toil from."
+      }
+    },
     "omsStorageAccount": {
       "type": "string",
       "metadata": {

--- a/contrib/azure/agent-gt0.json
+++ b/contrib/azure/agent-gt0.json
@@ -128,6 +128,18 @@
         "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
       }
     },
+    "githubSource": {
+      "type": "string",
+      "metadata": {
+        "description": "User and repo name on Github to pull cluster setup scripts and Toil from."
+      }
+    },
+    "githubBranch": {
+      "type": "string",
+      "metadata": {
+        "description": "Branch on Github to pull cluster setup scripts and Toil from."
+      }
+    },
     "omsStorageAccount": {
       "type": "string",
       "metadata": {
@@ -272,7 +284,7 @@
         "typeHandlerVersion": "1.3",
         "settings": {
           "fileUris": [],
-          "commandToExecute": "[concat(variables('commandPrefix'), variables('wgetCommandPrefix'), parameters('masterCount'), ' slaveconfiguration ', parameters('masterVMNamePrefix'), ' ', parameters('swarmEnabled'), ' ', parameters('marathonEnabled'), ' ', parameters('chronosEnabled'), ' ', parameters('toilEnabled'), ' ', parameters('omsStorageAccount'), ' ', parameters('omsStorageAccountKey'), ' ', parameters('adminUsername'), ' \"', parameters('sshRSAPublicKey'), '\" ', variables('wgetCommandPostfix'))]"
+          "commandToExecute": "[concat(variables('commandPrefix'), variables('wgetCommandPrefix'), parameters('masterCount'), ' slaveconfiguration ', parameters('masterVMNamePrefix'), ' ', parameters('swarmEnabled'), ' ', parameters('marathonEnabled'), ' ', parameters('chronosEnabled'), ' ', parameters('toilEnabled'), ' ', parameters('omsStorageAccount'), ' ', parameters('omsStorageAccountKey'), ' ', parameters('adminUsername'), ' \"', parameters('sshRSAPublicKey'), '\" ', parameters('githubSource'), ' ', parameters('githubBranch'), ' ', variables('wgetCommandPostfix'))]"
         }
       }
     }

--- a/contrib/azure/azuredeploy.json
+++ b/contrib/azure/azuredeploy.json
@@ -186,6 +186,20 @@
       "metadata": {
         "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
       }
+    },
+    "githubSource": {
+      "type": "string",
+      "defaultValue": "BD2KGenomics/toil",
+      "metadata": {
+        "description": "User and repo name on Github to pull cluster setup scripts and Toil from."
+      }
+    },
+    "githubBranch": {
+      "type": "string",
+      "defaultValue": "master",
+      "metadata": {
+        "description": "Branch on Github to pull cluster setup scripts and Toil from."
+      }
     }
   },
   "variables": {
@@ -208,7 +222,7 @@
     "nsgName": "node-nsg",
     "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
     "storageAccountType": "Standard_GRS",
-    "customScriptLocation": "https://raw.githubusercontent.com/BD2KGenomics/toil/master/contrib/azure/",
+    "customScriptLocation": "[concat('https://raw.githubusercontent.com/', parameters('githubSource'), '/', parameters('githubBranch'), '/contrib/azure/')]",
     "agentFiles": [
       "agent-0.json",
       "agent-gt0.json"
@@ -370,6 +384,12 @@
           "sshRSAPublicKey": {
             "value": "[parameters('sshRSAPublicKey')]"
           },
+          "githubSource": {
+            "value": "[parameters('githubSource')]"
+          },
+          "githubBranch": {
+            "value": "[parameters('githubBranch')]"
+          },
           "omsStorageAccount": {
             "value": "[variables('omsStorageAccount')]"
           },
@@ -456,6 +476,12 @@
           "sshRSAPublicKey": {
             "value": "[parameters('sshRSAPublicKey')]"
           },
+          "githubSource": {
+            "value": "[parameters('githubSource')]"
+          },
+          "githubBranch": {
+            "value": "[parameters('githubBranch')]"
+          },
           "omsStorageAccount": {
             "value": "[variables('omsStorageAccount')]"
           },
@@ -515,6 +541,12 @@
           },
           "sshRSAPublicKey": {
             "value": "[parameters('sshRSAPublicKey')]"
+          },
+          "githubSource": {
+            "value": "[parameters('githubSource')]"
+          },
+          "githubBranch": {
+            "value": "[parameters('githubBranch')]"
           }
         }
       }

--- a/contrib/azure/azuredeploy.parameters.json
+++ b/contrib/azure/azuredeploy.parameters.json
@@ -52,5 +52,11 @@
   },
   "sshRSAPublicKey": {
     "value": "disabled"
+  },
+  "githubSource": {
+    "value": "BD2KGenomics/toil"
+  },
+  "githubBranch": {
+    "value": "master"
   }
 }

--- a/contrib/azure/configure-mesos-cluster.sh
+++ b/contrib/azure/configure-mesos-cluster.sh
@@ -402,8 +402,10 @@ if [ "$TOILENABLED" == "true" ] ; then
   # Install the right bindings for the Mesos we installed
   UBUNTU_VERSION=`lsb_release -rs`
   sudo easy_install https://pypi.python.org/packages/source/m/mesos.interface/mesos.interface-${BINDINGS_MESOS_VERSION}.tar.gz
-  sudo easy_install https://downloads.mesosphere.io/master/ubuntu/${UBUNTU_VERSION}/mesos-${BINDINGS_MESOS_VERSION}-py2.7-linux-x86_64.egg
-  
+  # Easy-install doesn't like this server's ssl for some reason.
+  sudo wget https://downloads.mesosphere.io/master/ubuntu/${UBUNTU_VERSION}/mesos-${BINDINGS_MESOS_VERSION}-py2.7-linux-x86_64.egg
+  sudo easy_install mesos-${BINDINGS_MESOS_VERSION}-py2.7-linux-x86_64.egg
+  sudo rm mesos-${BINDINGS_MESOS_VERSION}-py2.7-linux-x86_64.egg
 fi
 
 date

--- a/contrib/azure/jumpbox-linux.json
+++ b/contrib/azure/jumpbox-linux.json
@@ -73,6 +73,18 @@
       "metadata": {
         "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
       }
+    },
+    "githubSource": {
+      "type": "string",
+      "metadata": {
+        "description": "User and repo name on Github to pull cluster setup scripts and Toil from."
+      }
+    },
+    "githubBranch": {
+      "type": "string",
+      "metadata": {
+        "description": "Branch on Github to pull cluster setup scripts and Toil from."
+      }
     }
   },
   "variables": {

--- a/contrib/azure/jumpbox-none.json
+++ b/contrib/azure/jumpbox-none.json
@@ -73,6 +73,18 @@
       "metadata": {
         "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure the machines"
       }
+    },
+    "githubSource": {
+      "type": "string",
+      "metadata": {
+        "description": "User and repo name on Github to pull cluster setup scripts and Toil from."
+      }
+    },
+    "githubBranch": {
+      "type": "string",
+      "metadata": {
+        "description": "Branch on Github to pull cluster setup scripts and Toil from."
+      }
     }
   },
   "variables": {},

--- a/contrib/azure/jumpbox-windows.json
+++ b/contrib/azure/jumpbox-windows.json
@@ -67,6 +67,24 @@
       "metadata": {
         "description": "The vm name prefix of the master"
       }
+    },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
+      }
+    },
+    "githubSource": {
+      "type": "string",
+      "metadata": {
+        "description": "User and repo name on Github to pull cluster setup scripts and Toil from."
+      }
+    },
+    "githubBranch": {
+      "type": "string",
+      "metadata": {
+        "description": "Branch on Github to pull cluster setup scripts and Toil from."
+      }
     }
   },
   "variables": {

--- a/contrib/azure/master.json
+++ b/contrib/azure/master.json
@@ -128,6 +128,18 @@
         "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
       }
     },
+    "githubSource": {
+      "type": "string",
+      "metadata": {
+        "description": "User and repo name on Github to pull cluster setup scripts and Toil from."
+      }
+    },
+    "githubBranch": {
+      "type": "string",
+      "metadata": {
+        "description": "Branch on Github to pull cluster setup scripts and Toil from."
+      }
+    },
     "omsStorageAccount": {
       "type": "string",
       "metadata": {
@@ -367,7 +379,7 @@
         "typeHandlerVersion": "1.3",
         "settings": {
           "fileUris": [],
-          "commandToExecute": "[concat(variables('commandPrefix'), variables('wgetCommandPrefix'), parameters('masterCount'), ' ', parameters('masterConfiguration'), ' ', parameters('masterVMNamePrefix'), ' ', parameters('swarmEnabled'), ' ', parameters('marathonEnabled'), ' ', parameters('chronosEnabled'), ' ', parameters('toilEnabled'), ' ', parameters('omsStorageAccount'), ' ', parameters('omsStorageAccountKey'), ' ', parameters('adminUsername'), ' \"', parameters('sshRSAPublicKey'), '\" ', variables('wgetCommandPostfix'))]"
+          "commandToExecute": "[concat(variables('commandPrefix'), variables('wgetCommandPrefix'), parameters('masterCount'), ' ', parameters('masterConfiguration'), ' ', parameters('masterVMNamePrefix'), ' ', parameters('swarmEnabled'), ' ', parameters('marathonEnabled'), ' ', parameters('chronosEnabled'), ' ', parameters('toilEnabled'), ' ', parameters('omsStorageAccount'), ' ', parameters('omsStorageAccountKey'), ' ', parameters('adminUsername'), ' \"', parameters('sshRSAPublicKey'), '\" ', parameters('githubSource'), ' ', parameters('githubBranch'), ' ', variables('wgetCommandPostfix'))]"
         }
       }
     }


### PR DESCRIPTION
I've patched up the Azure deployment template to work again, and to let you deploy any Github-hosted Toil instead of just BD2KGenomics/master (which is still the default). This makes debugging on Azure significantly easier.

I've also fixed the Azure jobStore to read large files to disk correctly, to fix #570.