### PR TITLE
Fix slow restart against the AzureJobStore (resolves #584)

### DIFF
--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -63,8 +63,8 @@ def _fetchAzureAccountKey(accountName):
     try:
         return configParser.get('AzureStorageCredentials', accountName)
     except NoOptionError:
-        raise RuntimeError("No account key found for %s, please provide it in " +
-                           credential_file_path % accountName)
+        raise RuntimeError("No account key found for %s, please provide it in %s" %
+                           (accountName, credential_file_path))
 
 
 maxAzureTablePropertySize = 64 * 1024

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -39,7 +39,7 @@ from toil.jobStores.abstractJobStore import (AbstractJobStore, NoSuchJobExceptio
                                              NoSuchFileException)
 import toil.lib.encryption as encryption
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 credential_file_path = '~/.toilAzureCredentials'
 
@@ -82,7 +82,7 @@ class AzureJobStore(AbstractJobStore):
 
         # Table names have strict requirements in Azure
         self.namePrefix = self._sanitizeTableName(namePrefix)
-        log.debug("Creating job store with name prefix '%s'" % self.namePrefix)
+        logger.debug("Creating job store with name prefix '%s'" % self.namePrefix)
 
         # These are the main API entrypoints.
         self.tableService = TableService(account_key=self.account_key, account_name=accountName)
@@ -123,8 +123,45 @@ class AzureJobStore(AbstractJobStore):
         return self.namePrefix + self.nameSeparator + name
 
     def jobs(self):
-        for jobEntity in self.jobItems.query_entities():
-            yield AzureJob.fromEntity(jobEntity)
+        # We need to page through the results, since we only get some of them at
+        # a time. Just like in the BlobService. See the only documentation
+        # available: the API bindings source code, at:
+        # https://github.com/Azure/azure-storage-python/blob/09e9f186740407672777d6cb6646c33a2273e1a8/azure/storage/table/tableservice.py#L385
+        
+        # These two together constitute the primary key for an item.
+        next_partition_key = None
+        next_row_key = None
+    
+        # How many jobs have we done?
+        total_processed = 0
+    
+        while True:
+            # Get a page (up to 1000 items)
+            page = self.jobItems.query_entities(
+                next_partition_key=next_partition_key,
+                next_row_key=next_row_key)
+            
+            for jobEntity in page:
+                # Process the items in the page
+                yield AzureJob.fromEntity(jobEntity)
+                total_processed += 1
+                
+            if hasattr(page, 'x_ms_continuation'):
+                # Next time ask for the next page. If you use .get() you need
+                # the lower-case evrsions, but this is some kind of fancy case-
+                # insensitive dictionary.
+                next_partition_key = page.x_ms_continuation['NextPartitionKey']
+                next_row_key = page.x_ms_continuation['NextRowKey']
+            else:
+                # No continuation to check
+                next_partition_key = None
+                next_row_key = None
+            
+            if not next_partition_key and not next_row_key:
+                # If we run out of pages, stop
+                break
+                
+            logger.info("Processed %d total jobs" % total_processed)
 
     def create(self, command, memory, cores, disk,
                predecessorNumber=0):
@@ -688,11 +725,11 @@ def retry_on_error(num_tries=5, retriable_exceptions=(socket.error, socket.gaier
             if last:
                 raise
             else:
-                log.info("Got a retriable exception %s, trying again" % e.__class__.__name__)
+                logger.info("Got a retriable exception %s, trying again" % e.__class__.__name__)
         except Exception as e:
             # For other exceptions, the retriable_check function determines whether to retry
             if retriable_check(e):
-                log.info("Exception %s passed predicate, trying again" % e.__class__.__name__)
+                logger.info("Exception %s passed predicate, trying again" % e.__class__.__name__)
             else:
                 raise
         else:

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -148,7 +148,13 @@ class AzureJobStore(AbstractJobStore):
                        predecessorNumber=predecessorNumber)
         entity = job.toItem(chunkSize=self.jobChunkSize)
         entity['RowKey'] = jobStoreID
-        self.jobItems.insert_entity(entity=entity)
+        try:
+            self.jobItems.insert_entity(entity=entity)
+        except WindowsAzureConflictError as e:
+            # A conflict on insert probably means we retried but already
+            # succeeded. Just ignore it. We made a _newJobID() ourselves, so
+            # unless that's broken we can't be re-using a job ID.
+            logger.warning("Conflict when inserting job %s" % jobStoreId)
         return job
 
     def exists(self, jobStoreID):

--- a/src/toil/utils/toilRestart.py
+++ b/src/toil/utils/toilRestart.py
@@ -57,8 +57,13 @@ def main():
     setLoggingFromOptions(options)
     options.restart = True
     with setupToil(options) as (config, batchSystem, jobStore):
-        jobStore.clean(Job._loadRootJob(jobStore))
-        mainLoop(config, batchSystem, jobStore, Job._loadRootJob(jobStore))
+        # Load the whole jobstore into memory in a batch
+        logger.info("Downloading entire JobStore")
+        jobCache = {jobWrapper.jobStoreID: jobWrapper
+            for jobWrapper in jobStore.jobs()}
+        logger.info("{} jobs downloaded.".format(len(jobCache)))
+        jobStore.clean(Job._loadRootJob(jobStore), jobCache=jobCache)
+        mainLoop(config, batchSystem, jobStore, Job._loadRootJob(jobStore), jobCache=jobCache)
     
 def _test():
     import doctest      


### PR DESCRIPTION
Basically, we now download all the jobs from the jobStore before trying
to "clean" the jobStore or rebuild the ToilState. This means we aren't
running individual per-job operations against every job in the jobStore,
which can be slow if the jobStore is Azure or AWS and each of those
operations requires a round-trip HTTP request.

To make this work, I also fixed the Azure job store's `jobs()` method,
which was only returning the first 1000 jobs.

The `clean()` method and the restart process in general is now much
noisier, with info messages letting you know how many jobs have been
loaded so far.

Fix logger naming in AzureJobStore

This still needs unit tests, but will close #584.