### PR TITLE
Fallback to sysctl when os.sysconf('SC_PHYS_PAGES') fails on OS X (resolves #587)

### DIFF
--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -17,6 +17,10 @@ from __future__ import absolute_import
 import os
 import sys
 
+from subprocess import check_output
+
+from bd2k.util import memoize
+
 
 def toilPackageDirPath():
     """
@@ -47,3 +51,18 @@ def resolveEntryPoint(entryPoint):
         # correct version of Toil. This is still better than an absolute path because it gives
         # the user control over Toil's location on both leader and workers.
         return entryPoint
+
+
+@memoize
+def physicalMemory():
+    """
+    >>> n = physicalMemory()
+    >>> n > 0
+    True
+    >>> n == physicalMemory()
+    True
+    """
+    try:
+        return os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    except ValueError:
+        return int(check_output(['sysctl', '-n', 'hw.memsize']).strip())

--- a/src/toil/batchSystems/parasolTestSupport.py
+++ b/src/toil/batchSystems/parasolTestSupport.py
@@ -9,6 +9,8 @@ import os
 from bd2k.util.files import rm_f
 from bd2k.util.objects import InnerClass
 
+from toil import physicalMemory
+
 log = logging.getLogger(__name__)
 
 
@@ -21,7 +23,7 @@ class ParasolTestSupport(object):
         if numCores is None:
             numCores = multiprocessing.cpu_count()
         if memory is None:
-            memory = self._physicalMemory()
+            memory = physicalMemory()
         self.numCores = numCores
         self.memory = memory
         self.leader = self.ParasolLeaderThread()
@@ -39,10 +41,6 @@ class ParasolTestSupport(object):
         self.leader.join()
         for path in ('para.results', 'parasol.jid'):
             rm_f(path)
-
-    @classmethod
-    def _physicalMemory(cls):
-        return os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
 
     class ParasolThread(threading.Thread):
 

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -23,6 +23,8 @@ import math
 from threading import Thread
 from threading import Lock, Condition
 from Queue import Queue, Empty
+
+import toil
 from toil.batchSystems.abstractBatchSystem import AbstractBatchSystem
 
 log = logging.getLogger(__name__)
@@ -44,7 +46,7 @@ class SingleMachineBatchSystem(AbstractBatchSystem):
     concurrently.
     """
 
-    physicalMemory = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    physicalMemory = toil.physicalMemory()
 
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         if maxCores > self.numCores:


### PR DESCRIPTION
Resolves #587