### PR TITLE
Support propagating Azure Storage keys for multiple accounts

### DIFF
--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -48,15 +48,18 @@ def _fetchAzureAccountKey(accountName):
     """
     Find the account key for a given Azure storage account.
 
-    The account key is taken from the AZURE_ACCOUNT_KEY environment
-    variable if it exists, or from looking in the file
-    "~/.toilAzureCredentials". That file has format:
+    The account key is taken from the AZURE_ACCOUNT_KEY_<account> environment
+    variable if it exists, then from plain AZURE_ACCOUNT_KEY, and then from
+    looking in the file "~/.toilAzureCredentials". That file has format:
 
     [AzureStorageCredentials]
     accountName1=ACCOUNTKEY1==
     accountName2=ACCOUNTKEY2==
     """
-    if 'AZURE_ACCOUNT_KEY' in os.environ:
+    
+    if "AZURE_ACCOUNT_KEY_{}".format(accountName) in os.environ:
+        return os.environ["AZURE_ACCOUNT_KEY_{}".format(accountName)]
+    elif 'AZURE_ACCOUNT_KEY' in os.environ:
         return os.environ['AZURE_ACCOUNT_KEY']
     configParser = RawConfigParser()
     configParser.read(os.path.expanduser(credential_file_path))


### PR DESCRIPTION
This adds support for propagating multiple Azure accounts to your nodes, in the absence of a shared filesystem for `.toilAzureConfig`. You just set `AZURE_ACCOUNT_KEY_<accountname>` for each account, and pass `-e AZURE_ACCOUNT_KEY_<accountname>` options for each account to your Toil script invocation.

Come to think of it, this is really only actually *useful* in combination with my own personal code which piggy-backs on top of the Toil Azure credential management code in order to get the keys for the storage accounts holding input and output data for my jobs.