### PR TITLE
Retry when Azure reports a service is unavailable (resolves #583)

### DIFF
--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -613,7 +613,9 @@ class AzureJob(JobWrapper):
 
 def retryOnAzureTimeout(exception):
     timeoutMsg = "could not be completed within the specified time"
-    return isinstance(exception, WindowsAzureError) and timeoutMsg in str(exception)
+    busyMsg = "Service Unavailable"
+    return isinstance(exception, WindowsAzureError) and (timeoutMsg in str(exception)
+        or busyMsg in str(exception))
 
 
 def retry_on_error(num_tries=5, retriable_exceptions=(socket.error, socket.gaierror,


### PR DESCRIPTION
Resolves #583.

Occasionally Azure Storage will report a "Service Unavailable" error. Unless Azure Storage is discontinued, we would expect the service to become available again in time, so it makes sense to retry after getting such an error.

This commit adds that error to the list of errors after which an Azure operation should be retried.