### PR TITLE
Fix Sphinx build warnings (resolves #594)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,7 +166,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/essentials.rst
+++ b/docs/essentials.rst
@@ -179,7 +179,8 @@ Scripting Quick Start
 ---------------------
 
 Toil's Job class (:class:`toil.job.Job`) contains the Toil API, documented below.
-To begin, consider this short toil script which illustrates defining a workflow:: 
+To begin, consider this short toil script which illustrates defining a workflow::
+
     from toil.job import Job
          
     def helloWorld(message, memory="2G", cores=2, disk="3G"):

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -11,6 +11,7 @@ Job basics
 The atomic unit of work in a Toil workflow is a *job* (:class:`toil.job.Job`). User
 scripts inherit from this base class to define units of work.
 For example::
+
     from toil.job import Job
     
     class HelloWorld(Job):
@@ -40,6 +41,7 @@ We can add to the previous example to turn it into a complete workflow by adding
 to create an instance of HelloWorld and to run this as a workflow containing a single job.
 This uses the :class:`toil.job.Job.Runner` class, which is used to start and resume Toil workflows. 
 For example::
+
     from toil.job import Job
     
     class HelloWorld(Job):
@@ -126,6 +128,7 @@ a constructor. To avoid this the classes :class:`toil.job.FunctionWrappingJob` a
 :class:`toil.job.JobFunctionWrappingTarget` allow functions to be directly converted to 
 jobs. 
 For example::
+
     from toil.job import Job
      
     def helloWorld(job, message, memory="2G", cores=2, disk="3G"):
@@ -146,6 +149,7 @@ job, see :class:`toil.job.JobFunctionWrappingTarget`.
 
 The function 
 call::
+
     Job.wrapJobFn(helloWorld, "woot")
 
 Creates the instance of the :class:`toil.job.JobFunctionWrappingTarget` that wraps the job
@@ -157,6 +161,7 @@ they can be passed to as arguments when wrapping a function as a job and will be
 
 Non-job functions can also be wrapped, 
 for example::
+
     from toil.job import Job
      
     def helloWorld2(message):
@@ -168,6 +173,7 @@ for example::
     
 Here the only major difference to note is the 
 line::
+
     Job.Runner.startToil(Job.wrapFn(helloWorld, "woot"), options)
 
 Which uses the function :func:`toil.job.Job.wrapFn` to wrap an ordinary function
@@ -190,6 +196,7 @@ The follow-on jobs of a job are run after its child jobs and their successors
 have completed. They are also run in parallel. Follow-ons allow the easy specification of 
 cleanup tasks that happen after a set of parallel child tasks. The following shows 
 a simple example that uses the earlier helloWorld job function::
+
     from toil.job import Job
     
     def helloWorld(job, message, memory="2G", cores=2, disk="3G"):
@@ -215,6 +222,7 @@ finally j4 is run as a follow-on of j1.
 
 There are multiple short hand functions to achieve the same workflow, 
 for example::
+
     from toil.job import Job
     
     def helloWorld(job, message, memory="2G", cores=2, disk="3G"):
@@ -239,6 +247,7 @@ Jobs graphs are not limited to trees, and can express arbitrary directed acylic 
 precise definition of legal graphs see :func:`toil.job.Job.checkJobGraphForDeadlocks`. The previous
 example could be specified as a DAG as 
 follows::
+
     from toil.job import Job
     
     def helloWorld(job, message, memory="2G", cores=2, disk="3G"):
@@ -264,6 +273,7 @@ Dynamic Job Creation
 The previous examples show a workflow being defined outside of a job. 
 However, Toil also allows jobs to be created dynamically within jobs. 
 For example::
+
     from toil.job import Job
     
     def binaryStringFn(job, message="", depth):
@@ -291,6 +301,7 @@ by recursive invocation of successor jobs within parent jobs. However, it is oft
 desirable to return variables from jobs in a non-recursive or dynamic context. 
 In Toil this is achieved with promises, as illustrated in the following 
 example::
+
     from toil.job import Job
     
     def fn(job, i):
@@ -311,6 +322,7 @@ Running this workflow results in three log messages from the jobs: "i is 1" from
 The return value from the first job is *promised* to the second job by the call to 
 :func:`toil.job.Job.rv` in the 
 line::
+
     j2 = j1.addChildFn(fn, j1.rv())
     
 The value of *j1.rv()* is a *promise*, rather than the actual return value of the function, 
@@ -323,6 +335,7 @@ Promises can be quite useful. For example, we can combine dynamic job creation
 with promises to achieve a job creation process that mimics the functional patterns 
 possible in many programming 
 languages::
+
     from toil.job import Job
     
     def binaryStrings(job, message="", depth):
@@ -358,6 +371,7 @@ shows how this can be used to create temporary files that persist for the length
 be placed in a specified local disk of the node and that 
 will be cleaned up, regardless of failure, when the job 
 finishes::
+
     from toil.job import Job
     
     class LocalFileStoreJob(Job):
@@ -380,6 +394,7 @@ finishes::
 Job functions can also access the file store for the job. The equivalent of the LocalFileStoreJob
 class is 
 equivalently::
+
     def localFileStoreJobFn(job):
         scratchDir = job.fileStore.getLocalTempDir()
         scratchFile = job.fileStore.getLocalTempFile()
@@ -390,6 +405,7 @@ In addition to temporary files that exist for the duration of a job, the file st
 creation of files in a *global* store, which persists during the workflow and are globally
 accessible (hence the name) between jobs. 
 For example::
+
     from toil.job import Job
     import os
     
@@ -457,6 +473,7 @@ for spawning such a service within a Toil workflow, allowing precise specificati
 of the start and end time of the service, and providing start and end methods to use
 for initialization and cleanup. The following simple, conceptual example illustrates how 
 services work::
+
     from toil.job import Job
     
     class DemoService(Job.Service):
@@ -504,6 +521,7 @@ Let A be a root job potentially with children and follow-ons. \
 Without an encapsulated job the simplest way to specify a job B which \
 runs after A and all its successors is to create a parent of A, call it Ap, \
 and then make B a follow-on of Ap. e.g.::
+
     from toil.job import Job
     
     # A is a job with children and follow-ons, for example:
@@ -525,7 +543,8 @@ and then make B a follow-on of Ap. e.g.::
         Job.Runner.startToil(Ap, options)
 
 An *encapsulated job* of E(A) of A saves making Ap, instead we can 
-write:: 
+write::
+
     from toil.job import Job
     
     # A 

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -163,7 +163,7 @@ class Job(object):
         """
         Adds a function as a child job.
         
-        :param fn: Function to be run as a child job with *args and **kwargs as \
+        :param fn: Function to be run as a child job with ``*args`` and ``**kwargs`` as \
         arguments to this function. See toil.job.FunctionWrappingJob for reserved \
         keyword arguments used to specify resource requirements.
         :return: The new child job that wraps fn.
@@ -175,7 +175,7 @@ class Job(object):
         """
         Adds a function as a follow-on job.
         
-        :param fn: Function to be run as a follow-on job with *args and **kwargs as \
+        :param fn: Function to be run as a follow-on job with ``*args`` and ``**kwargs`` as \
         arguments to this function. See toil.job.FunctionWrappingJob for reserved \
         keyword arguments used to specify resource requirements.
         :return: The new follow-on job that wraps fn.
@@ -188,7 +188,7 @@ class Job(object):
         Adds a job function as a child job. See :class:`toil.job.JobFunctionWrappingJob`
         for a definition of a job function.
         
-        :param fn: Job function to be run as a child job with *args and **kwargs as \
+        :param fn: Job function to be run as a child job with ``*args`` and ``**kwargs`` as \
         arguments to this function. See toil.job.JobFunctionWrappingJob for reserved \
         keyword arguments used to specify resource requirements.
         :return: The new child job that wraps fn.
@@ -201,7 +201,7 @@ class Job(object):
         Add a follow-on job function. See :class:`toil.job.JobFunctionWrappingJob`
         for a definition of a job function.
         
-        :param fn: Job function to be run as a follow-on job with *args and **kwargs as \
+        :param fn: Job function to be run as a follow-on job with ``*args`` and ``**kwargs`` as \
         arguments to this function. See toil.job.JobFunctionWrappingJob for reserved \
         keyword arguments used to specify resource requirements.
         :return: The new follow-on job that wraps fn.
@@ -215,7 +215,7 @@ class Job(object):
         Makes a Job out of a function. \
         Convenience function for constructor of :class:`toil.job.FunctionWrappingJob`.
         
-        :param fn: Function to be run with *args and **kwargs as arguments. \
+        :param fn: Function to be run with ``*args`` and ``**kwargs`` as arguments. \
         See toil.job.JobFunctionWrappingJob for reserved keyword arguments used \
         to specify resource requirements.
         :return: The new function that wraps fn.
@@ -229,7 +229,7 @@ class Job(object):
         Makes a Job out of a job function. \
         Convenience function for constructor of :class:`toil.job.JobFunctionWrappingJob`.
         
-        :param fn: Job function to be run with *args and **kwargs as arguments. \
+        :param fn: Job function to be run with ``*args`` and ``**kwargs`` as arguments. \
         See toil.job.JobFunctionWrappingJob for reserved keyword arguments used \
         to specify resource requirements.
         :return: The new job function that wraps fn.
@@ -299,6 +299,7 @@ class Job(object):
         """
         :return: The roots of the connected component of jobs that contains this job. \
         A root is a job with no predecessors.
+
         :rtype : set of toil.job.Job instances
         """
         roots = set()
@@ -343,7 +344,7 @@ class Job(object):
         an edge an "implied" edge. The augmented job graph is a job graph including \
         all the implied edges.
 
-        For a job graph G = (V, E) the algorithm is O(|V|^2). It is O(|V| + |E|) for \
+        For a job graph G = (V, E) the algorithm is ``O(|V|^2)``. It is ``O(|V| + |E|)`` for \
         a graph with no follow-ons. The former follow-on case could be improved!
         """
         #Get the root jobs
@@ -600,8 +601,8 @@ class Job(object):
             """
             Get a copy of a file in the job store. 
             
-            :param string userPath: a path to the name of file to which the global \ 
-            file will be copied or hard-linked (see below). 
+            :param string userPath: a path to the name of file to which the global \
+            file will be copied or hard-linked (see below).
             
             :param boolean cache: If True will use caching (see below). Caching will \
             attempt to keep copies of files between sequences of jobs run on the same \
@@ -622,7 +623,8 @@ class Job(object):
             this will result in two copies of the file on the system.
             
             :return: an absolute path to a local, temporary copy of the file keyed \
-            by fileStoreID. 
+            by fileStoreID.
+
             :rtype : string
             """
             if fileStoreID in self.filesToDelete:
@@ -1339,7 +1341,7 @@ class FunctionWrappingJob(Job):
     def __init__(self, userFunction, *args, **kwargs):
         """
         :param userFunction: The function to wrap. The userFunction will be called \
-        with the *args and **kwargs as arguments. 
+        with the ``*args`` and ``**kwargs`` as arguments.
         
         The keywords "memory", "cores", "disk", "cache" are reserved keyword arguments \
         that if specified will be used to determine the resources for the job, \
@@ -1401,6 +1403,7 @@ class EncapsulatedJob(Job):
     
     Let A be the root job of a job subgraph and B be another job we'd like to run after A
     and all its successors have completed, for this use encapsulate::
+
         A, B = A(), B() #Job A and subgraph, Job B
         A' = A.encapsulate()
         A'.addChild(B) #B will run after A and all its successors have 

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -61,11 +61,12 @@ class AbstractJobStore(object):
 
     def __init__(self, config=None):
         """
-        :param config: If config is not None then the
-        given configuration object will be written to the shared file "config.pickle" which can
-        later be retrieved using the readSharedFileStream. See writeConfigToStore. 
-        If this file already exists it will be overwritten. If config is None, 
+        :param config: If config is not None then the \
+        given configuration object will be written to the shared file "config.pickle" which can \
+        later be retrieved using the readSharedFileStream. See writeConfigToStore. \
+        If this file already exists it will be overwritten. If config is None, \
         the shared file "config.pickle" is assumed to exist and is retrieved. See loadConfigFromStore.
+
         """
         # Now get on with reading or writing the config
         if config is None:
@@ -398,7 +399,7 @@ class AbstractJobStore(object):
         Replaces the existing version of a file in the jobStore. Throws an exception if the file
         does not exist.
 
-        :raises ConcurrentFileModificationException: if the file was modified concurrently during
+        :raises ConcurrentFileModificationException: if the file was modified concurrently during \
         an invocation of this method
         """
         raise NotImplementedError()
@@ -410,7 +411,7 @@ class AbstractJobStore(object):
         which can be written to. The yielded file handle does not need to and 
         should not be closed explicitly.
 
-        :raises ConcurrentFileModificationException: if the file was modified concurrently during
+        :raises ConcurrentFileModificationException: if the file was modified concurrently during \
         an invocation of this method
         """
         raise NotImplementedError()
@@ -428,16 +429,16 @@ class AbstractJobStore(object):
     @contextmanager
     def writeSharedFileStream(self, sharedFileName, isProtected=None):
         """
-        Returns a context manager yielding a writable file handle to the global file referenced
+        Returns a context manager yielding a writable file handle to the global file referenced \
         by the given name.
 
-        :param sharedFileName: A file name matching AbstractJobStore.fileNameRegex, unique within
+        :param sharedFileName: A file name matching AbstractJobStore.fileNameRegex, unique within \
         the physical storage represented by this job store
 
-        :param isProtected: True if the file must be encrypted, None if it may be encrypted or
+        :param isProtected: True if the file must be encrypted, None if it may be encrypted or \
         False if it must be stored in the clear.
 
-        :raises ConcurrentFileModificationException: if the file was modified concurrently during
+        :raises ConcurrentFileModificationException: if the file was modified concurrently during \
         an invocation of this method
         """
         raise NotImplementedError()


### PR DESCRIPTION
Fixes several rst formatting errors and an incorrectly listed html source in conf.py. 

Most errors involved the use of special rst characters in docstrings ( * and | ) and required backslashes to escape them. This makes the docstrings much uglier but I don't see a way around it. 