### PR TITLE
Fix NPE in cwltoil entry point

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -390,6 +390,9 @@ def main(args=None):
     workdir = tempfile.mkdtemp()
     os.rmdir(workdir)
 
+    if args is None:
+        args = sys.argv[1:]
+
     options = parser.parse_args([workdir] + args)
 
     if options.quiet:


### PR DESCRIPTION
If no args are passed to cwltoil tool main method, use system args (the default None will cause exception on the [workdir] + args)