### PR TITLE
Issue 621 cwl schema (resolves #621)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ kwargs = dict(
         'encryption': [
             'pynacl==0.3.0'],
         'cwl': [
-            'cwltool==1.0.20151122025918']},
+            'cwltool==1.0.20151210154014']},
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=['*.test']),
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ kwargs = dict(
         'encryption': [
             'pynacl==0.3.0'],
         'cwl': [
-            'cwltool==1.0.20151210154014']},
+            'cwltool==1.0.20151211141743']},
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=['*.test']),
     entry_points={

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -390,6 +390,8 @@ def main(args=None):
     workdir = tempfile.mkdtemp()
     os.rmdir(workdir)
 
+    if args is None:
+        args = sys.argv[1:]
     options = parser.parse_args([workdir] + args)
 
     if options.quiet:

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -411,7 +411,8 @@ def main(args=None):
 
     job, _ = loader.resolve_ref(uri)
 
-    t = cwltool.main.load_tool(options.cwltool, False, False, cwltool.workflow.defaultMakeTool,
+    t = cwltool.main.load_tool(options.cwltool, False, True,
+                               cwltool.workflow.defaultMakeTool,
                                True)
 
     if type(t) == int:


### PR DESCRIPTION
Fix for issue #621 

This was due to the cwltool module having an open-ended dependency on the schema-salad module.  I made a incompatible change to schema-salad which broke cwltool which was pulling in the latest version.

cwltool now pins a specific version of schema salad, but this means toil needs to pin a new version of cwltool.

Also includes a small fix to the cwltoil main method.