### PR TITLE
Allow uploading unowned files to file store

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -565,8 +565,9 @@ class Job(object):
             if absLocalFileName.startswith(self.localTempDir):
                 jobStoreFileID = self.jobStore.getEmptyFileStoreID(cleanupID)
                 self.queue.put((open(absLocalFileName, 'r'), jobStoreFileID))
-                #Chmod to make file read only to try to prevent accidental user modification
-                os.chmod(absLocalFileName, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+                if os.stat(absLocalFileName).st_uid == os.getuid():
+                    #Chmod if permitted to make file read only to try to prevent accidental user modification
+                    os.chmod(absLocalFileName, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
                 with self._lockFilesLock:
                     self._lockFiles.add(jobStoreFileID)
                 self._jobStoreFileIDToCacheLocation[jobStoreFileID] = absLocalFileName


### PR DESCRIPTION
This commit checks file ownership before trying to change the
permissions on a file that a job wants to put in the file store. If you
want to, say, store the local node's syslog file, or a file owned by
another user on a shared disk, we have to do this.