### PR TITLE
Remove unnecessary assert that restricts toil commands names (resolves #631)

### DIFF
--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -328,7 +328,6 @@ class ModuleDescriptor(namedtuple('ModuleDescriptor', ('dirPath', 'name'))):
         filePath = os.path.abspath(module.__file__)
         filePath = filePath.split(os.path.sep)
         filePath[-1], extension = os.path.splitext(filePath[-1])
-        assert extension in ('.py', '.pyc')
         if name == '__main__':
             if module.__package__:
                 # invoked via python -m foo.bar


### PR DESCRIPTION
remove unnecessary assert that prevents toil commands from following UNIX naming conventions.

Fixes https://github.com/BD2KGenomics/toil/issues/631

Did not add tests for this, as I don't understand the test structure enough to do this.  Happy to add them if advised on the best approach.
