### PR TITLE
Add support for worker clean-up to single-machine and Mesos batch systems (resolves #651)

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -14,6 +14,7 @@
 
 
 from __future__ import absolute_import
+from collections import namedtuple
 from Queue import Empty
 import os
 
@@ -47,6 +48,12 @@ class AbstractBatchSystem:
         """
         :type dict[str,str]
         """
+        self.workerCleanupInfo = namedtuple('workerCleanupInfo', (
+            # A path to the value of config.workDir (where the cache would go)
+            'workDir',
+            # The value of config.workflowID (used to identify files specific to this workflow)
+            'workflowID'))(self.config.workDir, self.config.workflowID)
+
 
     def checkResourceRequest(self, memory, cores, disk):
         """Check resource request is not greater than that available.
@@ -138,6 +145,15 @@ class AbstractBatchSystem:
         and LSF currently use this.
         """
         return os.path.join(toilPath, "results.txt")
+
+    @staticmethod
+    def workerCleanup(workerCleanupInfo):
+        '''
+        Cleans up the worker node on batch system shutdown. For now it does nothing.
+        :param collections.namedtuple workerCleanupInfo: A named tuple consisting of all the
+        relevant information for cleaning up the worker.
+        '''
+        pass
 
 
 class InsufficientSystemResources(Exception):

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -366,3 +366,7 @@ class GridengineBatchSystem(AbstractBatchSystem):
             raise ValueError("GridEngine does not support commata in environment variable values")
         return AbstractBatchSystem.setEnv(self, name, value)
 
+    @staticmethod
+    def supportsWorkerCleanup():
+        return False
+

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -298,3 +298,7 @@ class LSFBatchSystem(AbstractBatchSystem):
         if self.maxCPU is 0 or self.maxMEM is 0:
                 RuntimeError("lshosts returns null ncpus or maxmem info")
         logger.info("Got the maxCPU: %s" % (self.maxMEM))
+
+    @staticmethod
+    def supportsWorkerCleanup():
+        return False

--- a/src/toil/batchSystems/mesos/__init__.py
+++ b/src/toil/batchSystems/mesos/__init__.py
@@ -42,4 +42,6 @@ ToilJob = namedtuple('ToilJob', (
     # The resource object representing the toil source tarball
     'toilDistribution',
     # A dictionary with additional environment variables to be set on the worker process
-    'environment'))
+    'environment',
+    # A named tuple containing all the required info for cleaning up the worker node
+    'workerCleanupInfo'))

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -115,7 +115,8 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
                       command=command,
                       userScript=self.userScript,
                       toilDistribution=self.toilDistribution,
-                      environment=self.environment.copy())
+                      environment=self.environment.copy(),
+                      workerCleanupInfo=self.workerCleanupInfo)
         job_type = job.resources
 
         log.debug("Queueing the job command: %s with job id: %s ..." % (command, str(jobID)))

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -36,12 +36,13 @@ log = logging.getLogger(__name__)
 
 class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
     """
-    A toil batch system implementation that uses Apache Mesos to distribute toil jobs as Mesos tasks over a
-    cluster of slave nodes. A Mesos framework consists of a scheduler and an executor. This class acts as the
-    scheduler and is typically run on the master node that also runs the Mesos master process with which the
-    scheduler communicates via a driver component. The executor is implemented in a separate class. It is run on each
-    slave node and communicates with the Mesos slave process via another driver object. The scheduler may also be run
-    on a separate node from the master, which we then call somewhat ambiguously the driver node.
+    A toil batch system implementation that uses Apache Mesos to distribute toil jobs as Mesos tasks
+    over a cluster of slave nodes. A Mesos framework consists of a scheduler and an executor. This
+    class acts as the scheduler and is typically run on the master node that also runs the Mesos
+    master process with which the scheduler communicates via a driver component. The executor is
+    implemented in a separate class. It is run on each slave node and communicates with the Mesos
+    slave process via another driver object. The scheduler may also be run on a separate node from
+    the master, which we then call somewhat ambiguously the driver node.
     """
 
     @staticmethod
@@ -75,7 +76,8 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
         #ended by themselves.
         self.intendedKill = set()
 
-        # Dict of launched jobIDs to TaskData named tuple. Contains start time, executorID, and slaveID.
+        # Dict of launched jobIDs to TaskData named tuple. Contains start time, executorID, and
+        # slaveID.
         self.runningJobMap = {}
 
         # Queue of jobs whose status has been updated, according to mesos. Req'd by toil
@@ -101,9 +103,9 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
 
     def issueBatchJob(self, command, memory, cores, disk):
         """
-        Issues the following command returning a unique jobID. Command is the string to run, memory is an int giving
-        the number of bytes the job needs to run in and cores is the number of cpus needed for the job and error-file
-        is the path of the file to place any std-err/std-out in.
+        Issues the following command returning a unique jobID. Command is the string to run, memory
+        is an int giving the number of bytes the job needs to run in and cores is the number of cpus
+        needed for the job and error-file is the path of the file to place any std-err/std-out in.
         """
         # puts job into job_type_queue to be run by Mesos, AND puts jobID in current_job[]
         self.checkResourceRequest(memory, cores, disk)
@@ -510,3 +512,7 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
         used when converting Mesos reqs to Toil reqs
         """
         return mem * 1024 * 1024
+
+    @staticmethod
+    def supportsWorkerCleanup():
+        return True

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -26,7 +26,7 @@ import psutil
 import mesos.interface
 from mesos.interface import mesos_pb2
 import mesos.native
-from toil.batchSystems.abstractBatchSystem import AbstractBatchSystem
+from toil.batchSystems.abstractBatchSystem import AbstractBatchSystem, WorkerCleanupInfo
 from toil.resource import Resource
 
 log = logging.getLogger(__name__)
@@ -42,6 +42,7 @@ class MesosExecutor(mesos.interface.Executor):
         super(MesosExecutor, self).__init__()
         self.popenLock = threading.Lock()
         self.runningTasks = {}
+        self.workerCleanupInfo = None
         Resource.prepareSystem()
         # FIXME: clean up resource root dir
 
@@ -62,7 +63,8 @@ class MesosExecutor(mesos.interface.Executor):
 
     def disconnected(self, driver):
         """
-        Invoked when the executor becomes "disconnected" from the slave (e.g., the slave is being restarted due to an upgrade).
+        Invoked when the executor becomes "disconnected" from the slave (e.g., the slave is being
+        restarted due to an upgrade).
         """
         log.critical("Disconnected from slave")
 
@@ -102,7 +104,10 @@ class MesosExecutor(mesos.interface.Executor):
             sendUpdate(mesos_pb2.TASK_RUNNING)
             # This is where task.data is first invoked. Using this position to setup cleanupInfo
             taskData = pickle.loads(task.data)
-            self.workerCleanupInfo = taskData.workerCleanupInfo
+            if self.workerCleanupInfo is not None:
+                assert self.workerCleanupInfo == taskData.workerCleanupInfo
+            else:
+                self.workerCleanupInfo = taskData.workerCleanupInfo
             popen = runJob(taskData)
             self.runningTasks[task.task_id.value] = popen.pid
             try:
@@ -115,7 +120,8 @@ class MesosExecutor(mesos.interface.Executor):
                     sendUpdate(mesos_pb2.TASK_FAILED, message=str(exitStatus))
             except:
                 exc_type, exc_value, exc_trace = sys.exc_info()
-                sendUpdate(mesos_pb2.TASK_FAILED, message=str(traceback.format_exception_only(exc_type, exc_value)))
+                sendUpdate(mesos_pb2.TASK_FAILED,
+                           message=str(traceback.format_exception_only(exc_type, exc_value)))
             finally:
                 del self.runningTasks[task.task_id.value]
 

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -346,3 +346,7 @@ class ParasolBatchSystem(AbstractBatchSystem):
         for results in self.resultsFiles.values():
             os.remove(results)
         os.rmdir(self.parasolResultsDir)
+
+    @staticmethod
+    def supportsWorkerCleanup():
+        return False

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -226,6 +226,10 @@ class SingleMachineBatchSystem(AbstractBatchSystem):
         """
         return 5400
 
+    @staticmethod
+    def supportsWorkerCleanup():
+        return True
+
 
 class Info(object):
     # Can't use namedtuple here since killIntended needs to be mutable

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -203,6 +203,7 @@ class SingleMachineBatchSystem(AbstractBatchSystem):
 
         for thread in self.workerThreads:
             thread.join()
+        AbstractBatchSystem.workerCleanup(self.workerCleanupInfo)
 
     def getUpdatedBatchJob(self, maxWait):
         """


### PR DESCRIPTION
Resolves #651 

1. Implemented abstract methods in AbstractBatchSystem for this.
2. SingleMachine and Mesos call the worker cleanup function on shutdown
3. All batch systems now have a static method for indicating whether they
    support worker cleanup.