### PR TITLE
Import and Export functions added to AWS JobStore and FileJobStore (resolves #618)

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -711,6 +711,12 @@ class Job(object):
                 #This will result in the files removal from the cache at the end of the current job
                 self._jobStoreFileIDToCacheLocation.pop(fileStoreID)
 
+        def importFile(self, sourceUrl):
+            return self.jobStore.importFile(sourceUrl)
+
+        def exportFile(self, jobStoreFileID, destUrl):
+            self.jobStore.exportFile(jobStoreFileID, destUrl)
+
         def logToMaster(self, text, level=logging.INFO):
             """
             Send a logging message to the leader. The message will also be \

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -422,6 +422,30 @@ class AbstractJobStore(object):
         """
         raise NotImplementedError()
 
+    fileUrlRegex = re.compile("[fF]ile://.+$")
+
+    @abstractmethod
+    def importFile(self, sourceUrl):
+        """
+        Imports file pointed at by sourceUrl into jobstore. The jobStoreFileId of the new file is
+        returned.
+
+        :param sourceUrl: URL of scheme 'file:' pointing to local files and urls pointing to the
+            local file scheme of the jobstore, e.g. 's3:' for AWS
+        :return jobStoreFileId
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def exportFile(self, jobStoreFileId, destUrl):
+        """
+        Exports file to destination pointed at by destUrl.
+
+        :param destUrl: URL of scheme 'file:' pointing to local files and urls pointing to the
+            local file scheme of the jobstore, e.g. 's3:' for AWS
+        """
+        raise NotImplementedError()
+
     ##########################################
     # The following methods deal with shared files, i.e. files not associated
     # with specific jobs.

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -290,6 +290,14 @@ class AzureJobStore(AbstractJobStore):
                                                      encrypted=str(encrypted)))
         self.statsFileIDs.insert_entity(entity={'RowKey': jobStoreFileID})
 
+    # FIXME: implementation
+    def importFile(self, sourceUrl):
+        pass
+
+    # FIXME: implementation
+    def exportFile(self, jobStoreFileId, destUrl):
+        pass
+
     def readStatsAndLogging(self, callback, readAll=False):
         suffix = '_old'
         numStatsFiles = 0


### PR DESCRIPTION
These methods are exposed to the user in job.FileStore. The test will fail because the multipart copy function has not beed added.