### PR TITLE
Support for Slurm batchSystem (resolves #682)

### DIFF
--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -1,0 +1,372 @@
+# Copyright (C) 2015 UCSC Computational Genomics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import logging
+import os
+from pipes import quote
+import subprocess
+import time
+import math
+from Queue import Queue, Empty
+from threading import Thread
+
+from toil.batchSystems.abstractBatchSystem import AbstractBatchSystem
+
+logger = logging.getLogger(__name__)
+
+sleepSeconds = 1
+
+
+class MemoryString:
+    def __init__(self, string):
+        if string[-1] == 'K' or string[-1] == 'M' or string[-1] == 'G' or string[-1] == 'T':
+            self.unit = string[-1]
+            self.val = float(string[:-1])
+        else:
+            self.unit = 'B'
+            self.val = float(string)
+        self.bytes = self.byteVal()
+
+    def __str__(self):
+        if self.unit != 'B':
+            return str(self.val) + self.unit
+        else:
+            return str(self.val)
+
+    def byteVal(self):
+        if self.unit == 'B':
+            return self.val
+        elif self.unit == 'K':
+            return self.val * 1024
+        elif self.unit == 'M':
+            return self.val * 1048576
+        elif self.unit == 'G':
+            return self.val * 1073741824
+        elif self.unit == 'T':
+            return self.val * 1099511627776
+
+    def __cmp__(self, other):
+        return cmp(self.bytes, other.bytes)
+
+
+class Worker(Thread):
+    def __init__(self, newJobsQueue, updatedJobsQueue, killQueue, killedJobsQueue, boss):
+        Thread.__init__(self)
+        self.newJobsQueue = newJobsQueue
+        self.updatedJobsQueue = updatedJobsQueue
+        self.killQueue = killQueue
+        self.killedJobsQueue = killedJobsQueue
+        self.waitingJobs = list()
+        self.runningJobs = set()
+        self.boss = boss
+        self.allocatedCpus = dict()
+        self.sgeJobIDs = dict()
+
+    def getRunningJobIDs(self):
+        times = {}
+        currentjobs = dict((str(self.sgeJobIDs[x][0]), x) for x in self.runningJobs)
+        process = subprocess.Popen(["qstat"], stdout=subprocess.PIPE)
+        stdout, stderr = process.communicate()
+
+        for currline in stdout.split('\n'):
+            items = currline.strip().split()
+            if items:
+                if items[0] in currentjobs and items[4] == 'r':
+                    jobstart = " ".join(items[5:7])
+                    jobstart = time.mktime(time.strptime(jobstart, "%m/%d/%Y %H:%M:%S"))
+                    times[currentjobs[items[0]]] = time.time() - jobstart
+
+        return times
+
+    def getSgeID(self, jobID):
+        if not jobID in self.sgeJobIDs:
+            RuntimeError("Unknown jobID, could not be converted")
+
+        (job, task) = self.sgeJobIDs[jobID]
+        if task is None:
+            return str(job)
+        else:
+            return str(job) + "." + str(task)
+
+    def forgetJob(self, jobID):
+        self.runningJobs.remove(jobID)
+        del self.allocatedCpus[jobID]
+        del self.sgeJobIDs[jobID]
+
+    def killJobs(self):
+        # Load hit list:
+        killList = list()
+        while True:
+            try:
+                jobId = self.killQueue.get(block=False)
+            except Empty:
+                break
+            else:
+                killList.append(jobId)
+
+        if not killList:
+            return False
+
+        # Do the dirty job
+        for jobID in list(killList):
+            if jobID in self.runningJobs:
+                logger.debug('Killing job: %s', jobID)
+                subprocess.check_call(['qdel', self.getSgeID(jobID)])
+            else:
+                if jobID in self.waitingJobs:
+                    self.waitingJobs.remove(jobID)
+                self.killedJobsQueue.put(jobID)
+                killList.remove(jobID)
+
+        # Wait to confirm the kill
+        while killList:
+            for jobID in list(killList):
+                if self.getJobExitCode(self.sgeJobIDs[jobID]) is not None:
+                    logger.debug('Adding jobID %s to killedJobsQueue', jobID)
+                    self.killedJobsQueue.put(jobID)
+                    killList.remove(jobID)
+                    self.forgetJob(jobID)
+            if len(killList) > 0:
+                logger.warn("Some jobs weren't killed, trying again in %is.", sleepSeconds)
+                time.sleep(sleepSeconds)
+
+        return True
+
+    def createJobs(self, newJob):
+        activity = False
+        # Load new job id if present:
+        if newJob is not None:
+            self.waitingJobs.append(newJob)
+        # Launch jobs as necessary:
+        while len(self.waitingJobs) > 0 and sum(self.allocatedCpus.values()) < int(
+                self.boss.maxCores):
+            activity = True
+            jobID, cpu, memory, command = self.waitingJobs.pop(0)
+            qsubline = self.prepareQsub(cpu, memory, jobID) + [command]
+            sgeJobID = self.qsub(qsubline)
+            self.sgeJobIDs[jobID] = (sgeJobID, None)
+            self.runningJobs.add(jobID)
+            self.allocatedCpus[jobID] = cpu
+        return activity
+
+    def checkOnJobs(self):
+        activity = False
+        logger.debug('List of running jobs: %r', self.runningJobs)
+        for jobID in list(self.runningJobs):
+            status = self.getJobExitCode(self.sgeJobIDs[jobID])
+            if status is not None:
+                activity = True
+                self.updatedJobsQueue.put((jobID, status))
+                self.forgetJob(jobID)
+        return activity
+
+    def run(self):
+        while True:
+            activity = False
+            newJob = None
+            if not self.newJobsQueue.empty():
+                activity = True
+                newJob = self.newJobsQueue.get()
+                if newJob is None:
+                    logger.debug('Received queue sentinel.')
+                    break
+            activity |= self.killJobs()
+            activity |= self.createJobs(newJob)
+            activity |= self.checkOnJobs()
+            if not activity:
+                logger.debug('No activity, sleeping for %is', sleepSeconds)
+                time.sleep(sleepSeconds)
+
+    def prepareQsub(self, cpu, mem, jobID):
+        qsubline = ['qsub', '-b', 'y', '-terse', '-j', 'y', '-cwd', '-o', '/dev/null',
+                    '-e', '/dev/null', '-N', 'toil_job_' + str(jobID)]
+
+        if self.boss.environment:
+            qsubline.append('-v')
+            qsubline.append(','.join(k + '=' + quote(os.environ[k] if v is None else v)
+                                     for k, v in self.boss.environment.iteritems()))
+
+        reqline = list()
+        if mem is not None:
+            memStr = str(mem / 1024) + 'K'
+            reqline += ['vf=' + memStr, 'h_vmem=' + memStr]
+        if len(reqline) > 0:
+            qsubline.extend(['-hard', '-l', ','.join(reqline)])
+        if cpu is not None and math.ceil(cpu) > 1:
+            peConfig = os.getenv('TOIL_GRIDENGINE_PE') or 'shm'
+            qsubline.extend(['-pe', peConfig, str(int(math.ceil(cpu)))])
+        return qsubline
+
+    def qsub(self, qsubline):
+        logger.debug("Running %r", qsubline)
+        process = subprocess.Popen(qsubline, stdout=subprocess.PIPE)
+        result = int(process.stdout.readline().strip().split('.')[0])
+        return result
+
+    def getJobExitCode(self, sgeJobID):
+        job, task = sgeJobID
+        args = ["qacct", "-j", str(job)]
+        if task is not None:
+            args.extend(["-t", str(task)])
+
+        process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        for line in process.stdout:
+            if line.startswith("failed") and int(line.split()[1]) == 1:
+                return 1
+            elif line.startswith("exit_status"):
+                logger.debug('Exit Status: %r', line.split()[1])
+                return int(line.split()[1])
+        return None
+
+
+class GridengineBatchSystem(AbstractBatchSystem):
+    """
+    The interface for SGE aka Sun GridEngine.
+    """
+
+    def __init__(self, config, maxCores, maxMemory, maxDisk):
+        AbstractBatchSystem.__init__(self, config, maxCores, maxMemory, maxDisk)
+        self.gridengineResultsFile = self._getResultsFileName(config.jobStore)
+        # Reset the job queue and results (initially, we do this again once we've killed the jobs)
+        self.gridengineResultsFileHandle = open(self.gridengineResultsFile, 'w')
+        # We lose any previous state in this file, and ensure the files existence
+        self.gridengineResultsFileHandle.close()
+        self.currentJobs = set()
+        self.maxCPU, self.maxMEM = self.obtainSystemConstants()
+        self.nextJobID = 0
+        self.newJobsQueue = Queue()
+        self.updatedJobsQueue = Queue()
+        self.killQueue = Queue()
+        self.killedJobsQueue = Queue()
+        self.worker = Worker(self.newJobsQueue, self.updatedJobsQueue, self.killQueue,
+                             self.killedJobsQueue, self)
+        self.worker.start()
+
+    def __des__(self):
+        # Closes the file handle associated with the results file.
+        self.gridengineResultsFileHandle.close()
+
+    def issueBatchJob(self, command, memory, cores, disk):
+        self.checkResourceRequest(memory, cores, disk)
+        jobID = self.nextJobID
+        self.nextJobID += 1
+        self.currentJobs.add(jobID)
+        self.newJobsQueue.put((jobID, cores, memory, command))
+        logger.debug("Issued the job command: %s with job id: %s ", command, str(jobID))
+        return jobID
+
+    def killBatchJobs(self, jobIDs):
+        """
+        Kills the given jobs, represented as Job ids, then checks they are dead by checking
+        they are not in the list of issued jobs.
+        """
+        jobIDs = set(jobIDs)
+        logger.debug('Jobs to be killed: %r', jobIDs)
+        for jobID in jobIDs:
+            self.killQueue.put(jobID)
+        while jobIDs:
+            killedJobId = self.killedJobsQueue.get()
+            if killedJobId is None:
+                break
+            jobIDs.remove(killedJobId)
+            if killedJobId in self.currentJobs:
+                self.currentJobs.remove(killedJobId)
+            if jobIDs:
+                logger.debug('Some kills (%s) still pending, sleeping %is', len(jobIDs),
+                             sleepSeconds)
+                time.sleep(sleepSeconds)
+
+    def getIssuedBatchJobIDs(self):
+        """
+        Gets the list of jobs issued to SGE.
+        """
+        return list(self.currentJobs)
+
+    def getRunningBatchJobIDs(self):
+        return self.worker.getRunningJobIDs()
+
+    def getUpdatedBatchJob(self, maxWait):
+        try:
+            i = self.updatedJobsQueue.get(timeout=maxWait)
+        except Empty:
+            return None
+        logger.debug('UpdatedJobsQueue Item: %s', i)
+        jobID, retcode = i
+        self.updatedJobsQueue.task_done()
+        self.currentJobs.remove(jobID)
+        return i
+
+    def shutdown(self):
+        """
+        Signals worker to shutdown (via sentinel) then cleanly joins the thread
+        """
+        newJobsQueue = self.newJobsQueue
+        self.newJobsQueue = None
+
+        newJobsQueue.put(None)
+        self.worker.join()
+
+    def getWaitDuration(self):
+        """
+        We give parasol a second to catch its breath (in seconds)
+        """
+        return 0.0
+
+    @classmethod
+    def getRescueBatchJobFrequency(cls):
+        """
+        Parasol leaks jobs, but rescuing jobs involves calls to parasol list jobs and pstat2,
+        making it expensive. We allow this every 10 minutes..
+        """
+        return 1800  # Half an hour
+
+    @staticmethod
+    def obtainSystemConstants():
+        lines = filter(None, map(str.strip, subprocess.check_output(["qhost"]).split('\n')))
+        line = lines[0]
+        items = line.strip().split()
+        num_columns = len(items)
+        cpu_index = None
+        mem_index = None
+        for i in range(num_columns):
+            if items[i] == 'NCPU':
+                cpu_index = i
+            elif items[i] == 'MEMTOT':
+                mem_index = i
+        if cpu_index is None or mem_index is None:
+            RuntimeError('qhost command does not return NCPU or MEMTOT columns')
+        maxCPU = 0
+        maxMEM = MemoryString("0")
+        for line in lines[2:]:
+            items = line.strip().split()
+            if len(items) < num_columns:
+                RuntimeError('qhost output has a varying number of columns')
+            if items[cpu_index] != '-' and items[cpu_index] > maxCPU:
+                maxCPU = items[cpu_index]
+            if items[mem_index] != '-' and MemoryString(items[mem_index]) > maxMEM:
+                maxMEM = MemoryString(items[mem_index])
+        if maxCPU is 0 or maxMEM is 0:
+            RuntimeError('qhost returned null NCPU or MEMTOT info')
+        return maxCPU, maxMEM
+
+    def setEnv(self, name, value=None):
+        if value and ',' in value:
+            raise ValueError("GridEngine does not support commata in environment variable values")
+        return AbstractBatchSystem.setEnv(self, name, value)
+
+    @staticmethod
+    def supportsWorkerCleanup():
+        return False
+

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -258,11 +258,14 @@ class Worker(Thread):
         args = ['sacct', '-n', '-j', str(slurmJobID), '--format','State,ExitCode']
         process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         for line in process.stdout:
-            logger.debug("Parsing sacct line %s", line)
             values = line.strip().split()
             if len(values) < 2:
                 continue
             state, exitcode = values
+            logger.debug("Job state is %s", state)
+            # If Job is in a running state, return None to indicate we don't have an update
+            if state in ('PENDING', 'RUNNING','CONFIGURING','COMPLETING','RESIZING','SUSPENDED'):
+                return None
             status, _ = exitcode.split(':')
             logger.debug("exit code is %s" % exitcode)
             logger.debug("status to return is %s", status)

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -242,7 +242,7 @@ class Worker(Thread):
         process = subprocess.Popen(sbatch_line, stdout=subprocess.PIPE)
 
         # sbatch prints a line like 'Submitted batch job 2954103'
-        result = int(process.stdout.readline().strip.split()[-1])
+        result = int(process.stdout.readline().strip().split()[-1])
         return result
 
     def getJobExitCode(self, slurmJobID):

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -223,7 +223,7 @@ class Worker(Thread):
         # -e means standard error (done)
         # -N is job name, which should be based on the jobID
 
-        sbatch_line = ['sbatch', '-Q', '-o=/dev/null', '-e=/dev/null', '-J', 'toil_job_{}'.format(jobID)]
+        sbatch_line = ['sbatch', '-Q', '-J', 'toil_job_{}'.format(jobID)]
 
         if self.boss.environment:
             for k, v in self.boss.environment.iteritems():

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -366,7 +366,10 @@ class SlurmBatchSystem(AbstractBatchSystem):
         max_mem = MemoryString('0')
         lines = subprocess.check_output(['sinfo', '-Nhe', '--format', '%m %c']).split('\n')
         for line in lines:
-            mem, cpu = line.split()
+            values = line.split()
+            if len(values) < 2:
+                continue
+            mem, cpu = values
             max_cpu = max(max_cpu, int(cpu))
             max_mem = max(max_mem, MemoryString(mem + 'M'))
         if max_cpu == 0 or max_mem.byteVal() ==  0:

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -186,6 +186,7 @@ class Worker(Thread):
         activity = False
         logger.debug('List of running jobs: %r', self.runningJobs)
         for jobID in list(self.runningJobs):
+            logger.debug("Checking status of internal job id %d" % jobID)
             status = self.getJobExitCode(self.slurmJobIDs[jobID])
             if status is not None:
                 activity = True
@@ -244,9 +245,11 @@ class Worker(Thread):
 
         # sbatch prints a line like 'Submitted batch job 2954103'
         result = int(process.stdout.readline().strip().split()[-1])
+        logger.debug("sbatch submitted job %d" % result)
         return result
 
     def getJobExitCode(self, slurmJobID):
+        logger.debug("Getting exit code for slurm job %d" % slurmJobID)
         # SLURM job exit codes are obtained by running sacct.
         # sacct returns
         # -n : no header
@@ -260,7 +263,9 @@ class Worker(Thread):
                 continue
             state, exitcode = values
             status, _ = exitcode.split(':')
+            logger.debug("exit code is %s" % status)
             return int(status)
+        logger.debug("Unable to get exit code")
         return None
 
 

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -232,7 +232,7 @@ class Worker(Thread):
         if mem is not None:
             sbatch_line.append('--mem={}'.format(mem))
         if cpu is not None:
-            sbatch_line.append('--cpus-per-task={}'.format(int(math.ceail(cpu))))
+            sbatch_line.append('--cpus-per-task={}'.format(int(math.ceil(cpu))))
 
         return sbatch_line
 

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -240,7 +240,6 @@ class Worker(Thread):
 
     def sbatch(self, sbatch_line):
         logger.debug("Running %r", sbatch_line)
-        # TODO: I'm assuming the last argument is a shell script that sbatch can handle. If not, I can always pipe it in.
         process = subprocess.Popen(sbatch_line, stdout=subprocess.PIPE)
 
         # sbatch prints a line like 'Submitted batch job 2954103'

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -175,7 +175,7 @@ class Worker(Thread):
                 self.boss.maxCores):
             activity = True
             jobID, cpu, memory, command = self.waitingJobs.pop(0)
-            sbatch_line = self.prepareSbatch(cpu, memory, jobID) + [command]
+            sbatch_line = self.prepareSbatch(cpu, memory, jobID) + command.split()
             slurmJobID = self.sbatch(sbatch_line)
             self.slurmJobIDs[jobID] = slurmJobID
             self.runningJobs.add(jobID)
@@ -222,7 +222,7 @@ class Worker(Thread):
         # -e means standard error (done)
         # -N is job name, which should be based on the jobID
 
-        sbatch_line = ['sbatch', '-Q', '-o=/dev/null', '-e=/dev/null', '-N', 'toil_job_{}'.format(jobID)]
+        sbatch_line = ['sbatch', '-Q', '-o=/dev/null', '-e=/dev/null', '-J', 'toil_job_{}'.format(jobID)]
 
         if self.boss.environment:
             for k, v in self.boss.environment.iteritems():

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -102,7 +102,7 @@ class Worker(Thread):
         # -h for no header
         # --format to get jobid i, state %t and time days-hours:minutes:seconds
 
-        lines = subprocess.check_output(['squeue', '-h', '--format', '%i %t %M']).split('\n')
+        lines = subprocess.check_output(['squeue', '-h', '--format', '\'%i %t %M\'']).split('\n')
         for line in lines:
             values = line.split()
             if len(values) < 3:
@@ -254,10 +254,12 @@ class Worker(Thread):
         # -n : no header
         # -j : job
         # --format : specify output columns
-        args = ['sacct', '-n', '-j', str(slurmJobID), '--format','State,ExitCode']
+        # -P : separate columns with pipes
+        # -S 1970-01-01 override start time limit
+        args = ['sacct', '-n', '-j', str(slurmJobID), '--format','State,ExitCode', '-P', '-S', '1970-01-01']
         process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         for line in process.stdout:
-            values = line.strip().split()
+            values = line.strip().split('|')
             if len(values) < 2:
                 continue
             state, exitcode = values
@@ -377,7 +379,7 @@ class SlurmBatchSystem(AbstractBatchSystem):
         # --format to get memory, cpu
         max_cpu = 0
         max_mem = MemoryString('0')
-        lines = subprocess.check_output(['sinfo', '-Nhe', '--format', '%m %c']).split('\n')
+        lines = subprocess.check_output(['sinfo', '-Nhe', '--format', '\'%m %c\'']).split('\n')
         for line in lines:
             values = line.split()
             if len(values) < 2:

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -258,12 +258,14 @@ class Worker(Thread):
         args = ['sacct', '-n', '-j', str(slurmJobID), '--format','State,ExitCode']
         process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         for line in process.stdout:
-            values = line.split()
+            logger.debug("Parsing sacct line %s", line)
+            values = line.strip().split()
             if len(values) < 2:
                 continue
             state, exitcode = values
             status, _ = exitcode.split(':')
-            logger.debug("exit code is %s" % status)
+            logger.debug("exit code is %s" % exitcode)
+            logger.debug("status to return is %s", status)
             return int(status)
         logger.debug("Unable to get exit code")
         return None

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -104,7 +104,10 @@ class Worker(Thread):
 
         lines = subprocess.check_output(['squeue', '-h', '--format', '%i %t %M']).split('\n')
         for line in lines:
-            slurm_jobid, state, elapsed_time = line.split()
+            values = line.split()
+            if len(values) < 3:
+                continue
+            slurm_jobid, state, elapsed_time = values
             if slurm_jobid in currentjobs and state == 'R':
                 seconds_running = self.parse_elapsed(elapsed_time)
                 times[currentjobs[slurm_jobid]] = seconds_running
@@ -251,10 +254,10 @@ class Worker(Thread):
         args = ['sacct', '-n', '-j', str(slurmJobID), '--format','State,ExitCode']
         process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         for line in process.stdout:
-            cols = line.split()
-            if len(cols) < 2:
+            values = line.split()
+            if len(values) < 2:
                 continue
-            state, exitcode = line.split()
+            state, exitcode = values
             status, _ = exitcode.split(':')
             return int(status)
         return None

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -232,7 +232,7 @@ class Worker(Thread):
 
         if mem is not None:
             # memory passed in is in bytes, but slurm expects megabytes
-            sbatch_line.append('--mem={}'.format(mem/2**20))
+            sbatch_line.append('--mem={}'.format(int(mem)/2**20))
         if cpu is not None:
             sbatch_line.append('--cpus-per-task={}'.format(int(math.ceil(cpu))))
 

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -230,7 +230,8 @@ class Worker(Thread):
                 sbatch_line.append('--export={}={}'.format(k, quoted_value))
 
         if mem is not None:
-            sbatch_line.append('--mem={}'.format(mem))
+            # memory passed in is in bytes, but slurm expects megabytes
+            sbatch_line.append('--mem={}'.format(mem/2**20))
         if cpu is not None:
             sbatch_line.append('--cpus-per-task={}'.format(int(math.ceil(cpu))))
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -26,6 +26,7 @@ from toil.batchSystems.parasol import ParasolBatchSystem
 from toil.batchSystems.gridengine import GridengineBatchSystem
 from toil.batchSystems.singleMachine import SingleMachineBatchSystem
 from toil.batchSystems.lsf import LSFBatchSystem
+from toil.batchSystems.slurm import SlurmBatchSystem
 
 logger = logging.getLogger( __name__ )
 
@@ -372,6 +373,9 @@ def loadBatchSystemClass(config):
     elif batchSystemName == 'lsf' or batchSystemName == 'LSF':
         batchSystemClass = LSFBatchSystem
         logger.info('Using the lsf batch system')
+    elif batchSystemName == 'slurm' or batchSystemName == 'Slurm':
+        batchSystemClass = SlurmBatchSystem
+        logger.info('Using the SLURM batch system')
     elif batchSystemName == 'mesos' or batchSystemName == 'Mesos':
         from toil.batchSystems.mesos.batchSystem import MesosBatchSystem
         batchSystemClass = MesosBatchSystem

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -219,6 +219,22 @@ def needs_parasol(test_item):
         return test_item
 
 
+def needs_slurm(test_item):
+    """
+    Use as a decorator before test classes or methods to only run them if Slurm is installed.
+    """
+    test_item = _mark_test('slurm', test_item)
+    try:
+        with open(os.devnull, 'r+') as devnull:
+            subprocess.Popen('squeue', stdout=devnull, stderr=devnull, stdin=devnull)
+    except OSError:
+        return unittest.skip("Skipping test. Install Slurm to include this test.")(test_item)
+    except:
+        raise
+    else:
+        return test_item
+
+
 def needs_encryption(test_item):
     """
     Use as a decorator before test classes or methods to only run them if PyNaCl is installed

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -34,7 +34,7 @@ from toil.batchSystems.parasol import ParasolBatchSystem
 from toil.batchSystems.singleMachine import SingleMachineBatchSystem
 from toil.batchSystems.abstractBatchSystem import InsufficientSystemResources
 from toil.job import Job
-from toil.test import ToilTest, needs_mesos, needs_parasol, needs_gridengine
+from toil.test import ToilTest, needs_mesos, needs_parasol, needs_gridengine, needs_slurm
 
 log = logging.getLogger(__name__)
 
@@ -464,6 +464,29 @@ class GridEngineBatchSystemTest(hidden.AbstractBatchSystemTest):
     @classmethod
     def setUpClass(cls):
         super(GridEngineBatchSystemTest, cls).setUpClass()
+        logging.basicConfig(level=logging.DEBUG)
+
+
+@needs_slurm
+class SlurmBatchSystemTest(hidden.AbstractBatchSystemTest):
+    """
+    Tests against the Slurm batch system
+    """
+
+    def _createDummyConfig(self):
+        config = super(SlurmBatchSystemTest, self)._createDummyConfig()
+        # can't use _getTestJobStorePath since that method removes the directory
+        config.jobStore = self._createTempDir('jobStore')
+        return config
+
+    def createBatchSystem(self):
+        from toil.batchSystems.slurm import SlurmBatchSystem
+        return SlurmBatchSystem(config=self.config, maxCores=numCores, maxMemory=1000e9,
+                                maxDisk=1e9)
+
+    @classmethod
+    def setUpClass(cls):
+        super(SlurmBatchSystemTest, cls).setUpClass()
         logging.basicConfig(level=logging.DEBUG)
 
 


### PR DESCRIPTION
Resolves #682 

This change implements a batchSystem that talks to a slurm scheduler. It is modeled after the SGE batch system, and uses subprocess calls for `sbatch`, `sinfo`, `sacct`, and `squeue`.

So far I've only tested on simple jobs, but results are promising. I'd like to use this to run CWL workflows, but am encountering issues with cross-device linking on file staging and gathering.