### PR TITLE
Use ephemeral for running Toil tests on Jenkins (resolves #704)

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,4 +10,5 @@ pip2.7 install sphinx
 make develop extras=[aws,mesos,azure,encryption,cwl]
 export LIBPROCESS_IP=127.0.0.1
 export PYTEST_ADDOPTS="--junitxml=test-report.xml"
+mkdir /mnt/ephemeral/tmp && export TMPDIR=/mnt/ephemeral/temp
 make $make_targets


### PR DESCRIPTION
resolves #704

The test framework uses the system TMPDIR to create temp working directories for running toil tests. If we
set it to a directory on /mnt/ephemeral while running tests on jenkins, then the tests can run in a larger volume
allowing for tests to use more space if need be.