### PR TITLE
Implement dynamic mesos disk estimation (resolves #681)

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -29,12 +29,12 @@ bash -ex <<-"END"
                 sudo umount /dev/loop0
             fi
         fi
-        rm -rf /mnt/ephemeral/tmp*
+        rm -rf /mnt/ephemeral/tmp /mnt/ephemeral/tmp.img
     }
 
     # We place the workdir into a loopback file system to isolate it from the rest of the system.
     # The size of the loopback device is large enough to run tests that don't specify a value for
-    # disk in jobs (default=2G)
+    # disk in jobs (The default disk request it 2GB -- the device set to 10GB)
     cleanup
     dd if=/dev/zero of=/mnt/ephemeral/tmp.img bs=1M count=10240
     mkfs.ext4 -F -E root_owner=$UID:$UID /mnt/ephemeral/tmp.img

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,7 +10,41 @@ pip2.7 install sphinx
 make develop extras=[aws,mesos,azure,encryption,cwl]
 export LIBPROCESS_IP=127.0.0.1
 export PYTEST_ADDOPTS="--junitxml=test-report.xml"
-rm -rf /mnt/ephemeral/tmp
-mkdir /mnt/ephemeral/tmp && export TMPDIR=/mnt/ephemeral/tmp
-make $make_targets
-rm -rf /mnt/ephemeral/tmp
+export make_targets
+
+bash -ex <<-"END"
+    # If there is an output directory, delete it.  Furthermore, if the directory is a mountpoint
+    # then it must be on the loopback filesystem and needs to be unmounted.  Lastly, delete the
+    # image used for the loopback system.
+    cleanup() {
+        trap - EXIT
+        # Delete the temp dir
+        if [ -d /mnt/ephemeral/tmp ]
+        then
+            if mountpoint -q /mnt/ephemeral/tmp
+            then
+                # If there are processes still interacting with the device, kill them before
+                # unmounting
+                lsof +D /mnt/ephemeral/tmp -t | xargs -r -n1 kill
+                sudo umount /dev/loop0
+            fi
+        fi
+        rm -rf /mnt/ephemeral/tmp*
+    }
+
+    # We place the workdir into a loopback file system to isolate it from the rest of the system.
+    # The size of the loopback device is large enough to run tests that don't specify a value for
+    # disk in jobs (default=2G)
+    cleanup
+    dd if=/dev/zero of=/mnt/ephemeral/tmp.img bs=1M count=10240
+    mkfs.ext4 -F -E root_owner=$UID:$UID /mnt/ephemeral/tmp.img
+    mkdir /mnt/ephemeral/tmp && sudo mount -o loop /mnt/ephemeral/tmp.img /mnt/ephemeral/tmp
+
+    # Run cleanup on exit, and any SIGINT (used if a jenkins build is aborted by the user or by
+    # jenkins if the build times out).  SIGKILL and SIGTERM might be overkill but hey, better safe
+    # than sorry.
+    trap cleanup EXIT
+
+    export TMPDIR=/mnt/ephemeral/tmp
+    make $make_targets
+END

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -191,7 +191,7 @@ class AbstractBatchSystem:
         '''
         allWorkflowDirs = Toil.getAllWorkflowDirs(workflowID, workDir)
         toilDiskUsed = sum([cls.getWorkflowDirSize(wFD) for wFD in allWorkflowDirs])
-        diskStats = os.statvfs(workflowDir)
+        diskStats = os.statvfs(allWorkflowDirs[0])
         # Total Disk used = block size * (total blocks - free blocks)
         diskUsed = diskStats.f_frsize * (diskStats.f_blocks - diskStats.f_bavail)
         # Disk used for non-toil purposes = Total disk used - Disk used by toil (workDir)

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -19,6 +19,10 @@ from toil.common import Toil
 import os
 import shutil
 
+# This constant is set to the default value used on unix for block size (in bytes) when
+# os.stat(<file>).st_blocks is called.
+unixBlockSize = 512
+
 # A class containing the information required for worker cleanup on shutdown of the batch system.
 WorkerCleanupInfo = namedtuple('WorkerCleanupInfo', (
     # A path to the value of config.workDir (where the cache would go)
@@ -174,6 +178,85 @@ class AbstractBatchSystem:
         cleanWorkDir = workerCleanupInfo.cleanWorkDir
         if cleanWorkDir == 'always' or dirIsEmpty and cleanWorkDir in ('onSuccess', 'onError'):
             shutil.rmtree(workflowDir)
+
+    @classmethod
+    def probeUsedDisk(cls, workflowID, workDir=None, **kwargs):
+        '''
+        Used to probe the used disk space (on the block device mounting workDir) minus the space
+        used by Toil. Subtracting this from the total disk size gives the batchsystem an estimate of
+        how much space is available for Toil. On Mesos, this can be reserved for a non-Toil role.
+
+        :param str workflowID: Unique ID for this workflow
+        :param str workDir: value for --workDir passed by the user.
+        :param dict **kwargs: Buffer to handle the other objects in the workerCleanupInfo construct
+        :return: Amount of disk used by non-Toil purposes
+        '''
+        workflowDir = Toil.getWorkflowDir(workflowID, workDir)
+        toilDiskUsed = cls.getWorkflowDirSize(workflowDir)
+        diskStats = os.statvfs(workflowDir)
+        # Total Disk used = block size * (total blocks - free blocks)
+        diskUsed = diskStats.f_frsize * (diskStats.f_blocks - diskStats.f_bavail)
+        # Disk used for non-toil purposes = Total disk used - Disk used by toil (workDir)
+        nonToilDiskUsed = diskUsed - toilDiskUsed
+        return nonToilDiskUsed
+
+    @classmethod
+    def getWorkflowDirSize(cls, workflowDir):
+        '''
+        This method will walk through the workflow directory and return the cumulative filesize in
+        bytes of all the files in the directory and its subdirectories.
+
+        :param workflowDir: path to the workflow working directory
+        :return: cumulative size in bytes of all files in the directory
+        '''
+        totalSize = 0
+        # The value from running stat on each linked file is equal. To prevent the same file
+        # from being counted multiple times, we save the inodes of files that have more than one
+        # nlink associated with them.
+        linkedFileInodes = set()
+        for dirPath, dirNames, fileNames in os.walk(workflowDir):
+            folderSize = cls._getDirSize(dirPath, fileNames, linkedFileInodes)
+            totalSize += folderSize
+        return totalSize
+
+    @staticmethod
+    def _getDirSize(dirPath, fileNames, linkedFileInodes):
+        '''
+        Returns the size of the directory including all linked files provided their inode was not in
+        linkedFileInodes.
+
+        :param str dirPath: Dir path
+        :param list fileNames: Files in the directory
+        :param set linkedFileInodes: set of inode numbers of files that have multiple links, and
+                                     have already been acccounted for.
+        :return: Size of the directory
+        '''
+        folderSize = 0
+        for f in fileNames:
+            fp = os.path.join(dirPath, f)
+            fileStats = os.stat(fp)
+            if fileStats.st_nlink > 1:
+                if fileStats.st_ino not in linkedFileInodes:
+                    folderSize += fileStats.st_blocks * unixBlockSize
+                    linkedFileInodes.add(fileStats.st_ino)
+                else:
+                    continue
+            else:
+                folderSize += fileStats.st_size
+        return folderSize
+
+    @staticmethod
+    def getFileSystemSize(workflowID, workDir=None, **kwargs):
+        '''
+        Returns the size of the block device containing the workflow directory, in bytes.
+
+        :param str workflowID: Unique ID for this workflow
+        :param str workDir: value for --workDir passed by the user.
+        :param dict **kwargs: Buffer to handle the other objects in the workerCleanupInfo construct
+        :return: size of the file system
+        '''
+        diskStats = os.statvfs(Toil.getWorkflowDir(workflowID, workDir))
+        return diskStats.f_frsize * diskStats.f_blocks
 
 
 class InsufficientSystemResources(Exception):

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -19,8 +19,7 @@ from toil.common import Toil
 import os
 import shutil
 
-# This constant is set to the default value used on unix for block size (in bytes) when
-# os.stat(<file>).st_blocks is called.
+# The unit of os.stat().st_blocks according to the documentation of os.stat
 unixBlockSize = 512
 
 # A class containing the information required for worker cleanup on shutdown of the batch system.

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -170,8 +170,7 @@ class AbstractBatchSystem:
         :param collections.namedtuple workerCleanupInfo: A named tuple consisting of all the
         relevant information for cleaning up the worker.
         """
-        # FIXME: not the correct way to check for a type (Hannes)
-        assert workerCleanupInfo.__class__.__name__ == 'WorkerCleanupInfo'
+        assert isinstance(workerCleanupInfo, WorkerCleanupInfo)
         workflowDir = Toil.getWorkflowDir(workerCleanupInfo.workflowID, workerCleanupInfo.workDir)
         dirIsEmpty = os.listdir(workflowDir) == []
         cleanWorkDir = workerCleanupInfo.cleanWorkDir
@@ -190,8 +189,8 @@ class AbstractBatchSystem:
         :param dict **kwargs: Buffer to handle the other objects in the workerCleanupInfo construct
         :return: Amount of disk used by non-Toil purposes
         '''
-        workflowDir = Toil.getWorkflowDir(workflowID, workDir)
-        toilDiskUsed = cls.getWorkflowDirSize(workflowDir)
+        allWorkflowDirs = Toil.getAllWorkflowDirs(workflowID, workDir)
+        toilDiskUsed = sum([cls.getWorkflowDirSize(wFD) for wFD in allWorkflowDirs])
         diskStats = os.statvfs(workflowDir)
         # Total Disk used = block size * (total blocks - free blocks)
         diskUsed = diskStats.f_frsize * (diskStats.f_blocks - diskStats.f_bavail)

--- a/src/toil/batchSystems/mesos/__init__.py
+++ b/src/toil/batchSystems/mesos/__init__.py
@@ -44,4 +44,8 @@ ToilJob = namedtuple('ToilJob', (
     # A dictionary with additional environment variables to be set on the worker process
     'environment',
     # A named tuple containing all the required info for cleaning up the worker node
-    'workerCleanupInfo'))
+    'workerCleanupInfo',
+    # A string containing the resolved Mesos master address
+    'masterAddress',
+    # A path to the credentials file used when the Mesos master was set up
+    'mesosCredentials'))

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -58,7 +58,7 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
         self.userScript = userScript
         self.toilDistribution = toilDistribution
 
-        # Written to when mesos kills tasks, as directed by toil
+        # Written to when Mesos kills tasks, as directed by toil
         self.killedSet = set()
 
         # Dictionary of queues, which toil assigns jobs to. Each queue represents a job type,
@@ -67,6 +67,9 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
 
         # Address of Mesos master in the form host:port where host can be an IP or a hostname
         self.masterAddress = masterAddress
+
+        # Path to the Mesos credentials file
+        self.mesosCredentials = config.mesosCredentials
 
         # queue of jobs to kill, by jobID.
         self.killSet = set()
@@ -117,7 +120,9 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
                       userScript=self.userScript,
                       toilDistribution=self.toilDistribution,
                       environment=self.environment.copy(),
-                      workerCleanupInfo=self.workerCleanupInfo)
+                      workerCleanupInfo=self.workerCleanupInfo,
+                      masterAddress=self.resolveAddress(self.masterAddress),
+                      mesosCredentials=self.mesosCredentials)
         job_type = job.resources
 
         log.debug("Queueing the job command: %s with job id: %s ..." % (command, str(jobID)))
@@ -429,7 +434,7 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
         if toMiB(jt_job.resources.disk) > 1:
             disk.scalar.value = toMiB(jt_job.resources.disk)
         else:
-            log.warning("Job %s uses less disk than mesos requires. Rounding %s up to one MiB",
+            log.warning("Job %s uses less disk than Mesos requires. Rounding %s up to one MiB",
                         jt_job.jobID, jt_job.resources.disk)
             disk.scalar.value = 1
         mem = task.resources.add()
@@ -438,7 +443,7 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
         if toMiB(jt_job.resources.memory) > 1:
             mem.scalar.value = toMiB(jt_job.resources.memory)
         else:
-            log.warning("Job %s uses less memory than mesos requires. Rounding %s up to one MiB",
+            log.warning("Job %s uses less Memory than mesos requires. Rounding %s up to one MiB",
                         jt_job.jobID, jt_job.resources.memory)
             mem.scalar.value = 1
         return task

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -443,7 +443,7 @@ class MesosBatchSystem(AbstractBatchSystem, mesos.interface.Scheduler):
         if toMiB(jt_job.resources.memory) > 1:
             mem.scalar.value = toMiB(jt_job.resources.memory)
         else:
-            log.warning("Job %s uses less Memory than mesos requires. Rounding %s up to one MiB",
+            log.warning("Job %s uses less memory than Mesos requires. Rounding %s up to one MiB",
                         jt_job.jobID, jt_job.resources.memory)
             mem.scalar.value = 1
         return task

--- a/src/toil/batchSystems/mesos/test/__init__.py
+++ b/src/toil/batchSystems/mesos/test/__init__.py
@@ -3,6 +3,8 @@ from abc import ABCMeta, abstractmethod
 import logging
 import shutil
 import threading
+import tempfile
+import os
 import time
 import subprocess
 import multiprocessing
@@ -17,10 +19,19 @@ class MesosTestSupport(object):
     def _startMesos(self, numCores=None):
         if numCores is None:
             numCores = multiprocessing.cpu_count()
-        shutil.rmtree('/tmp/mesos', ignore_errors=True)
-        self.master = self.MesosMasterThread(numCores)
+        self.mesosDir = tempfile.gettempdir() + '/mesos'
+        try:
+            shutil.rmtree(self.mesosDir, ignore_errors=True)
+        except OSError as err:
+            if err.errno != 2:
+                raise
+        # Setup credentials for the test on the fly
+        self.mesosCredentials = tempfile.mkstemp()[1]
+        with open(self.mesosCredentials, 'w') as cF:
+            cF.write('toil liot')
+        self.master = self.MesosMasterThread(numCores, mesosCredentials=self.mesosCredentials)
         self.master.start()
-        self.slave = self.MesosSlaveThread(numCores)
+        self.slave = self.MesosSlaveThread(numCores, mesosDir=self.mesosDir)
         self.slave.start()
         while self.master.popen is None or self.slave.popen is None:
             log.info("Waiting for master and slave processes")
@@ -31,6 +42,8 @@ class MesosTestSupport(object):
         self.slave.join()
         self.master.popen.kill()
         self.master.join()
+        shutil.rmtree(self.mesosDir, ignore_errors=True)
+        os.remove(self.mesosCredentials)
 
     class MesosThread(threading.Thread):
         __metaclass__ = ABCMeta
@@ -38,9 +51,11 @@ class MesosTestSupport(object):
         # Lock is used because subprocess is NOT thread safe: http://tinyurl.com/pkp5pgq
         lock = threading.Lock()
 
-        def __init__(self, numCores):
+        def __init__(self, numCores, mesosCredentials=None, mesosDir=None):
             threading.Thread.__init__(self)
             self.numCores = numCores
+            self.mesosCredentials = mesosCredentials
+            self.mesosDir = mesosDir
             self.popen = None
 
         @abstractmethod
@@ -53,19 +68,29 @@ class MesosTestSupport(object):
             self.popen.wait()
             log.info('Exiting %s', self.__class__.__name__)
 
+
     class MesosMasterThread(MesosThread):
         def mesosCommand(self):
             return ['mesos-master',
                     '--registry=in_memory',
                     '--ip=127.0.0.1',
                     '--port=5050',
-                    '--allocation_interval=500ms']
+                    '--allocation_interval=500ms',
+                    '--credentials=' + self.mesosCredentials]
 
     class MesosSlaveThread(MesosThread):
         def mesosCommand(self):
+            diskStats = os.statvfs(os.path.dirname(self.mesosDir))
+            totalDiskSize = round(diskStats.f_frsize * diskStats.f_bavail / 1024 / 1024.0, 2)
+            if totalDiskSize <= 5120:
+                totalDiskSize /= 2
+            else:
+                totalDiskSize -= 5120
             # NB: The --resources parameter forces this test to use a predictable number of
             # cores, independent of how many cores the system running the test actually has.
             return ['mesos-slave',
                     '--ip=127.0.0.1',
                     '--master=127.0.0.1:5050',
-                    '--resources=cpus(*):%i' % self.numCores]
+                    '--work_dir=' + self.mesosDir,
+                    '--resources=cpus(*):%i;disk(*):%s' % (self.numCores, totalDiskSize),
+                    '--executor_shutdown_grace_period=60secs']

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -650,8 +650,8 @@ class Toil(object):
         """
         workFlowDirRegexp = re.compile('^toil-[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab]'
                                        '[a-f0-9]{3}-?[a-f0-9]{12}\Z', re.I)
-        selfWorkFlowDir = cls.getWorkflowDir(workflowID, configWorkDir)
-        return [d for d in os.listdir(os.path.dirname(selfWorkFlowDir))
+        workDir = os.path.dirname(cls.getWorkflowDir(workflowID, configWorkDir))
+        return [os.path.join(workDir, d) for d in os.listdir(workDir)
                 if re.match(workFlowDirRegexp, d)]
 
     def _assertContextManagerIsUsed(self):

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -58,6 +58,7 @@ class Config(object):
         #Batch system options
         self.batchSystem = "singleMachine"
         self.scale = 1
+        self.mesosCredentials = '/etc/mesos/credentials'
         self.mesosMasterAddress = 'localhost:5050'
         self.parasolCommand = "parasol"
         self.parasolMaxBatches = 10000
@@ -149,6 +150,7 @@ class Config(object):
         #Batch system options
         setOption("batchSystem")
         setOption("scale", float, fC(0.0))
+        setOption("mesosCredentials")
         setOption("mesosMasterAddress")
         setOption("parasolCommand")
         setOption("parasolMaxBatches", int, iC(1))
@@ -240,6 +242,10 @@ def _addOptions(addGroupFn, config):
                       "Used in singleMachine batch system. default=%s" % config.scale))
     addOptionFn("--mesosMaster", dest="mesosMasterAddress", default=None,
                 help=("The host and port of the Mesos master separated by colon. default=%s" % config.mesosMasterAddress))
+    addOptionFn("--mesosCredentials", dest="mesosCredentials", default=None,
+                help=("A path to a credentials file used to authenticate Mesos HTTP requests. The "
+                      "file contains one line with \"<principal><tab><secret>\. NOTE: The file has "
+                      "to be present on the master and on ALL slaves. default=%s" % config.mesosCredentials))
     addOptionFn("--parasolCommand", dest="parasolCommand", default=None,
                       help="The name or path of the parasol program. Will be looked up on PATH "
                            "unless it starts with a slashdefault=%s" % config.parasolCommand)

--- a/src/toil/test/mesos/mesosTest.py
+++ b/src/toil/test/mesos/mesosTest.py
@@ -62,7 +62,8 @@ class MesosTest(ToilTest, MesosTestSupport):
                 '-m', helloWorld.__name__,
                 './toilTest',
                 '--batchSystem=mesos',
+                '--mesosCredentials=%s' % self.mesosCredentials,
                 '--logLevel', getLogLevelString()])
 
     def test_stress_good(self):
-        stressMain(numJobs=2)
+        stressMain(numJobs=2, mesosCreds=self.mesosCredentials)

--- a/src/toil/test/mesos/stress.py
+++ b/src/toil/test/mesos/stress.py
@@ -59,12 +59,13 @@ class HelloWorldFollowOn(Job):
     def run(self, fileStore):
         touchFile( fileStore)
 
-def main(numJobs):
+def main(numJobs, mesosCreds):
     # Boilerplate -- startToil requires options
     parser = ArgumentParser()
     Job.Runner.addToilOptions(parser)
     options = parser.parse_args( args=["./toilTest"] )
     options.batchSystem="mesos"
+    options.mesosCredentials = mesosCreds
     # Launch first toil Job
     i = LongTestJob( numJobs )
     Job.Runner.startToil(i,  options )

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -49,7 +49,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
         self.tempDir = self._createTempDir(purpose='tempDir')
 
     def _toilSort(self, jobStore, batchSystem,
-                  lines=defaultLines, N=defaultN, testNo=1, lineLen=defaultLineLen,
+                  lines=defaultLines, N=defaultN, testNo=1, lineLen=defaultLineLen, mesosCreds=None,
                   retryCount=2, badWorker=0.5, downCheckpoints=False):
         """
         Generate a file consisting of the given number of random lines, each line of the given
@@ -76,6 +76,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
                 options.logLevel = getLogLevelString()
                 options.retryCount = retryCount
                 options.batchSystem = batchSystem
+                options.mesosCredentials = mesosCreds
                 options.clean = "never"
                 options.badWorker = badWorker
                 options.badWorkerFailInterval = 0.05
@@ -161,7 +162,8 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
     def testAwsMesos(self):
         self._startMesos()
         try:
-            self._toilSort(jobStore=self._awsJobStore(), batchSystem="mesos")
+            self._toilSort(jobStore=self._awsJobStore(), batchSystem="mesos",
+                           mesosCreds=self.mesosCredentials)
         finally:
             self._stopMesos()
 
@@ -169,7 +171,8 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
     def testFileMesos(self):
         self._startMesos()
         try:
-            self._toilSort(jobStore=self._getTestJobStorePath(), batchSystem="mesos")
+            self._toilSort(jobStore=self._getTestJobStorePath(), batchSystem="mesos",
+                           mesosCreds=self.mesosCredentials)
         finally:
             self._stopMesos()
 
@@ -182,10 +185,11 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
     def testAzureMesos(self):
         self._startMesos()
         try:
-            self._toilSort(jobStore=self._azureJobStore(), batchSystem="mesos")
+            self._toilSort(jobStore=self._azureJobStore(), batchSystem="mesos",
+                           mesosCreds=self.mesosCredentials)
         finally:
             self._stopMesos()
-            
+
     def testFileSingle(self):
         self._toilSort(jobStore=self._getTestJobStorePath(), batchSystem='singleMachine')
 


### PR DESCRIPTION
resolves #681
1. Executors now probe the used disk after a job and reserve leftovers into an
   un-offered role -- `toil-leftover`,
2. The Master address is sent to executor via ToilJob (Needed to send http
   requests to master endpoints),
3. The mesos credentials are also sent to the executor via ToilJob (Needed to authenticate the http requests). Credentials are now an input to toil - by default they look at `/etc/mesos/credentials.txt`.
4. Mesos Tests place the slaves workdir in a location described by TMP, TMPDIR,
   or TEMP instead of /tmp (allows for this to be on the mounted volume).
5. Added a test `testDynamicReservation` to batchSystemsTest.py that tests reservation.