### PR TITLE
Add import/export file methods to AbstractJobStore (resolves #645, resolves #618, resolves #660)

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -489,6 +489,37 @@ Also worth noting is that there is no file system hierarchy for files in the glo
 store. These limitations allow us to fairly easily support different object stores and to 
 use caching to limit the amount of network file transfer between jobs.
 
+File Staging
+~~~~~~~~~~~~
+Files can be imported or exported from the current job store prior to running the workflow
+when the :class:`toil.common.Toil` context manager is used. The context manager has methods
+:func:`toil.common.Toil.importFile`, and :func:`toil.common.Toil.exportFile` which import
+files into and export files out of a job store respectively. The destination and source
+locations of such files are described with urls passed to the two methods a list of the
+currently supported urls can be found at :func:`toil.jobStores.abstractJobStore.AbstractJobStore.importFile`
+
+
+Example::
+
+    from toil.common import Toil
+    from toil.job import Job
+
+    class HelloWorld(Job):
+        def __init__(self, message):
+            Job.__init__(self,  memory="2G", cores=2, disk="3G")
+            self.message = message
+
+        def run(self, fileStore):
+            return "Hello, world!, here's a message: %s" % self.message
+
+    if __name__=="__main__":
+        options = Job.Runner.getDefaultOptions("./toilWorkflowRun")
+        options.logLevel = "INFO"
+        job = HelloWorld("enter the void empty and become wind")
+        with Toil(options) as toil:
+            jobStoreFileID = toil.fileStore(job).importFile('s3://somebucketname/anditskey')
+            toil.exportFile(jobStoreFileID, 'file:///some/local/path')
+            toil.run(job)
 
 Services
 --------

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ kwargs = dict(
     author_email='benedict@soe.usc.edu',
     url="https://github.com/BD2KGenomics/toil",
     install_requires=[
-        'bd2k-python-lib==1.10.dev6'],
+        'bd2k-python-lib==1.13.dev14'],
     tests_require=[
         'mock==1.0.1',
         'pytest==2.8.3'],

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from contextlib import contextmanager
 import re
 import logging
 import os
@@ -399,8 +400,8 @@ class Toil(object):
         """
         Clean up after a workflow invocaton. Depending on the configuration, delete the job store.
         """
-        if ((exc_type is not None and self.config.clean == "onError") or
-            (exc_type is None and self.config.clean == "onSuccess") or
+        if (exc_type is not None and self.config.clean == "onError" or
+            exc_type is None and self.config.clean == "onSuccess" or
             self.config.clean == "always"):
             self.jobStore.deleteJobStore()
         return False  # let exceptions through
@@ -497,7 +498,7 @@ class Toil(object):
 
         elif jobStoreName == 'aws':
             from toil.jobStores.aws.jobStore import AWSJobStore
-            return AWSJobStore.createJobStore(jobStoreArgs, config=config)
+            return AWSJobStore.loadOrCreateJobStore(jobStoreArgs, config=config)
 
         elif jobStoreName == 'azure':
             from toil.jobStores.azureJobStore import AzureJobStore
@@ -559,6 +560,14 @@ class Toil(object):
                 # TODO: toil distribution
 
         return batchSystemClass(**kwargs)
+
+    def importFile(self, srcUrl):
+        self._assertContextManagerIsUsed()
+        return self.jobStore.importFile(srcUrl)
+
+    def exportFile(self, jobStoreFileID, dstUrl):
+        self._assertContextManagerIsUsed()
+        self.jobStore.exportFile(jobStoreFileID, dstUrl)
 
     def _setBatchSystemEnvVars(self):
         """

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -725,6 +725,12 @@ class Job(object):
                 #This will result in the files removal from the cache at the end of the current job
                 self._jobStoreFileIDToCacheLocation.pop(fileStoreID)
 
+        def importFile(self, srcUrl):
+            return self.jobStore.importFile(srcUrl)
+
+        def exportFile(self, jobStoreFileID, dstUrl):
+            self.jobStore.exportFile(jobStoreFileID, dstUrl)
+
         def logToMaster(self, text, level=logging.INFO):
             """
             Send a logging message to the leader. The message will also be \

--- a/src/toil/test/src/importExportFileTest.py
+++ b/src/toil/test/src/importExportFileTest.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2015 UCSC Computational Genomics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import uuid
+
+import shutil
+
+import os
+from toil.common import Toil
+from toil.job import Job
+from toil.test import ToilTest
+import tempfile
+
+
+class ImportExportFileTest(ToilTest):
+    def setUp(self):
+        self.srcFile = "%s/%s" % (tempfile.mkdtemp(), uuid.uuid4())
+        with open(self.srcFile, 'w') as f:
+            f.write(os.urandom(2**10))
+
+    def tearDown(self):
+        shutil.rmtree(self.srcFile.rsplit('/', 1)[0])
+
+    def testImportExportFile(self):
+        options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
+        options.logLevel = "INFO"
+        job = HelloWorld()
+        with Toil(options) as toil:
+            jobStoreFileID = toil.importFile('file://%s' % self.srcFile)
+            assert toil.jobStore.fileExists(jobStoreFileID)
+
+            destPath = '%s/%s' % (self.srcFile.rsplit('/', 1)[0], uuid.uuid4())
+            toil.exportFile(jobStoreFileID, 'file://%s' % destPath)
+            assert os.path.exists(destPath)
+
+            toil.run(job)
+
+
+class HelloWorld(Job):
+    def __init__(self):
+        Job.__init__(self,  memory=100000, cores=2, disk="3G")
+
+    def run(self, fileStore):
+        fileID = self.addChildJobFn(childFn, cores=1, memory="1M", disk="1M").rv()
+        self.addFollowOn(FollowOn(fileID))
+
+
+def childFn(job):
+    with job.fileStore.writeGlobalFileStream() as (fH, fileID):
+        fH.write("Hello, World!")
+        return fileID
+
+
+class FollowOn(Job):
+    def __init__(self,fileId):
+        Job.__init__(self)
+        self.fileId=fileId
+
+    def run(self, fileStore):
+        tempDir = fileStore.getLocalTempDir()
+        tempFilePath = "/".join([tempDir,"LocalCopy"])
+        with fileStore.readGlobalFileStream(self.fileId) as globalFile:
+            with open(tempFilePath, "w") as localFile:
+                localFile.write(globalFile.read())


### PR DESCRIPTION
Every concrete jobStore now supports importing and exporting files to other jobStores. These methods are exposed to the toil user in job.py. There is also now a standalone multipart copy function for S3, and a dynamic test method generator function in toil test.