### PR TITLE
logLevel in logToMaster is not a valid parameter anymore

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -305,7 +305,7 @@ example::
     from toil.job import Job
     
     def fn(job, i):
-        job.fileStore.logToMaster("i is: %s" % i, logLevel=100)
+        job.fileStore.logToMaster("i is: %s" % i, level=100)
         return i+1
         
     j1 = Job.wrapJobFn(fn, 1)


### PR DESCRIPTION
The [promises documentation example](http://toil.readthedocs.org/en/releases-3.1.x/tutorial.html#promises) raises the following error when tested:

```
2016-03-11 17:44:37,186 WARNING:toil.leader: o/u/job3P9XQk:       File "promises_test.py", line 6, in fn
2016-03-11 17:44:37,186 WARNING:toil.leader: o/u/job3P9XQk:         job.fileStore.logToMaster("i is: %s" % i, logLevel=100)
2016-03-11 17:44:37,186 WARNING:toil.leader: o/u/job3P9XQk:     TypeError: logToMaster() got an unexpected keyword argument 'logLevel'
```