### PR TITLE
Refactored setupToil and other methods into common.Toil class (resolves #619, resolves #749)

### DIFF
--- a/docs/toilAPI.rst
+++ b/docs/toilAPI.rst
@@ -22,6 +22,13 @@ The Runner contains the methods needed to configure and start a Toil run.
 .. autoclass:: toil.job::Job.Runner
    :members:
    
+Toil
+----
+The Toil class provides for a more general way to configure and start a Toil run.
+
+.. autoclass:: toil.common::Toil
+   :members:
+
 Job.Service
 -----------
 The Service class allows databases and servers to be spawned within a Toil workflow.
@@ -66,8 +73,4 @@ Toil specific exceptions.
    :members:  
    
 .. autoclass:: toil.job::JobGraphDeadlockException
-   :members: 
-   
-
-
-   
+   :members:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -31,19 +31,16 @@ The :func:`toil.job.Job.run` method is the function the user overrides to get wo
 Here it just logs a message using :func:`toil.job.Job.FileStore.logToMaster`, which
 will be registered in the log output of the leader process of the workflow.
 
-Job.Runner
-----------
-
 Invoking a workflow
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
-We can add to the previous example to turn it into a complete workflow by adding the necessary function calls 
-to create an instance of HelloWorld and to run this as a workflow containing a single job.
-This uses the :class:`toil.job.Job.Runner` class, which is used to start and resume Toil workflows. 
-For example::
+We can add to the previous example to turn it into a complete workflow by adding the necessary
+function calls to create an instance of HelloWorld and to run this as a workflow containing a
+single job. This uses the :class:`toil.job.Job.Runner` class, which is used to start and resume
+Toil workflows. For example::
 
     from toil.job import Job
-    
+
     class HelloWorld(Job):
         def __init__(self, message):
             Job.__init__(self,  memory="2G", cores=2, disk="3G")
@@ -52,11 +49,39 @@ For example::
         def run(self, fileStore):
             fileStore.logToMaster("Hello, world!, I have a message: %s" 
                                   % self.message)
-    
-    if __name__=="__main__":   
+
+    if __name__=="__main__":
         options = Job.Runner.getDefaultOptions("./toilWorkflowRun")
         options.logLevel = "INFO"
         Job.Runner.startToil(HelloWorld("woot"), options)
+
+
+Alternatively, the more powerful :class:`toil.common.Toil` class can be used to run and resume
+workflows. It is used as a context manager and allows for preliminary setup, such as staging of
+files into the job store on the leader node. An instance of the class is initialized by specifying
+an options object. The actual workflow is then invoked by calling the :func:`toil.common.Toil.run`
+method, passing the root job of the workflow, or, if a workflow is being restarted, without any
+arguments. For example::
+
+    from toil.job import Job
+    from toil.common import Toil
+
+    class HelloWorld(Job):
+        def __init__(self, message):
+            Job.__init__(self,  memory="2G", cores=2, disk="3G")
+            self.message = message
+
+        def run(self, fileStore):
+            fileStore.logToMaster("Hello, world!, I have a message: %s"
+                                  % self.message)
+    if __name__=="__main__":
+        options = Job.Runner.getDefaultOptions("./toilWorkflowRun")
+        options.logLevel = "INFO"
+
+        with Toil(options) as toil:
+            job = HelloWorld("Smitty Werbenmanjensen, he was #1")
+            toil.run(job)
+
     
 The call to :func:`toil.job.Job.Runner.getDefaultOptions` creates a set of default
 options for the workflow. The only argument is a description of how to store the workflow's
@@ -73,7 +98,7 @@ runs it as a workflow. Note all Toil workflows start from a single starting job,
 the *root* job.
 
 Specifying arguments via the command line
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------
 
 To allow command line control of the options we can use the :func:`toil.job.Job.Runner.getDefaultArgumentParser` 
 method to create a :class:`argparse.ArgumentParser` object which can be used to 
@@ -104,7 +129,7 @@ Alternatively an existing :class:`argparse.ArgumentParser` or
 added to it with the :func:`toil.job.Job.Runner.addToilOptions` method.
 
 Resuming a workflow
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 In the event that a workflow fails, either because of programmatic error within
 the jobs being run, or because of node failure, the workflow can be resumed. Workflows
@@ -463,7 +488,8 @@ to update an existing "global" file, meaning that files are, barring deletion, i
 Also worth noting is that there is no file system hierarchy for files in the global file 
 store. These limitations allow us to fairly easily support different object stores and to 
 use caching to limit the amount of network file transfer between jobs.
-        
+
+
 Services
 --------
 

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 from collections import namedtuple
-from toil.common import getToilWorkflowDir
+from toil.common import Toil
 import os
 import shutil
 
@@ -167,11 +167,12 @@ class AbstractBatchSystem:
         :param collections.namedtuple workerCleanupInfo: A named tuple consisting of all the
         relevant information for cleaning up the worker.
         """
+        # FIXME: not the correct way to check for a type (Hannes)
         assert workerCleanupInfo.__class__.__name__ == 'WorkerCleanupInfo'
-        workflowDir = getToilWorkflowDir(workerCleanupInfo.workflowID, workerCleanupInfo.workDir)
+        workflowDir = Toil.getWorkflowDir(workerCleanupInfo.workflowID, workerCleanupInfo.workDir)
         dirIsEmpty = os.listdir(workflowDir) == []
         cleanWorkDir = workerCleanupInfo.cleanWorkDir
-        if cleanWorkDir == 'always' or ((cleanWorkDir == 'onSuccess' or cleanWorkDir == 'onError') and dirIsEmpty):
+        if cleanWorkDir == 'always' or dirIsEmpty and cleanWorkDir in ('onSuccess', 'onError'):
             shutil.rmtree(workflowDir)
 
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from contextlib import contextmanager
+import re
 import logging
 import os
 import sys
@@ -22,10 +22,12 @@ import time
 import tempfile
 from argparse import ArgumentParser
 from bd2k.util.humanize import bytes2human
+from toil.leader import mainLoop
 
 from toil.lib.bioio import addLoggingOptions, getLogLevelString
+from toil.realtimeLogger import RealtimeLogger
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
 
 
 class Config(object):
@@ -178,6 +180,7 @@ class Config(object):
         #Debug options
         setOption("badWorker", float, fC(0.0, 1.0))
         setOption("badWorkerFailInterval", float, fC(0.0))
+
 
 def _addOptions(addGroupFn, config):
     #
@@ -353,152 +356,292 @@ def addOptions(parser, config=Config()):
         raise RuntimeError("Unanticipated class passed to addOptions(), %s. Expecting "
                            "argparse.ArgumentParser" % parser.__class__)
 
-def loadBatchSystem(config):
-    """
-    Load the configured batch system class, instantiate it and return the instance.
-    """
-    batchSystemClass, kwargs = loadBatchSystemClass(config)
-    return createBatchSystem(config, batchSystemClass, kwargs)
 
-def loadBatchSystemClass(config):
+class Toil(object):
     """
-    Returns a pair containing the concrete batch system class and a dictionary of keyword arguments to be passed to
-    the constructor of that class.
-
-    :param config: the current configuration
-    :param key: the name of the configuration attribute that holds the configured batch system name
+    A context manager that represents a Toil workflow, specifically the batch system, job store,
+    and its configuration.
     """
-    from toil.batchSystems.parasol import ParasolBatchSystem
-    from toil.batchSystems.gridengine import GridengineBatchSystem
-    from toil.batchSystems.singleMachine import SingleMachineBatchSystem
-    from toil.batchSystems.lsf import LSFBatchSystem
-    batchSystemName = config.batchSystem
-    kwargs = dict(config=config,
-                  maxCores=config.maxCores,
-                  maxMemory=config.maxMemory,
-                  maxDisk=config.maxDisk)
-    if batchSystemName == 'parasol':
-        batchSystemClass = ParasolBatchSystem
-        logger.info('Using the parasol batch system')
-    elif batchSystemName == 'single_machine' or batchSystemName == 'singleMachine':
-        batchSystemClass = SingleMachineBatchSystem
-        logger.info('Using the single machine batch system')
-    elif batchSystemName == 'gridengine' or batchSystemName == 'gridEngine':
-        batchSystemClass = GridengineBatchSystem
-        logger.info('Using the grid engine machine batch system')
-    elif batchSystemName == 'lsf' or batchSystemName == 'LSF':
-        batchSystemClass = LSFBatchSystem
-        logger.info('Using the lsf batch system')
-    elif batchSystemName == 'mesos' or batchSystemName == 'Mesos':
-        from toil.batchSystems.mesos.batchSystem import MesosBatchSystem
-        batchSystemClass = MesosBatchSystem
-        kwargs['masterAddress'] = config.mesosMasterAddress
-        logger.info('Using the mesos batch system')
-    else:
-        raise RuntimeError('Unrecognised batch system: %s' % batchSystemName)
-    return batchSystemClass, kwargs
 
-def createBatchSystem(config, batchSystemClass, kwargs):
+    def __init__(self, options):
+        """
+        Initialize a Toil object from the given options. Note that this is very light-weight and
+        that the bulk of the work is done when the context is entered.
+
+        :param argparse.Namespace options: command line options specified by the user
+        """
+        super(Toil, self).__init__()
+        self.options = options
+        self.config = None
+        self.jobStore = None
+        self.batchSystem = None
+        self.jobCache = dict()
+
+    def __enter__(self):
+        """
+        Derive configuration from the command line options, load the job store and, on restart,
+        consolidate the derived configuration with the one from the previous invocation of the
+        workflow.
+        """
+        self.config = Config()
+        self.config.setOptions(self.options)
+        self.jobStore = self.loadOrCreateJobStore(self.config.jobStore,
+                                                  config=None if self.config.restart else self.config)
+        if self.config.restart:
+            # Reload configuration from job store
+            self.config = self.jobStore.config
+            self.config.setOptions(self.options)
+            self.jobStore.writeConfigToStore()
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Clean up after a workflow invocaton. Depending on the configuration, delete the job store.
+        """
+        if ((exc_type is not None and self.config.clean == "onError") or
+            (exc_type is None and self.config.clean == "onSuccess") or
+            self.config.clean == "always"):
+            self.jobStore.deleteJobStore()
+        return False  # let exceptions through
+
+    def run(self, job=None):
+        """
+        Invoke a Toil workflow with the given job as the root. The job argument may be omitted if
+        the invocaton is a restart in which case the previous invocation's root job will be used.
+        This method must be called in the body of a ``with Toil(...):`` statement.
+
+        :param toil.job.Job job: The root job for the workflow
+        :return: The return value of the root job
+        :rtype: Any
+        """
+        self._assertContextManagerIsUsed()
+
+        userScript = None if job is None else job.getUserScript()
+        self.batchSystem = self.createBatchSystem(self.config,
+                                                  jobStore=self.jobStore,
+                                                  userScript=userScript)
+
+        realtimeLogLevel = self.options.logLevel if self.options.realTimeLogging else None
+        with RealtimeLogger(self.batchSystem, level=realtimeLogLevel):
+            try:
+                self._setBatchSystemEnvVars()
+                self._serialiseEnvironment()
+
+                logger.info('Caching all jobs in job store')
+                self._cacheJobs()
+                logger.info('{} jobs downloaded.'.format(len(self.jobCache)))
+
+                if job is not None:
+                    if self.config.restart:
+                        raise ToilConfigException('Cannot override root job on restart')
+
+                    # Make a file to store the root job's return value in
+                    jobStoreFileID = self.jobStore.getEmptyFileStoreID()
+
+                    # Add the root job return value as a promise
+                    if None not in job._rvs:
+                        job._rvs[None] = []
+                    job._rvs[None].append(jobStoreFileID)
+
+                    # Write the name of the promise file in a shared file
+                    with self.jobStore.writeSharedFileStream("rootJobReturnValue") as fH:
+                        fH.write(jobStoreFileID)
+
+                    # Setup the first wrapper and cache it
+                    rootJob = job._serialiseFirstJob(self.jobStore)
+                    self._cacheJob(rootJob)
+
+                else:  # restarting
+                    if not self.config.restart:
+                        raise ToilConfigException('Need root job on first invocation')
+
+                    # This cleans up any half written jobs after a restart
+                    rootJob = self.jobStore.clean(jobCache=self.jobCache)
+
+                return mainLoop(self.config, self.batchSystem, self.jobStore, rootJob, jobCache=self.jobCache)
+
+            finally:
+                startTime = time.time()
+                logger.debug('Shutting down batch system')
+                self.batchSystem.shutdown()
+                logger.debug('Finished shutting down the batch system in %s seconds.' % (time.time() - startTime))
+
+
+    @staticmethod
+    def loadOrCreateJobStore(jobStoreString, config=None):
+        """
+        Loads an existing jobStore if it already exists. Otherwise a new instance of a jobStore is
+        created and returned.
+
+        :param str jobStoreString: see exception message below
+        :param toil.common.Config config: see AbstractJobStore.__init__
+        :return: an instance of a concrete subclass of AbstractJobStore
+        :rtype: jobStores.abstractJobStore.AbstractJobStore
+        """
+        if jobStoreString[0] in '/.':
+            jobStoreString = 'file:' + jobStoreString
+
+        try:
+            jobStoreName, jobStoreArgs = jobStoreString.split(':', 1)
+        except ValueError:
+            raise RuntimeError(
+                'Job store string must either be a path starting in . or / or a contain at least one '
+                'colon separating the name of the job store implementation from an initialization '
+                'string specific to that job store. If a path starting in . or / is passed, the file '
+                'job store will be used for backwards compatibility.' )
+
+        if jobStoreName == 'file':
+            from toil.jobStores.fileJobStore import FileJobStore
+            return FileJobStore(jobStoreArgs, config=config)
+
+        elif jobStoreName == 'aws':
+            from toil.jobStores.aws.jobStore import AWSJobStore
+            return AWSJobStore.createJobStore(jobStoreArgs, config=config)
+
+        elif jobStoreName == 'azure':
+            from toil.jobStores.azureJobStore import AzureJobStore
+            account, namePrefix = jobStoreArgs.split(':', 1)
+            return AzureJobStore(account, namePrefix, config=config)
+
+        else:
+            raise RuntimeError("Unknown job store implementation '%s'" % jobStoreName)
+
+    @staticmethod
+    def createBatchSystem(config, jobStore=None, userScript=None):
+        """
+        Creates an instance of the batch system specified in the given config. If a job store and a user
+        script are given then the user script can be hot deployed into the workflow.
+
+        :param toil.common.Config config: the current configuration
+        :param jobStores.abstractJobStore.AbstractJobStore jobStore: an instance of a jobStore
+        :param ModuleDescriptor userScript: a user supplied script to use for hot development
+        :return: an instance of a concrete subclass of AbstractBatchSystem
+        :rtype: batchSystems.abstractBatchSystem.AbstractBatchSystem
+        """
+        kwargs = dict(config=config,
+                      maxCores=config.maxCores,
+                      maxMemory=config.maxMemory,
+                      maxDisk=config.maxDisk)
+
+        if config.batchSystem == 'parasol':
+            from toil.batchSystems.parasol import ParasolBatchSystem
+            batchSystemClass = ParasolBatchSystem
+
+        elif config.batchSystem == 'single_machine' or config.batchSystem == 'singleMachine':
+            from toil.batchSystems.singleMachine import SingleMachineBatchSystem
+            batchSystemClass = SingleMachineBatchSystem
+
+        elif config.batchSystem == 'gridengine' or config.batchSystem == 'gridEngine':
+            from toil.batchSystems.gridengine import GridengineBatchSystem
+            batchSystemClass = GridengineBatchSystem
+
+        elif config.batchSystem == 'lsf' or config.batchSystem == 'LSF':
+            from toil.batchSystems.lsf import LSFBatchSystem
+            batchSystemClass = LSFBatchSystem
+
+        elif config.batchSystem == 'mesos' or config.batchSystem == 'Mesos':
+            from toil.batchSystems.mesos.batchSystem import MesosBatchSystem
+            batchSystemClass = MesosBatchSystem
+
+            kwargs['masterAddress'] = config.mesosMasterAddress
+
+        else:
+            raise RuntimeError('Unrecognised batch system: %s' % config.batchSystem)
+
+        logger.info('Using the %s' %
+                    re.sub("([a-z])([A-Z])", "\g<1> \g<2>", batchSystemClass.__name__).lower())
+
+        if jobStore is not None and userScript is not None:
+            hotDeployUserScript = (not userScript.belongsToToil and batchSystemClass.supportsHotDeployment())
+            if hotDeployUserScript:
+                kwargs['userScript'] = userScript.saveAsResourceTo(jobStore)
+                # TODO: toil distribution
+
+        return batchSystemClass(**kwargs)
+
+    def _setBatchSystemEnvVars(self):
+        """
+        Sets the environment variables required by the job store and those passed on command line.
+        """
+        for envDict in (self.jobStore.getEnv(), self.config.environment):
+            for k, v in envDict.iteritems():
+                self.batchSystem.setEnv(k, v)
+
+    def _serialiseEnvironment(self):
+        """
+        Puts the environment in a globally accessible pickle file.
+        """
+        # Dump out the environment of this process in the environment pickle file.
+        with self.jobStore.writeSharedFileStream("environment.pickle") as fileHandle:
+            cPickle.dump(os.environ, fileHandle, cPickle.HIGHEST_PROTOCOL)
+        logger.info("Written the environment for the jobs to the environment file")
+
+    def _cacheJobs(self):
+        """
+        Downloads all jobs in the current job store into self.jobCache.
+        """
+        self.jobCache = {jobWrapper.jobStoreID: jobWrapper for jobWrapper in self.jobStore.jobs()}
+
+    def _cacheJob(self, job):
+        """
+        Adds given job to curent jobCache.
+
+        :param toil.jobWrapper.JobWrapper job: job to be added to current job cache
+        """
+        self.jobCache[job.jobStoreID] = job
+
+    @staticmethod
+    def getWorkflowDir(workflowID, configWorkDir=None):
+        """
+        Returns a path to the directory where worker directories and the cache will be located for this
+        workflow.
+
+        :param str workflowID: Unique identifier for the workflow
+        :param str configWorkDir: Value passed to the program using the --workDir flag
+        :return: Path to the workflow directory
+        :rtype: str
+        """
+        workDir = configWorkDir or os.getenv('TOIL_WORKDIR') or tempfile.gettempdir()
+        if not os.path.exists(workDir):
+            raise RuntimeError("The directory specified by --workDir or TOIL_WORKDIR (%s) does not "
+                               "exist." % workDir)
+        # Create the workflow dir
+        workflowDir = os.path.join(workDir, 'toil-%s' % workflowID)
+        try:
+            # Directory creation is atomic
+            os.mkdir(workflowDir)
+        except OSError as err:
+            if err.errno != 17:
+                # The directory exists if a previous worker set it up.
+                raise
+        else:
+            logger.info('Created the workflow directory at %s' % workflowDir)
+        return workflowDir
+
+    def _assertContextManagerIsUsed(self):
+        # Assert that we are inside the context manager
+        if self.jobStore is None:
+            # __enter__() sets self.jobStore
+            raise ToilContextManagerMisuseException("Toil class cannot be instantiated outside of a context manager")
+
+
+class ToilConfigException(Exception):
     """
-    Returns an instance of the given batch system class, or if a big batch system is configured, a batch system
-    instance that combines the given class with the configured big batch system.
-
-    :param config: the current configuration
-    :param batchSystemClass: the class to be instantiated
-    :param kwargs: a list of keyword arguments to be passed to the given class' constructor
+    Misconfigured toil workflow exception
     """
-    batchSystem = batchSystemClass(**kwargs)
-    return batchSystem
 
-def loadJobStore( jobStoreString, config=None ):
+    def __init__(self, message):
+        super(ToilConfigException, self).__init__(message)
+
+
+class ToilContextManagerMisuseException(Exception):
     """
-    Loads a jobStore.
-
-    :param jobStoreString: see exception message below
-    :param config: see AbstractJobStore.__init__
-    :return: an instance of a concrete subclass of AbstractJobStore
-    :rtype: jobStores.abstractJobStore.AbstractJobStore
+    Toil class used without context manager exception
     """
-    if jobStoreString[ 0 ] in '/.':
-        jobStoreString = 'file:' + jobStoreString
 
-    try:
-        jobStoreName, jobStoreArgs = jobStoreString.split( ':', 1 )
-    except ValueError:
-        raise RuntimeError(
-            'Job store string must either be a path starting in . or / or a contain at least one '
-            'colon separating the name of the job store implementation from an initialization '
-            'string specific to that job store. If a path starting in . or / is passed, the file '
-            'job store will be used for backwards compatibility.' )
-
-    if jobStoreName == 'file':
-        from toil.jobStores.fileJobStore import FileJobStore
-        return FileJobStore( jobStoreArgs, config=config )
-    elif jobStoreName == 'aws':
-        from toil.jobStores.aws.jobStore import AWSJobStore
-        return AWSJobStore.createJobStore( jobStoreArgs, config=config )
-    elif jobStoreName == 'azure':
-        from toil.jobStores.azureJobStore import AzureJobStore
-        account, namePrefix = jobStoreArgs.split( ':', 1 )
-        return AzureJobStore( account, namePrefix, config=config )
-    else:
-        raise RuntimeError( "Unknown job store implementation '%s'" % jobStoreName )
-
-def serialiseEnvironment(jobStore):
-    """
-    Puts the environment in a globally accessible pickle file.
-    """
-    #Dump out the environment of this process in the environment pickle file.
-    with jobStore.writeSharedFileStream("environment.pickle") as fileHandle:
-        cPickle.dump(os.environ, fileHandle, cPickle.HIGHEST_PROTOCOL)
-    logger.info("Written the environment for the jobs to the environment file")
-
-@contextmanager
-def setupToil(options, userScript=None):
-    """
-    Creates the data-structures needed for running a toil.
-
-    :type userScript: toil.resource.ModuleDescriptor
-    """
-    #Make the default config object
-    config = Config()
-    #Get options specified by the user
-    config.setOptions(options)
-    if not options.restart: #Create for the first time
-        batchSystemClass, kwargs = loadBatchSystemClass(config)
-        #Load the jobStore
-        jobStore = loadJobStore(config.jobStore, config=config)
-    else:
-        #Reload the workflow
-        jobStore = loadJobStore(config.jobStore)
-        config = jobStore.config
-        #Update the earlier config with any options that have been set
-        config.setOptions(options)
-        #Write these new options back to disk
-        jobStore.writeConfigToStore()
-        #Get the batch system class
-        batchSystemClass, kwargs = loadBatchSystemClass(config)
-    if (userScript is not None
-        and not userScript.belongsToToil
-        and batchSystemClass.supportsHotDeployment()):
-        kwargs['userScript'] = userScript.saveAsResourceTo(jobStore)
-        # TODO: toil distribution
-
-    batchSystem = createBatchSystem(config, batchSystemClass, kwargs)
-    try:
-        # Set environment variables required by job store
-        for k, v in jobStore.getEnv().iteritems():
-            batchSystem.setEnv(k, v)
-        # Set environment variables passed on command line
-        for k, v in config.environment.iteritems():
-            batchSystem.setEnv(k, v)
-        serialiseEnvironment(jobStore)
-        yield (config, batchSystem, jobStore)
-    finally:
-        startTime = time.time()
-        logger.debug('Shutting down batch system')
-        batchSystem.shutdown()
-        logger.debug('Finished shutting down the batch system in %s seconds.' % (time.time() - startTime))
+    def __init__(self, message):
+        super(ToilContextManagerMisuseException, self).__init__(message)
 
 # Nested functions can't have doctests so we have to make this global
 
@@ -543,31 +686,3 @@ def parseSetEnv(l):
             raise ValueError('Empty name')
         d[k] = v
     return d
-
-
-def getToilWorkflowDir(workflowID, configWorkDir=None):
-    """
-    Returns a path to the directory where worker directories and the cache will be located for this
-    workflow.
-
-    :param str workflowID: Unique identifier for the workflow
-    :param str configWorkDir: Value passed to the program using the --workDir flag
-    :return: Path to the workflow directory
-    :rtype: str
-    """
-    workDir = configWorkDir or os.getenv('TOIL_WORKDIR') or tempfile.gettempdir()
-    if not os.path.exists(workDir):
-        raise RuntimeError("The directory specified by --workDir or TOIL_WORKDIR (%s) does not "
-                           "exist." % workDir)
-    # Create the workflow dir
-    workflowDir = os.path.join(workDir, 'toil-%s' % workflowID)
-    try:
-        # Directory creation is atomic
-        os.mkdir(workflowDir)
-    except OSError as err:
-        if err.errno != 17:
-            # The directory exists if a previous worker set it up.
-            raise
-    else:
-        logger.info('Created the workflow directory at %s' % workflowDir)
-    return workflowDir

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -22,8 +22,6 @@ import json
 from multiprocessing import Process
 from multiprocessing import Event as ProcessEvent
 import cPickle
-import sys
-import traceback
 
 from bd2k.util.expando import Expando
 from toil import resolveEntryPoint
@@ -614,6 +612,7 @@ def mainLoop(config, batchSystem, jobStore, rootJobWrapper, jobCache=None):
     failed jobs
     
     :return: The return value of the root job's run function.
+    :rtype: Any
     """
 
     # Get a snap shot of the current state of the jobs in the jobStore
@@ -651,25 +650,18 @@ def mainLoop(config, batchSystem, jobStore, rootJobWrapper, jobCache=None):
 
     # Cleanup
     if len(toilState.totalFailedJobs) > 0:
-        if config.clean == "onError" or config.clean == "always" :
-            jobStore.deleteJobStore()
         raise FailedJobsException( config.jobStore, len(toilState.totalFailedJobs) )
 
     # Parse out the return value from the root job
-    with jobStore.readSharedFileStream("rootJobReturnValue") as fH:
-        jobStoreFileID = fH.read()
-    with jobStore.readFileStream(jobStoreFileID) as fH:
-        try:
-            rootJobReturnValue = cPickle.load(fH)
-        except EOFError:
-            logger.exception("Failed to unpickle root job return value")
-            raise FailedJobsException(jobStoreFileID, toilState.totalFailedJobs)
+    with jobStore.readSharedFileStream("rootJobReturnValue") as jobStoreFileID:
+        with jobStore.readFileStream(jobStoreFileID.read()) as fH:
+            try:
+                return cPickle.load(fH)  # rootJobReturnValue
+            except EOFError:
+                logger.exception("Failed to unpickle root job return value")
+                raise FailedJobsException(jobStoreFileID, toilState.totalFailedJobs)
 
-    # Cleanup
-    if config.clean == "onSuccess" or config.clean == "always":
-        jobStore.deleteJobStore()
 
-    return rootJobReturnValue
 
 def innerLoop(jobStore, config, batchSystem, toilState, jobBatcher, serviceManager, statsAndLogging):
     # Putting this in separate function for easier reading
@@ -891,11 +883,12 @@ def innerLoop(jobStore, config, batchSystem, toilState, jobBatcher, serviceManag
         serviceManager.check()
 
     logger.info("Finished the main loop")
-    
+
     # Consistency check the toil state
     assert toilState.updatedJobs == set()
-    assert toilState.successorCounts == { }
-    assert toilState.successorJobStoreIDToPredecessorJobs == { }
-    assert toilState.serviceJobStoreIDToPredecessorJob == { }
-    assert toilState.servicesIssued == { }
-    #assert toilState.hasFailedSuccessors == set() # These are not properly emptied yet
+    assert toilState.successorCounts == {}
+    assert toilState.successorJobStoreIDToPredecessorJobs == {}
+    assert toilState.serviceJobStoreIDToPredecessorJob == {}
+    assert toilState.servicesIssued == {}
+    # assert toilState.hasFailedSuccessors == set() # These are not properly emptied yet
+

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -438,17 +438,16 @@ class hidden:
             master = self.master
 
             # Create parent job
-            rootJob = master.create('rootjob', 12, 34, 35)
-            
+            rootJob = master.createRootJob('rootjob', 12, 34, 35)
             # Create a bunch of child jobs
             for i in range(100):
                 child = master.create("child%s" % i, 23, 45, 46, 1)
                 rootJob.stack.append(((child.jobStoreID, 23, 45, 46, 1),))
             master.update(rootJob)
-            
+
             # See how long it takes to clean with no cache
             noCacheStart = time.time()
-            master.clean(rootJob)
+            master.clean()
             noCacheEnd = time.time()
             
             noCacheTime = noCacheEnd - noCacheStart
@@ -457,7 +456,7 @@ class hidden:
             jobCache = {jobWrapper.jobStoreID: jobWrapper
                         for jobWrapper in master.jobs()}
             cacheStart = time.time()
-            master.clean(rootJob, jobCache=jobCache)
+            master.clean(jobCache)
             cacheEnd = time.time()
             
             cacheTime = cacheEnd - cacheStart
@@ -475,7 +474,7 @@ class hidden:
             master = self.master
 
             # Create parent job
-            rootJob = master.create('rootjob', 12, 34, 35)
+            rootJob = master.createRootJob('rootjob', 12, 34, 35)
             
             # Create a bunch of child jobs
             for i in range(3000):

--- a/src/toil/test/src/jobWrapperTest.py
+++ b/src/toil/test/src/jobWrapperTest.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import
 import os
 from argparse import ArgumentParser
-from toil.common import setupToil
+from toil.common import Toil
 from toil.job import Job
 from toil.test import ToilTest
 from toil.jobWrapper import JobWrapper
@@ -23,19 +23,19 @@ from toil.jobWrapper import JobWrapper
 class JobWrapperTest(ToilTest):
     
     def setUp(self):
-        super( JobWrapperTest, self ).setUp( )
+        super(JobWrapperTest, self).setUp()
         self.jobStorePath = self._getTestJobStorePath()
         parser = ArgumentParser()
         Job.Runner.addToilOptions(parser)
         options = parser.parse_args(args=[self.jobStorePath])
-        self.contextManager = setupToil(options)
-        config, batchSystem, self.jobStore = self.contextManager.__enter__()
+        self.toil = Toil(options)
+        self.assertEquals( self.toil, self.toil.__enter__() )
 
     def tearDown(self):
-        self.contextManager.__exit__(None, None, None)
-        self.jobStore.deleteJobStore()
+        self.toil.__exit__(None, None, None)
+        self.toil.jobStore.deleteJobStore()
         self.assertFalse(os.path.exists(self.jobStorePath))
-        super( JobWrapperTest, self ).tearDown( )
+        super(JobWrapperTest, self).tearDown()
     
     def testJob(self):       
         """

--- a/src/toil/test/src/toilContextManagerTest.py
+++ b/src/toil/test/src/toilContextManagerTest.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2015 UCSC Computational Genomics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from toil.common import Toil, ToilContextManagerMisuseException
+from toil.job import Job
+from toil.test import ToilTest
+
+
+class ToilContextManagerTest(ToilTest):
+    def testContextManger(self):
+        options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
+        options.logLevel = 'INFO'
+        with Toil(options) as toil:
+            toil.run(HelloWorld())
+
+    def testNoContextManger(self):
+        options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
+        options.logLevel = 'INFO'
+        toil = Toil(options)
+        self.assertRaises(ToilContextManagerMisuseException, toil.run, HelloWorld())
+
+
+class HelloWorld(Job):
+    def __init__(self):
+        Job.__init__(self, memory=100000, cores=2, disk='1M')
+
+    def run(self, fileStore):
+        fileID = self.addChildJobFn(childFn, cores=1, memory='1M', disk='1M').rv()
+        self.addFollowOn(FollowOn(fileID))
+
+
+def childFn(job):
+    with job.fileStore.writeGlobalFileStream() as (fH, fileID):
+        fH.write("Hello, World!")
+        return fileID
+
+
+class FollowOn(Job):
+    def __init__(self, fileId):
+        Job.__init__(self)
+        self.fileId = fileId
+
+    def run(self, fileStore):
+        tempDir = fileStore.getLocalTempDir()
+        tempFilePath = "/".join([tempDir, 'LocalCopy'])
+        with fileStore.readGlobalFileStream(self.fileId) as globalFile:
+            with open(tempFilePath, "w") as localFile:
+                localFile.write(globalFile.read())

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -27,7 +27,7 @@ from toil.lib.bioio import system
 from toil.test import ToilTest
 from toil.test.sort.sortTest import makeFileToSort
 from toil.utils.toilStats import getStats, processData
-from toil.common import loadJobStore
+from toil.common import Toil
 
 
 class UtilsTest(ToilTest):
@@ -178,7 +178,7 @@ class UtilsTest(ToilTest):
         options.stats = True
         Job.Runner.startToil(RunTwoJobsPerWorker(), options)
 
-        jobStore = loadJobStore(options.jobStore)
+        jobStore = Toil.loadOrCreateJobStore(options.jobStore)
         stats = getStats(options)
         collatedStats =  processData(jobStore.config, stats, options)
         self.assertTrue(len(collatedStats.job_types)==2,"Some jobs are not represented in the stats")

--- a/src/toil/utils/toilClean.py
+++ b/src/toil/utils/toilClean.py
@@ -15,12 +15,11 @@
 """
 from __future__ import absolute_import
 import logging
-import os
 import sys
 
 from toil.lib.bioio import getBasicOptionParser
 from toil.lib.bioio import parseBasicOptions
-from toil.common import loadJobStore
+from toil.common import Toil
 from toil.jobStores.abstractJobStore import JobStoreCreationException
 from toil.version import version
 
@@ -51,7 +50,7 @@ def main():
     ##########################################
     logger.info("Checking if we have files for toil")
     try:
-        jobStore = loadJobStore(options.jobStore)
+        jobStore = Toil.loadOrCreateJobStore(options.jobStore)
     except JobStoreCreationException:
         logger.info("The specified JobStore does not exist, it may have already been deleted")
         sys.exit(0)

--- a/src/toil/utils/toilKill.py
+++ b/src/toil/utils/toilKill.py
@@ -16,11 +16,10 @@
 """
 from __future__ import absolute_import
 import logging
-import sys
 
 from toil.lib.bioio import getBasicOptionParser
 from toil.lib.bioio import parseBasicOptions
-from toil.common import loadJobStore, loadBatchSystem
+from toil.common import Toil
 from toil.version import version
 
 logger = logging.getLogger( __name__ )
@@ -38,11 +37,11 @@ def main():
     parser.add_argument("--version", action='version', version=version)
     options = parseBasicOptions(parser)
 
-    jobStore = loadJobStore(options.jobStore)
+    jobStore = Toil.loadOrCreateJobStore(options.jobStore)
     
     logger.info("Starting routine to kill running jobs in the toil workflow: %s" % options.jobStore)
     ####This behaviour is now broken
-    batchSystem = loadBatchSystem(jobStore.config) #This should automatically kill the existing jobs.. so we're good.
+    batchSystem = Toil.createBatchSystem(jobStore.config) #This should automatically kill the existing jobs.. so we're good.
     for jobID in batchSystem.getIssuedBatchJobIDs(): #Just in case we do it again.
         batchSystem.killBatchJobs(jobID)
     logger.info("All jobs SHOULD have been killed")

--- a/src/toil/utils/toilRestart.py
+++ b/src/toil/utils/toilRestart.py
@@ -16,14 +16,12 @@
 """
 
 from __future__ import absolute_import
-import sys
+
 from toil.lib.bioio import getBasicOptionParser
 from toil.lib.bioio import parseBasicOptions
 
-from toil.leader import mainLoop
-from toil.common import setupToil
+from toil.common import Toil
 from toil.lib.bioio import setLoggingFromOptions
-from toil.job import Job
 from toil.version import version
 import logging
 logger = logging.getLogger( __name__ )
@@ -56,14 +54,10 @@ def main():
         
     setLoggingFromOptions(options)
     options.restart = True
-    with setupToil(options) as (config, batchSystem, jobStore):
-        # Load the whole jobstore into memory in a batch
-        logger.info("Downloading entire JobStore")
-        jobCache = {jobWrapper.jobStoreID: jobWrapper
-            for jobWrapper in jobStore.jobs()}
-        logger.info("{} jobs downloaded.".format(len(jobCache)))
-        jobStore.clean(Job._loadRootJob(jobStore), jobCache=jobCache)
-        mainLoop(config, batchSystem, jobStore, Job._loadRootJob(jobStore), jobCache=jobCache)
+
+    with Toil(options) as toil:
+        toil.run()
+
     
 def _test():
     import doctest      

--- a/src/toil/utils/toilStats.py
+++ b/src/toil/utils/toilStats.py
@@ -21,7 +21,7 @@ import logging
 import json
 from toil.lib.bioio import getBasicOptionParser
 from toil.lib.bioio import parseBasicOptions
-from toil.common import loadJobStore
+from toil.common import Toil
 from toil.version import version
 from bd2k.util.expando import Expando
 
@@ -530,7 +530,7 @@ def getStats(options):
             logger.critical("File %s contains corrupted json. Skipping file." % fileHandle)
             pass  # The file is corrupted.
 
-    jobStore = loadJobStore(options.jobStore)
+    jobStore = Toil.loadOrCreateJobStore(options.jobStore)
     aggregateObject = Expando()
     callBack = partial(aggregateStats, aggregateObject=aggregateObject)
     jobStore.readStatsAndLogging(callBack, readAll=True)
@@ -601,7 +601,7 @@ def main():
     initializeOptions(parser)
     options = parseBasicOptions(parser)
     checkOptions(options, parser)
-    jobStore = loadJobStore(options.jobStore)
+    jobStore = Toil.loadOrCreateJobStore(options.jobStore)
     stats = getStats(options)
     collatedStatsTag = processData(jobStore.config, stats, options)
     reportData(collatedStatsTag, options)

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -22,7 +22,7 @@ import sys
 from toil.lib.bioio import logStream
 from toil.lib.bioio import getBasicOptionParser
 from toil.lib.bioio import parseBasicOptions
-from toil.common import loadJobStore
+from toil.common import Toil
 from toil.leader import ToilState
 from toil.job import Job, JobException
 from toil.version import version
@@ -74,9 +74,9 @@ def main():
     #Survey the status of the job and report.
     ##########################################  
     
-    jobStore = loadJobStore(options.jobStore)
+    jobStore = Toil.loadOrCreateJobStore(options.jobStore)
     try:
-        rootJob = Job._loadRootJob(jobStore)
+        rootJob = jobStore.loadRootJob()
     except JobException:
         print "The root job of the jobStore is not present, the toil workflow has probably completed okay"
         sys.exit(0)

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -28,7 +28,7 @@ import cPickle
 import shutil
 from threading import Thread
 from bd2k.util.expando import Expando, MagicExpando
-from toil.common import getToilWorkflowDir
+from toil.common import Toil
 import signal
 
 logger = logging.getLogger( __name__ )
@@ -75,7 +75,6 @@ def main():
     from toil.lib.bioio import getTotalCpuTimeAndMemoryUsage
     from toil.lib.bioio import makePublicDir
     from toil.lib.bioio import system
-    from toil.common import loadJobStore
     from toil.job import Job
     
     ########################################## 
@@ -89,7 +88,7 @@ def main():
     #Load the jobStore/config file
     ##########################################
     
-    jobStore = loadJobStore(jobStoreString)
+    jobStore = Toil.loadOrCreateJobStore(jobStoreString)
     config = jobStore.config
     
     ##########################################
@@ -124,7 +123,7 @@ def main():
 
     setLogLevel(config.logLevel)
 
-    toilWorkflowDir = getToilWorkflowDir(config.workflowID, config.workDir)
+    toilWorkflowDir = Toil.getWorkflowDir(config.workflowID, config.workDir)
 
     ##########################################
     #Setup the temporary directories.
@@ -453,7 +452,7 @@ def main():
             statsDict.workers.clock = str(totalCPUTime - startClock)
             statsDict.workers.memory = str(totalMemoryUsage)
 
-		# logToMaster messages should be always be passed
+        # logToMaster messages should be always be passed
         statsDict.workers.logsToMaster = messages
 
         # log the worker log path here so that if the file is truncated the path can still be found


### PR DESCRIPTION
The Toil class is meant to be used as a context manager and has all of the functionality of setupToil. Many of the  top level methods in common that
setupToil previously used have been refactored as regular or static methods of common.Toil.

Here is a list of methods that were refactored and their common.Toil counter parts:
    - (loadBatchSystem, loadBatchSystemClass, createBatchSystem) >> Toil.createBatchSystem
    - loadJobStore >> Toil.loadOrCreateJobStore
    - serialiseEnvironment >> Toil._serialiseEnvironment
    - getToilWorkflowDir >> Toil.getWorkflowDir

A word on the loadBatchSystem, loadBatchSystemClass, createBatchSystem:
These methods were extremely redundant. createBatchSystem did almost nothing; loadBatchSystem simply calls createBatchSystem and there was
no useful use case for the loadBatchSystemClass method, which returns a class, without instantiating said class immediately after. Thus it made sense
to flatten the three batch system methods into a single createBatchSystem.

Some inlined functionality in setupToil has also been refactored into Toil methods to improve readability.

Here is a list of these new methods :
    - Toil._setBatchSystemEnvVars
    - Toil._cacheJobs

common.Toil includes a run method which is a refactoring of the functionality of job.startToil. Note that job.startToil has been reimplemented to use Toil.run()
in order to support legacy toil scripts. Toil.run must be called inside the Toil context manager. This will allow future features to easily add setup and clean up
functionalities that will not break backwards compatibility.

Take note that Toil.__exit__ now deletes the current job store instead of mainLoop.