### PR TITLE
Port commits from 3.1.x onto master (resolves #683, resolves #686, resolves #690)

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -47,6 +47,7 @@ class Config(object):
         # Because the stats option needs the jobStore to persist past the end of the run,
         # the clean default value depends the specified stats option and is determined in setOptions
         self.clean = None
+        self.cleanWorkDir = None
 
         #Restarting the workflow options
         self.restart = False
@@ -127,6 +128,7 @@ class Config(object):
         #TODO: LOG LEVEL STRING
         setOption("workDir")
         setOption("stats")
+        setOption("cleanWorkDir")
         setOption("clean")
         if self.stats:
             if self.clean != "never" and self.clean is not None:
@@ -207,7 +209,11 @@ def _addOptions(addGroupFn, config):
                             "information from the jobStore upon completion so the jobStore will never be deleted with"
                             "that flag. If you wish to be able to restart the run, choose \'never\' or \'onSuccess\'. "
                             "Default is \'never\' if stats is enabled, and \'onSuccess\' otherwise"))
-
+    addOptionFn("--cleanWorkDir", dest="cleanWorkDir",
+                choices=['always', 'never', 'onSuccess', 'onError'], default='always',
+                help=("Determines deletion of temporary worker directory upon completion of a job. Choices: 'always', "
+                      "'never', 'onSuccess'. Default = always. WARNING: This option should be changed for debugging "
+                      "only. Running a full pipeline with this option could fill your disk with intermediate data."))
     #
     #Restarting the workflow options
     #

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -659,7 +659,11 @@ def mainLoop(config, batchSystem, jobStore, rootJobWrapper, jobCache=None):
     with jobStore.readSharedFileStream("rootJobReturnValue") as fH:
         jobStoreFileID = fH.read()
     with jobStore.readFileStream(jobStoreFileID) as fH:
-        rootJobReturnValue = cPickle.load(fH)
+        try:
+            rootJobReturnValue = cPickle.load(fH)
+        except EOFError:
+            logger.exception("Failed to unpickle root job return value")
+            raise FailedJobsException(jobStoreFileID, toilState.totalFailedJobs)
 
     # Cleanup
     if config.clean == "onSuccess" or config.clean == "always":

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -41,7 +41,7 @@ class StatsAndLogging( object ):
     """
     Class manages process to aggregate statistics and logging information on a toil run.
     """
-    
+
     def __init__(self, jobStore):
         # Start the stats/logging aggregation process
         self._stop = ProcessEvent() 
@@ -62,7 +62,7 @@ class StatsAndLogging( object ):
         def callback(fileHandle):
             stats = json.load(fileHandle, object_hook=Expando)
             try:
-                logs = stats.workers.log
+                logs = stats.workers.logsToMaster
             except AttributeError:
                 # To be expected if there were no calls to logToMaster()
                 pass

--- a/src/toil/test/src/retainTempDirTest.py
+++ b/src/toil/test/src/retainTempDirTest.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2015 UCSC Computational Genomics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, print_function
+import os
+import shutil
+from toil.job import Job
+from toil.leader import FailedJobsException
+from toil.test import ToilTest
+
+class CleanWorkDirTest(ToilTest):
+    """
+    Tests testing the Job.FileStore class
+    """
+    def setUp(self):
+        super(CleanWorkDirTest, self).setUp()
+        self.testDir = self._createTempDir()
+
+    def tearDown(self):
+        super(CleanWorkDirTest, self).tearDown()
+        shutil.rmtree(self.testDir)
+
+    def testNever(self):
+        retainedTempData = self._runAndReturnWorkDir("never", job=tempFileTestJob)
+        self.assertNotEqual(retainedTempData, [], "The worker's temporary workspace was deleted despite "
+                                                  "cleanWorkDir being set to 'never'")
+
+    def testAlways(self):
+        retainedTempData = self._runAndReturnWorkDir("always", job=tempFileTestJob)
+        self.assertEqual(retainedTempData, [], "The worker's temporary workspace was not deleted despite "
+                                               "cleanWorkDir being set to 'always'")
+
+    def testOnErrorWithError(self):
+        retainedTempData = self._runAndReturnWorkDir("onError", job=tempFileTestErrorJob, expectError=True)
+        self.assertEqual(retainedTempData, [], "The worker's temporary workspace was not deleted despite "
+                                               "an error occurring and cleanWorkDir being set to 'onError'")
+
+    def testOnErrorWithNoError(self):
+        retainedTempData = self._runAndReturnWorkDir("onError", job=tempFileTestJob)
+        self.assertNotEqual(retainedTempData, [], "The worker's temporary workspace was deleted despite "
+                                                  "no error occurring and cleanWorkDir being set to 'onError'")
+
+    def testOnSuccessWithError(self):
+        retainedTempData = self._runAndReturnWorkDir("onSuccess", job=tempFileTestErrorJob, expectError=True)
+        self.assertNotEqual(retainedTempData, [], "The worker's temporary workspace was deleted despite "
+                                                  "an error occurring and cleanWorkDir being set to 'onSuccesss'")
+
+    def testOnSuccessWithSuccess(self):
+        retainedTempData = self._runAndReturnWorkDir("onSuccess", job=tempFileTestJob)
+        self.assertEqual(retainedTempData, [], "The worker's temporary workspace was not deleted despite "
+                                               "a successful job execution and cleanWorkDir being set to 'onSuccesss'")
+
+    def _runAndReturnWorkDir(self, cleanWorkDir, job, expectError=False):
+        """
+        Runs toil with the specified job and cleanWorkDir setting. expectError determines whether the test's toil
+        run is expected to succeed, and the test will fail if that expectation is not met. returns the contents of
+        the workDir after completion of the run
+        """
+        options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
+        options.workDir = self.testDir
+        options.clean = "always"
+        options.cleanWorkDir = cleanWorkDir
+        A = Job.wrapJobFn(job)
+        if expectError:
+            self._launchError(A, options)
+        else:
+            self._launchRegular(A, options)
+        return os.listdir(self.testDir)
+
+    def _launchRegular(self, A, options):
+        Job.Runner.startToil(A, options)
+
+    def _launchError(self, A, options):
+        try:
+            Job.Runner.startToil(A, options)
+        except FailedJobsException:
+            pass  # we expect a job to fail here
+        else:
+            self.fail("Toil run succeeded unexpectedly")
+
+def tempFileTestJob(job):
+    with open(job.fileStore.getLocalTempFile(), "w") as f:
+        f.write("test file retention")
+
+def tempFileTestErrorJob(job):
+    with open(job.fileStore.getLocalTempFile(), "w") as f:
+        f.write("test file retention")
+    raise RuntimeError()  # test failure

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -33,20 +33,10 @@ import signal
 
 logger = logging.getLogger( __name__ )
 
-def truncateFile(fileNameString, tooBig=50000):
-    """
-    Truncates a file that is bigger than tooBig bytes, leaving only the 
-    last tooBig bytes in the file.
-    """
-    if os.path.getsize(fileNameString) > tooBig:
-        fh = open(fileNameString, 'rb+')
-        fh.seek(-tooBig, 2) 
-        data = fh.read()
-        fh.seek(0) # rewind
-        fh.write(data)
-        fh.truncate()
-        fh.close()
-    
+
+logFileByteReportLimit = 50000
+
+
 def nextOpenDescriptor():
     """Gets the number of the next available file descriptor.
     """
@@ -294,7 +284,7 @@ def main():
                 logger.debug("The checkpoint jobs seems to have completed okay, removing any checkpoint files to delete.")
                 #Delete any remnant files
                 map(jobStore.deleteFile, filter(jobStore.fileExists, jobWrapper.checkpointFilesToDelete))
-    
+
         ##########################################
         #Setup the stats, if requested
         ##########################################
@@ -463,8 +453,11 @@ def main():
             statsDict.workers.clock = str(totalCPUTime - startClock)
             statsDict.workers.memory = str(totalMemoryUsage)
 
-        statsDict.workers.logsToMaster = messages  # logToMaster messages should be always be passed
+		# logToMaster messages should be always be passed
+        statsDict.workers.logsToMaster = messages
 
+        # log the worker log path here so that if the file is truncated the path can still be found
+        logger.info("Worker log can be found at %s. Set --cleanWorkDir to retain this log", localTempDir)
         logger.info("Finished running the chain of jobs on this node, we ran for a total of %f seconds", time.time() - startTime)
     
     ##########################################
@@ -521,21 +514,28 @@ def main():
     
     #Copy back the log file to the global dir, if needed
     if workerFailed:
-        truncateFile(tempWorkerLogPath)
-        jobWrapper.logJobStoreFileID = jobStore.writeFile( tempWorkerLogPath, jobWrapper.jobStoreID )
-        os.remove(tempWorkerLogPath)
+        jobWrapper.logJobStoreFileID = jobStore.getEmptyFileStoreID(jobWrapper.jobStoreID)
+        with jobStore.updateFileStream(jobWrapper.logJobStoreFileID) as w:
+            with open(tempWorkerLogPath, "r") as f:
+                if os.path.getsize(tempWorkerLogPath) > logFileByteReportLimit:
+                    f.seek(-logFileByteReportLimit, 2)  # seek to last tooBig bytes of file
+                w.write(f.read())
         jobStore.update(jobWrapper)
-    elif debugging: # write log messages
-        truncateFile(tempWorkerLogPath)
-        with open(tempWorkerLogPath, 'r') as logFile:
-            logMessages = logFile.read().splitlines()
-        statsDict.logs = [Expando(jobStoreID=jobStoreID,text=logMessage) for logMessage in logMessages]
 
-    if (debugging or config.stats or messages) and not workerFailed: # We have stats/logging to report back
+    elif debugging:  # write log messages
+        with open(tempWorkerLogPath, 'r') as logFile:
+            if os.path.getsize(tempWorkerLogPath) > logFileByteReportLimit:
+                logFile.seek(-logFileByteReportLimit, 2)  # seek to last tooBig bytes of file
+            logMessages = logFile.read().splitlines()
+        statsDict.logs = [Expando(jobStoreID=jobStoreID, text=logMessage) for logMessage in logMessages]
+
+    if (debugging or config.stats or messages) and not workerFailed:  # We have stats/logging to report back
         jobStore.writeStatsAndLogging(json.dumps(statsDict))
 
     #Remove the temp dir
-    shutil.rmtree(localWorkerTempDir)
+    cleanUp = config.cleanWorkDir
+    if cleanUp == 'always' or (cleanUp == 'onSuccess' and not workerFailed) or (cleanUp == 'onError' and workerFailed):
+        shutil.rmtree(localWorkerTempDir)
     
     #This must happen after the log file is done with, else there is no place to put the log
     if (not workerFailed) and jobWrapper.command == None and len(jobWrapper.stack) == 0 and len(jobWrapper.services) == 0:

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -462,8 +462,9 @@ def main():
             statsDict.workers.time = str(time.time() - startTime)
             statsDict.workers.clock = str(totalCPUTime - startClock)
             statsDict.workers.memory = str(totalMemoryUsage)
-            statsDict.workers.log = messages
-        
+
+        statsDict.workers.logsToMaster = messages  # logToMaster messages should be always be passed
+
         logger.info("Finished running the chain of jobs on this node, we ran for a total of %f seconds", time.time() - startTime)
     
     ##########################################


### PR DESCRIPTION
Cherry picked already merged commits from 3.1.x branch. Resolves a logToMaster issue, EOF error upon root job failure, and adds support for optionally retaining the workDir on workers.