### PR TITLE
Moving try to stop service.stop from being called if service.start (Resolves #756)

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -1571,10 +1571,9 @@ class ServiceJob(Job):
         #Unpickle the service
         userModule = self._loadUserModule(self.serviceModule)
         service = self._unpickle( userModule, BytesIO( self.pickledService ) )
+        #Start the service
+        startCredentials = service.start(fileStore)
         try:
-            #Start the service
-            startCredentials = service.start(fileStore)
-            
             #The start credentials  must be communicated to processes connecting to
             #the service, to do this while the run method is running we
             #cheat and set the return value promise within the run method


### PR DESCRIPTION
fails.