### PR TITLE
Added robust clean and improved job store construction (resolves #785, resolves #789, resolves #869, resolves #834)

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -2723,7 +2723,7 @@ class Promise(object):
         # Initialize the cached job store if it was never initialized in the current process or
         # if it belongs to a different workflow that was run earlier in the current process.
         if cls._jobstore is None or cls._jobstore.config.jobStore != jobStoreString:
-            cls._jobstore = Toil.loadOrCreateJobStore(jobStoreString)
+            cls._jobstore = Toil.loadJobStore(jobStoreString)
         cls.filesToDelete.add(jobStoreFileID)
         with cls._jobstore.readFileStream(jobStoreFileID) as fileHandle:
             # If this doesn't work then the file containing the promise may not exist or be

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -145,6 +145,23 @@ class AbstractJobStore(object):
                 config = cPickle.load(fileHandle)
                 assert config.workflowID is not None
                 self.__config = config
+    @abstractmethod
+    def jobStoreString(self):
+        """
+        Returns the job store string of the current job store.
+
+        :rtype: str
+        """
+        raise NotImplementedError()
+
+    @abstractclassmethod
+    def _extractArgsFromString(cls, jobStoreStr):
+        """
+        Extracts args necessary for job store creation from the given job store string.
+
+        :param str jobStoreStr: A string that uniquely identifies a job store.
+        """
+        raise NotImplementedError()
         else:
             assert config.workflowID is None
             config.workflowID = str(uuid4())
@@ -159,6 +176,19 @@ class AbstractJobStore(object):
         """
         with self.writeSharedFileStream("config.pickle", isProtected=False) as fileHandle:
             cPickle.dump(self.__config, fileHandle, cPickle.HIGHEST_PROTOCOL)
+
+    @classmethod
+    def cleanJobStore(cls, jobStoreStr):
+        """
+        Removes the job store represented by the jobStoreStr from the disk/store. Careful!
+        """
+        cls._deleteJobStore(jobStoreStr)
+
+    def deleteJobStore(self):
+        """
+        Removes the job store from the disk/store. Careful!
+        """
+        self._deleteJobStore(self.jobStoreString())
 
     @property
     def config(self):
@@ -343,13 +373,6 @@ class AbstractJobStore(object):
         :param bool export: Determines if the url is supported for exported
         :param urlparse.ParseResult url: a parsed URL that may be supported
         :return bool: returns true if the cls supports the URL
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def deleteJobStore(self):
-        """
-        Removes the job store from the disk/store. Careful!
         """
         raise NotImplementedError()
 

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -36,8 +36,15 @@ class FileJobStore(AbstractJobStore):
     Represents the toil using a network file system. For doc-strings of functions see
     AbstractJobStore.
     """
+    def jobStoreString(self):
+        return self.jobStoreDir
 
     def __init__(self, jobStoreDir, config=None):
+    @classmethod
+    def _extractArgsFromString(cls, jobStoreStr):
+        jobStoreDir = absSymPath(jobStoreStr)
+        tempFilesDir = os.path.join(jobStoreDir, "tmp")
+        return jobStoreDir, tempFilesDir
         """
         :param jobStoreDir: Place to create jobStore
         :param config: See jobStores.abstractJobStore.AbstractJobStore.__init__
@@ -62,9 +69,12 @@ class FileJobStore(AbstractJobStore):
         self.levels = 2
         super(FileJobStore, self).__init__(config=config)
 
-    def deleteJobStore(self):
-        if os.path.exists(self.jobStoreDir):
-            shutil.rmtree(self.jobStoreDir)
+    @classmethod
+    def _deleteJobStore(cls, jobStoreStr):
+        try:
+            shutil.rmtree(jobStoreStr)
+        except OSError:
+            pass
 
     ##########################################
     # The following methods deal with creating/loading/updating/writing/checking for the

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -178,7 +178,7 @@ class UtilsTest(ToilTest):
         options.stats = True
         Job.Runner.startToil(RunTwoJobsPerWorker(), options)
 
-        jobStore = Toil.loadOrCreateJobStore(options.jobStore)
+        jobStore = Toil.loadJobStore(options.jobStore)
         stats = getStats(options)
         collatedStats =  processData(jobStore.config, stats, options)
         self.assertTrue(len(collatedStats.job_types)==2,"Some jobs are not represented in the stats")

--- a/src/toil/utils/toilClean.py
+++ b/src/toil/utils/toilClean.py
@@ -45,18 +45,8 @@ def main():
     options = parseBasicOptions(parser)
     logger.info("Parsed arguments")
 
-    ##########################################
-    #Survey the status of the job and report.
-    ##########################################
-    logger.info("Checking if we have files for toil")
-    try:
-        jobStore = Toil.loadOrCreateJobStore(options.jobStore)
-    except JobStoreCreationException:
-        logger.info("The specified JobStore does not exist, it may have already been deleted")
-        sys.exit(0)
-
     logger.info("Attempting to delete the job store")
-    jobStore.deleteJobStore()
+    Toil.clean(options.jobStore)
     logger.info("Successfully deleted the job store")
 
 

--- a/src/toil/utils/toilKill.py
+++ b/src/toil/utils/toilKill.py
@@ -37,7 +37,7 @@ def main():
     parser.add_argument("--version", action='version', version=version)
     options = parseBasicOptions(parser)
 
-    jobStore = Toil.loadOrCreateJobStore(options.jobStore)
+    jobStore = Toil.loadJobStore(options.jobStore)
     
     logger.info("Starting routine to kill running jobs in the toil workflow: %s" % options.jobStore)
     ####This behaviour is now broken

--- a/src/toil/utils/toilStats.py
+++ b/src/toil/utils/toilStats.py
@@ -530,7 +530,7 @@ def getStats(options):
             logger.critical("File %s contains corrupted json. Skipping file." % fileHandle)
             pass  # The file is corrupted.
 
-    jobStore = Toil.loadOrCreateJobStore(options.jobStore)
+    jobStore = Toil.loadJobStore(options.jobStore)
     aggregateObject = Expando()
     callBack = partial(aggregateStats, aggregateObject=aggregateObject)
     jobStore.readStatsAndLogging(callBack, readAll=True)
@@ -601,7 +601,7 @@ def main():
     initializeOptions(parser)
     options = parseBasicOptions(parser)
     checkOptions(options, parser)
-    jobStore = Toil.loadOrCreateJobStore(options.jobStore)
+    jobStore = Toil.loadJobStore(options.jobStore)
     stats = getStats(options)
     collatedStatsTag = processData(jobStore.config, stats, options)
     reportData(collatedStatsTag, options)

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -76,7 +76,7 @@ def main():
     #Survey the status of the job and report.
     ##########################################  
     
-    jobStore = Toil.loadOrCreateJobStore(options.jobStore)
+    jobStore = Toil.loadJobStore(options.jobStore)
     try:
         rootJob = jobStore.loadRootJob()
     except JobException:

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -88,7 +88,7 @@ def main():
     #Load the jobStore/config file
     ##########################################
     
-    jobStore = Toil.loadOrCreateJobStore(jobStoreString)
+    jobStore = Toil.loadJobStore(jobStoreString)
     config = jobStore.config
     
     ##########################################


### PR DESCRIPTION
Continued from #835 
Resolves #785, #789, #869 and #834

Added a more robust cleanJobStore method that is exposed to the user in ```toil.common.Toil.clean()```. The new clean method will not fail if a job store is partially deleted prior to cleaning. 

Job stores now also have consistent factory methods for construction, and each ```__init__()``` method is now lighter. This allows greater flexibility and precision when constructing job stores in different states. 

The role of the job store string has been expanded as a means of job store construction and cleaning. 