### PR TITLE
CWL: new cwltool pin; raise errors in batch setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ kwargs = dict(
             'gcs_oauth2_boto_plugin==1.9',
             botoVersionRequired],
         'cwl': [
-            'cwltool==1.0.20160425140546']},
+            'cwltool==1.0.20160427142240']},
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=['*.test']),
     entry_points={

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -762,12 +762,11 @@ class Toil(object):
         """
         Shuts down current batch system if it has been created.
         """
-        assert self._batchSystem is not None
-
-        startTime = time.time()
-        logger.debug('Shutting down batch system')
-        self._batchSystem.shutdown()
-        logger.debug('Finished shutting down the batch system in %s seconds.' % (time.time() - startTime))
+        if self._batchSystem is not None:
+            startTime = time.time()
+            logger.debug('Shutting down batch system')
+            self._batchSystem.shutdown()
+            logger.debug('Finished shutting down the batch system in %s seconds.' % (time.time() - startTime))
 
     def _assertContextManagerUsed(self):
         if not self._inContextManager:


### PR DESCRIPTION
These are two small fixes from testing running cwltoil on bcbio CWL
runs:

- Does not error out on batch system shutdown if _batchSystem setup
  failed. This avoids a non-helpful assertion error and allows
  propagation of the initial error for debugging.
- Pins against a version of cwltool compatible with arvados-cwl-runner
  so users can have both in a single python environment.