### PR TITLE
Handle EOFError while unpicking promises (resolves #517)

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -2044,7 +2044,13 @@ class Job(object):
                 return getattr(importlib.import_module(module_name), class_name)
 
         unpickler.find_global = filter_main
-        return unpickler.load()
+        try:
+            return unpickler.load()
+        except EOFError:
+            raise RuntimeError('EOFError encountered while unpickling a promise. Is the job '
+                               'attempting to receive a promise from a non-encapsulated parent?')
+
+
 
     def getUserScript(self):
         return self.userModule


### PR DESCRIPTION
resolves #517

The EOFError is caught in a  try-except and raised as a RuntimeError with an informative message.