### PR TITLE
Fix scheduling a restarted successor twice (resolves #808)

### DIFF
--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -366,6 +366,7 @@ class JobBatcher:
                 assert self.toilState.successorCounts[predecessorJob.jobStoreID] >= 0
                 if self.toilState.successorCounts[predecessorJob.jobStoreID] == 0: #Job is done
                     self.toilState.successorCounts.pop(predecessorJob.jobStoreID)
+                    predecessorJob.stack.pop()
                     logger.debug('Job %s has all its non-service successors completed or totally '
                                  'failed', predecessorJob.jobStoreID)
                     assert predecessorJob not in self.toilState.updatedJobs
@@ -821,7 +822,7 @@ def innerLoop(jobStore, config, batchSystem, toilState, jobBatcher, serviceManag
                     #List of successors to schedule
                     successors = []
                     #For each successor schedule if all predecessors have been completed
-                    for successorJobStoreID, memory, cores, disk, preemptable, predecessorID in jobWrapper.stack.pop():
+                    for successorJobStoreID, memory, cores, disk, preemptable, predecessorID in jobWrapper.stack[-1]:
                         #Build map from successor to predecessors.
                         if successorJobStoreID not in toilState.successorJobStoreIDToPredecessorJobs:
                             toilState.successorJobStoreIDToPredecessorJobs[successorJobStoreID] = []


### PR DESCRIPTION
The previous behavior sometimes caused a parent job to schedule its already-finished children, because  its stack hadn't been correctly updated.

The basic pattern was: a failed child job reruns successfully, notices that its parent job's successors have all finished, then puts the parent in updatedJobs so it can be deleted. However, the parent job still had the failed child job in its stack, so the child got scheduled again. Since the child had already finished, that raised a NoSuchJobException.

Stylistic note: the `stackNeedsUpdating` variable is just for convenience, so that the if statement on line 778 doesn't get too complicated.