### PR TITLE
Synchronize cwltool version with arvados-cwl-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
             'gcs_oauth2_boto_plugin==1.9',
             botoRequirement],
         'cwl': [
-            'cwltool==1.0.20160425140546']},
+            'cwltool==1.0.20160427142240']},
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=['*.test']),
     entry_points={


### PR DESCRIPTION
Moves cwltool version pin to match that used in arvados-cwl-runner so
both can exist in the same python environment. This has been tested with
full bcbio generated CWL runs on arvados-cwl-runner and cwltoil.
Discussed with @tetron who recommended synchronizing until we move to
semantic versioning on cwltool. Follows up on #910.