### PR TITLE
Refactor Job._execute (resolves #973)

### DIFF
--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -328,15 +328,14 @@ def main():
 
                 # Create a fileStore object for the job
                 fileStore = FileStore(jobStore, jobWrapper, localWorkerTempDir, blockFn)
-                with fileStore.open(job):
-                    #Get the next block function and list that will contain any messages
-                    blockFn = fileStore._blockFn
+                with job._executor(jobWrapper=jobWrapper,
+                                   stats=statsDict if config.stats else None,
+                                   fileStore=fileStore):
+                    with fileStore.open(job):
+                        # Get the next block function and list that will contain any messages
+                        blockFn = fileStore._blockFn
 
-                    job._execute(jobWrapper=jobWrapper,
-                                 stats=statsDict if config.stats else None,
-                                 localTempDir=fileStore.localTempDir,
-                                 jobStore=jobStore,
-                                 fileStore=fileStore)
+                        job._runner(jobWrapper=jobWrapper, jobStore=jobStore, fileStore=fileStore)
 
                 # Accumulate messages from this job & any subsequent chained jobs
                 statsDict.workers.logsToMaster += fileStore.loggingMessages


### PR DESCRIPTION
resolves #973

refactored Job._execute into Job._executor and Job._runner and modified worker.py to use the new
context manager syntax of Job._executor.