### PR TITLE
Fix async writing of files to jobstore in caching (resolves #966)

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -18,5 +18,5 @@ export LIBPROCESS_IP=127.0.0.1
 
 rm -rf /mnt/ephemeral/tmp
 mkdir /mnt/ephemeral/tmp && export TMPDIR=/mnt/ephemeral/tmp
-make $make_targets
+make test tests="src/toil/test/src/jobCacheTest.py"
 rm -rf /mnt/ephemeral/tmp

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -18,5 +18,5 @@ export LIBPROCESS_IP=127.0.0.1
 
 rm -rf /mnt/ephemeral/tmp
 mkdir /mnt/ephemeral/tmp && export TMPDIR=/mnt/ephemeral/tmp
-make test tests="src/toil/test/src/jobCacheTest.py"
+make $make_targets
 rm -rf /mnt/ephemeral/tmp

--- a/src/toil/test/src/jobCacheEjectionTest.py
+++ b/src/toil/test/src/jobCacheEjectionTest.py
@@ -39,13 +39,13 @@ class JobCacheEjectionTest(ToilTest):
             options.retryCount=100
             options.badWorker=0.5
             options.badWorkerFailInterval = 1.0
-            # Create a temp file to write teh test results
+            # Create a temp file to write the test results
             handle, logfile = tempfile.mkstemp(dir=test_dir)
             os.close(handle)
             file_sizes = [50000, 40000, 30000]
             # Randomize to (potentially) test all combinations
             random.shuffle(file_sizes)
-            # Run the workflow. A, B and C do teh cache operations, and D prints test status to tempFile
+            # Run the workflow. A, B and C do the cache operations, and D prints test status to tempFile
             A = Job.wrapJobFn(fileTestJob, file_sizes[0])
             B = Job.wrapJobFn(fileTestJob, file_sizes[0])
             C = Job.wrapJobFn(fileTestJob, file_sizes[0])

--- a/src/toil/test/src/jobCacheTest.py
+++ b/src/toil/test/src/jobCacheTest.py
@@ -395,7 +395,7 @@ class hidden:
             :param fileMB: File Size
             :return: Job store file ID for second written file
             """
-            job.fileStore.logToMaster('Double writing')
+            job.fileStore.logToMaster('Double writing a file into job store')
             work_dir = job.fileStore.getLocalTempDir()
             with open(os.path.join(work_dir, str(uuid4())), 'w') as testFile:
                 testFile.write(os.urandom(fileMB * 1024 * 1024))
@@ -412,10 +412,9 @@ class hidden:
             :param fsID: Job store file ID for the read file
             :return: None
             """
-            job.fileStore.logToMaster('Reading')
-            # These will be relevant once the rest of the code comes in
-            # assert not job.fileStore._fileIsCached(fsID)
-            # assert os.path.exists(job.fileStore.getHarbingerFileName(fileStoreID=fsID))
+            job.fileStore.logToMaster('Reading the written file')
+            assert not job.fileStore._fileIsCached(fsID)
+            assert job.fileStore.HarbingerFile(job.fileStore, fileStoreID=fsID).exists()
             job.fileStore.readGlobalFile(fsID)
 
         # writeGlobalFile tests


### PR DESCRIPTION
resolves #966 

asyncWrite is now a class method and CachedFileStore overloads it with a cache-friendly version