### PR TITLE
Refactored job store string to locator (resolves #864, resolves #991, resolves #992)

### DIFF
--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -213,7 +213,7 @@ class AbstractJobStore(object):
         return rootJob
 
     @staticmethod
-    def _checkJobStoreCreation(create, exists, jobStoreString):
+    def _checkJobStoreCreation(create, exists, locator):
         """
         Consistency checks which will result in exceptions if we attempt to overwrite an existing
         job store. This method must be called by the constructor of a subclass before any
@@ -230,10 +230,10 @@ class AbstractJobStore(object):
             raise JobStoreCreationException("The job store '%s' already exists. Use --restart to "
                                             "resume the workflow, or remove the job store with "
                                             "'toil clean' to start the workflow from scratch" %
-                                            jobStoreString) 
+                                            locator)
         if not create and not exists:
             raise JobStoreCreationException("The job store '%s' does not exist, so there "
-                                            "is nothing to restart." % jobStoreString)
+                                            "is nothing to restart." % locator)
 
     def importFile(self, srcUrl, sharedFileName=None):
         """

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -151,8 +151,8 @@ class AWSJobStore(AbstractJobStore):
     """
 
     @classmethod
-    def loadOrCreateJobStore(cls, jobStoreString, config=None, **kwargs):
-        region, namePrefix = jobStoreString.split(':')
+    def loadOrCreateJobStore(cls, locator, config=None, **kwargs):
+        region, namePrefix = locator.split(':')
         if not cls.bucketNameRe.match(namePrefix):
             raise ValueError("Invalid name prefix '%s'. Name prefixes must contain only digits, "
                              "hyphens or lower-case letters and must not start or end in a "

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -87,8 +87,8 @@ class AzureJobStore(AbstractJobStore):
     Table Service to store job info with strong consistency."""
 
     @classmethod
-    def loadOrCreateJobStore(cls, jobStoreString, config=None, **kwargs):
-        account, namePrefix = jobStoreString.split(':', 1)
+    def loadOrCreateJobStore(cls, locator, config=None, **kwargs):
+        account, namePrefix = locator.split(':', 1)
         if '--' in namePrefix:
             raise ValueError("Invalid name prefix '%s'. Name prefixes may not contain "
                              "%s." % (namePrefix, cls.nameSeparator))

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -50,7 +50,7 @@ class FileJobStore(AbstractJobStore):
         # Safety checks for existing jobStore
         self._checkJobStoreCreation(create=config is not None,
                                     exists=os.path.exists(self.jobStoreDir),
-                                    jobStoreString=self.jobStoreDir)
+                                    locator=self.jobStoreDir)
         # Directory where temporary files go
         self.tempFilesDir = os.path.join(self.jobStoreDir, "tmp")
         # Creation of jobStore, if necessary

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -22,13 +22,12 @@ GOOGLE_STORAGE = 'gs'
 class GoogleJobStore(AbstractJobStore):
 
     @classmethod
-    def createJobStore(cls, jobStoreString, config=None):
+    def createJobStore(cls, locator, config=None):
         try:
-            namePrefix, projectID = jobStoreString.split(":", 1)
-            # jobstorestring = gs:project_id:bucket
+            projectID, namePrefix = locator.split(":", 1)
         except ValueError:
             # we don't have a specified projectID
-            namePrefix = jobStoreString
+            namePrefix = locator
             projectID = None
         return cls(namePrefix, projectID, config)
 

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -131,7 +131,7 @@ class JobBatcher:
     def __init__(self, config, batchSystem, jobStore, toilState, serviceManager):
         self.config = config
         self.jobStore = jobStore
-        self.jobStoreString = config.jobStore
+        self.jobStoreLocator = config.jobStore
         self.toilState = toilState
         # Map of batch system IDs to IsseudJob tuples
         self.jobBatchSystemIDToIssuedJob = {}
@@ -147,7 +147,7 @@ class JobBatcher:
         Add a job to the queue of jobs
         """
         self.jobsIssued += 1
-        jobCommand = ' '.join((resolveEntryPoint('_toil_worker'), self.jobStoreString, jobStoreID))
+        jobCommand = ' '.join((resolveEntryPoint('_toil_worker'), self.jobStoreLocator, jobStoreID))
         jobBatchSystemID = self.batchSystem.issueBatchJob(jobCommand, memory, cores, disk, preemptable)
         self.jobBatchSystemIDToIssuedJob[jobBatchSystemID] = IssuedJob(jobStoreID, memory, cores, disk, preemptable)
         logger.debug("Issued job with job store ID: %s and job batch system ID: "
@@ -464,9 +464,9 @@ class ToilState( object ):
                     self.successorJobStoreIDToPredecessorJobs[successorJobStoreID].append(jobWrapper)
 
 class FailedJobsException( Exception ):
-    def __init__( self, jobStoreString, numberOfFailedJobs ):
-        super( FailedJobsException, self ).__init__( "The job store '%s' contains %i failed jobs" % (jobStoreString, numberOfFailedJobs))
-        self.jobStoreString = jobStoreString
+    def __init__(self, jobStoreLocator, numberOfFailedJobs):
+        super( FailedJobsException, self ).__init__( "The job store '%s' contains %i failed jobs" % (jobStoreLocator, numberOfFailedJobs))
+        self.jobStoreLocator = jobStoreLocator
         self.numberOfFailedJobs = numberOfFailedJobs
 
 class ServiceManager( object ):

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -741,7 +741,7 @@ class GoogleJobStoreTest(AbstractJobStoreTest.Test):
 
     def _createJobStore(self, config=None):
         from toil.jobStores.googleJobStore import GoogleJobStore
-        return GoogleJobStore.createJobStore(self.namePrefix + ":" + GoogleJobStoreTest.projectID,
+        return GoogleJobStore.createJobStore(GoogleJobStoreTest.projectID + ":" + self.namePrefix,
                                              config=config)
 
     def _prepareTestFile(self, bucket, size=None):

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -55,7 +55,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
         super(SortTest, self).setUp()
         self.tempDir = self._createTempDir(purpose='tempDir')
 
-    def _toilSort(self, jobStore, batchSystem,
+    def _toilSort(self, jobStoreLocator, batchSystem,
                   lines=defaultLines, N=defaultN, testNo=1, lineLen=defaultLineLen,
                   retryCount=2, badWorker=0.5, downCheckpoints=False):
         """
@@ -64,7 +64,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
         than the given number of bytes, sorting each part and merging them back together. Then
         verify the result.
 
-        :param jobStore: a job store string
+        :param jobStoreLocator: The location of the job store.
 
         :param batchSystem: the name of the batch system
 
@@ -79,7 +79,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
         for test in xrange(testNo):
             try:
                 # Specify options
-                options = Job.Runner.getDefaultOptions(jobStore)
+                options = Job.Runner.getDefaultOptions(jobStoreLocator)
                 options.logLevel = getLogLevelString()
                 options.retryCount = retryCount
                 options.batchSystem = batchSystem
@@ -157,18 +157,18 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
                     l2 = fileHandle.readlines()
                     self.assertEquals(l, l2)
             finally:
-                subprocess.check_call([resolveEntryPoint('toil'), 'clean', jobStore])
+                subprocess.check_call([resolveEntryPoint('toil'), 'clean', jobStoreLocator])
 
     @needs_aws
     def testAwsSingle(self):
-        self._toilSort(jobStore=self._awsJobStore(), batchSystem='singleMachine')
+        self._toilSort(jobStoreLocator=self._awsJobStore(), batchSystem='singleMachine')
 
     @needs_aws
     @needs_mesos
     def testAwsMesos(self):
         self._startMesos()
         try:
-            self._toilSort(jobStore=self._awsJobStore(), batchSystem="mesos")
+            self._toilSort(jobStoreLocator=self._awsJobStore(), batchSystem="mesos")
         finally:
             self._stopMesos()
 
@@ -176,14 +176,14 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
     def testFileMesos(self):
         self._startMesos()
         try:
-            self._toilSort(jobStore=self._getTestJobStorePath(), batchSystem="mesos")
+            self._toilSort(jobStoreLocator=self._getTestJobStorePath(), batchSystem="mesos")
         finally:
             self._stopMesos()
 
     @experimental
     @needs_azure
     def testAzureSingle(self):
-        self._toilSort(jobStore=self._azureJobStore(), batchSystem='singleMachine')
+        self._toilSort(jobStoreLocator=self._azureJobStore(), batchSystem='singleMachine')
 
     @experimental
     @needs_azure
@@ -191,14 +191,14 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
     def testAzureMesos(self):
         self._startMesos()
         try:
-            self._toilSort(jobStore=self._azureJobStore(), batchSystem="mesos")
+            self._toilSort(jobStoreLocator=self._azureJobStore(), batchSystem="mesos")
         finally:
             self._stopMesos()
 
     @experimental
     @needs_google
     def testGoogleSingle(self):
-        self._toilSort(jobStore=self._googleJobStore(), batchSystem="singleMachine")
+        self._toilSort(jobStoreLocator=self._googleJobStore(), batchSystem="singleMachine")
 
     @experimental
     @needs_google
@@ -206,31 +206,31 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
     def testGoogleMesos(self):
         self._startMesos()
         try:
-            self._toilSort(jobStore=self._googleJobStore(), batchSystem="mesos")
+            self._toilSort(jobStoreLocator=self._googleJobStore(), batchSystem="mesos")
         finally:
             self._stopMesos()
 
     def testFileSingle(self):
-        self._toilSort(jobStore=self._getTestJobStorePath(), batchSystem='singleMachine')
+        self._toilSort(jobStoreLocator=self._getTestJobStorePath(), batchSystem='singleMachine')
 
     def testFileSingleCheckpoints(self):
-        self._toilSort(jobStore=self._getTestJobStorePath(), batchSystem='singleMachine', retryCount=2, downCheckpoints=True)
+        self._toilSort(jobStoreLocator=self._getTestJobStorePath(), batchSystem='singleMachine', retryCount=2, downCheckpoints=True)
 
     def testFileSingle10000(self):
-        self._toilSort(jobStore=self._getTestJobStorePath(), batchSystem='singleMachine',
+        self._toilSort(jobStoreLocator=self._getTestJobStorePath(), batchSystem='singleMachine',
                        lines=10000, N=10000)
 
     @needs_gridengine
     @unittest.skip('Gridengine does not support shared caching')
     def testFileGridEngine(self):
-        self._toilSort(jobStore=self._getTestJobStorePath(), batchSystem='gridengine')
+        self._toilSort(jobStoreLocator=self._getTestJobStorePath(), batchSystem='gridengine')
 
     @needs_parasol
     @unittest.skip("skipping until parasol support is less flaky (see github issue #449")
     def testFileParasol(self):
         self._startParasol()
         try:
-            self._toilSort(jobStore=self._getTestJobStorePath(), batchSystem='parasol')
+            self._toilSort(jobStoreLocator=self._getTestJobStorePath(), batchSystem='parasol')
         finally:
             self._stopParasol()
 

--- a/src/toil/utils/toilClean.py
+++ b/src/toil/utils/toilClean.py
@@ -40,7 +40,7 @@ def main():
                       "(If this is a file path this needs to be globally accessible "
                       "by all machines running jobs).\n"
                       "If the store already exists and restart is false an"
-                      " ExistingJobStoreException exception will be thrown."))
+                      " JobStoreCreationException exception will be thrown."))
     parser.add_argument("--version", action='version', version=version)
     options = parseBasicOptions(parser)
     logger.info("Parsed arguments")

--- a/src/toil/utils/toilKill.py
+++ b/src/toil/utils/toilKill.py
@@ -33,7 +33,7 @@ def main():
               "(If this is a file path this needs to be globally accessible "
               "by all machines running jobs).\n"
               "If the store already exists and restart is false an"
-              " ExistingJobStoreException exception will be thrown."))
+              " JobStoreCreationException exception will be thrown."))
     parser.add_argument("--version", action='version', version=version)
     options = parseBasicOptions(parser)
 

--- a/src/toil/utils/toilStats.py
+++ b/src/toil/utils/toilStats.py
@@ -65,7 +65,7 @@ def initializeOptions(parser):
               "(If this is a file path this needs to be globally accessible "
               "by all machines running jobs).\n"
               "If the store already exists and restart is false an"
-              " ExistingJobStoreException exception will be thrown."))
+              " JobStoreCreationException exception will be thrown."))
     parser.add_argument("--outputFile", dest="outputFile", default=None,
                       help="File in which to write results")
     parser.add_argument("--raw", action="store_true", default=False,

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -47,7 +47,7 @@ def main():
               "(If this is a file path this needs to be globally accessible "
               "by all machines running jobs).\n"
               "If the store already exists and restart is false an"
-              " ExistingJobStoreException exception will be thrown."))
+              " JobStoreCreationException exception will be thrown."))
     
     parser.add_argument("--verbose", dest="verbose", action="store_true",
                       help="Print loads of information, particularly all the log files of \

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -81,14 +81,14 @@ def main():
     #Input args
     ##########################################
     
-    jobStoreString = sys.argv[1]
+    jobStoreLocator = sys.argv[1]
     jobStoreID = sys.argv[2]
     
     ##########################################
     #Load the jobStore/config file
     ##########################################
     
-    jobStore = Toil.loadOrCreateJobStore(jobStoreString)
+    jobStore = Toil.loadOrCreateJobStore(jobStoreLocator)
     config = jobStore.config
     
     ##########################################


### PR DESCRIPTION
Job store string has now been refactored completely. The syntax for each job store locator has been documented in the job store option help message. Minor corrections to outdated documentation have also been made.