### PR TITLE
Retry on certain errors during HTTP imports (resolves #1010)

### DIFF
--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -378,7 +378,7 @@ class AbstractJobStoreTest:
                 logger.info('Cleaning up external store for %s.', test)
                 test._cleanUpExternalStore(store)
 
-        mpTestPartSize = 5 * 2 ** 20
+        mpTestPartSize = 5 << 20
 
         @classmethod
         def makeImportExportTests(cls):
@@ -448,15 +448,11 @@ class AbstractJobStoreTest:
                        otherCls=activeTestClassesByName)
 
         def testImportHttpFile(self):
-            # Prepare random file for import
-            self.master.partSize = self.mpTestPartSize
-            srcUrl = 'https://raw.githubusercontent.com/BD2KGenomics/toil/master/Makefile'
-            srcHash = hashlib.md5(urllib2.urlopen(srcUrl).read()).hexdigest()
-            # test import
-            jobStoreFileID = self.master.importFile(srcUrl)
-            with self.master.readFileStream(jobStoreFileID) as f:
-                fileMD5 = hashlib.md5(f.read()).hexdigest()
-            self.assertEqual(fileMD5, srcHash)
+            srcUrl, srcHash = ('https://raw.githubusercontent.com/BD2KGenomics/toil'
+                               '/12c711ff91caa5d8fb37a072bad376f447faa797/Makefile',
+                               '16a38fd7ae233616083d43d81159d4e8')
+            with self.master.readFileStream(self.master.importFile(srcUrl)) as f:
+                self.assertEqual(hashlib.md5(f.read()).hexdigest(), srcHash)
 
         def testFileDeletion(self):
             """


### PR DESCRIPTION
HTTP import now uses ```shutil.copyfilobj``` and uses the general retry functionality in job store utils. 