### PR TITLE
Removed registry from Azure job store (resolves #975)

### DIFF
--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -936,6 +936,11 @@ class AzureJobStoreTest(AbstractJobStoreTest.Test):
         self.assertIsNot(job1, job2)
         self.assertEqual(job2.command, command)
 
+    def testJobStoreExists(self):
+        self.assertTrue(self.master._jobStoreExists())
+        self.master.deleteJobStore()
+        self.assertFalse(self.master._jobStoreExists())
+
     def _prepareTestFile(self, containerName, size=None):
         from toil.jobStores.azureJobStore import _fetchAzureAccountKey
         from azure.storage.blob import BlobService


### PR DESCRIPTION
A new jobStoreExists method is used to test for existence. A unit test has been added for the new method.