### PR TITLE
Prevents exception masking in Toil context manager (resolves #921)

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -490,15 +490,21 @@ class Toil(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
-        Clean up after a workflow invocaton. Depending on the configuration, delete the job store.
+        Clean up after a workflow invocation. Depending on the configuration, delete the job store.
         """
+        try:
+            if (exc_type is not None and self.config.clean == "onError" or
+                            exc_type is None and self.config.clean == "onSuccess" or
+                        self.config.clean == "always"):
+                logger.info("Attempting to delete the job store")
+                self._jobStore.deleteJobStore()
+                logger.info("Successfully deleted the job store")
+        except Exception as e:
+            if exc_type is None:
+                raise
+            else:
+                logger.exception('The following error was raised during clean up:')
         self._inContextManager = False
-        if (exc_type is not None and self.config.clean == "onError" or
-                        exc_type is None and self.config.clean == "onSuccess" or
-                    self.config.clean == "always"):
-            logger.info("Attempting to delete the job store")
-            self._jobStore.deleteJobStore()
-            logger.info("Successfully deleted the job store")
         return False  # let exceptions through
 
     def start(self, rootJob):


### PR DESCRIPTION
Resolves #921

Secondary exceptions raised in  the ```__exit__``` method of the Toil context manger can mask a primary exception. This has been fixed with a simple try except block.