### PR TITLE
Improve logging message for filestore CWL runs

### DIFF
--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -120,6 +120,33 @@ class SingleMachineBatchSystem(BatchSystemSupport):
             self.workerThreads.append(worker)
             worker.start()
 
+    def _getDebugCmd(self, jobCommand):
+        """Calculate useful debugging command line, handling CWL runs.
+
+        Tries to print out underlying CWL base command being run if possible,
+        otherwise defaulting to the toil jobCommand.
+        """
+        debug_cmd = jobCommand
+        cmd_args = jobCommand.split()
+        if len(cmd_args) == 3 and cmd_args[0] == "_toil_worker":
+            _, job_store_locator, job_store_id = cmd_args
+            if job_store_locator.startswith("file:") or os.path.exists(job_store_locator):
+                import cPickle
+                import marshal as pickler
+                job_store_locator = job_store_locator.replace("file:", "")
+                job_cmd_file = os.path.join(job_store_locator, "tmp", job_store_id, "job")
+                with open(job_cmd_file) as in_handle:
+                    job = pickler.load(in_handle)
+                if job.get("command"):
+                    command_parts = job["command"].split()
+                    input_pickle_file = os.path.join(job_store_locator, "tmp", command_parts[1])
+                    with open(input_pickle_file) as in_handle:
+                        input = cPickle.load(in_handle)
+                    if (hasattr(input, "cwltool") and hasattr(input.cwltool, "tool")
+                            and "baseCommand" in input.cwltool.tool):
+                        debug_cmd = " ".join(input.cwltool.tool["baseCommand"])
+        return debug_cmd
+
     # Note: The input queue is passed as an argument because the corresponding attribute is reset
     # to None in shutdown()
 
@@ -141,7 +168,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
                                   jobCores)
                         with self.coreFractions.acquisitionOf(coreFractions):
                             with self.disk.acquisitionOf(jobDisk):
-                                log.info("Executing command: '%s'.", jobCommand)
+                                log.info("Executing command: '%s'.", self._getDebugCmd(jobCommand))
                                 startTime = time.time() #Time job is started
                                 with self.popenLock:
                                     popen = subprocess.Popen(jobCommand,


### PR DESCRIPTION
The output logging messages when running cwltoil pipelines were generic
references to jobstore directories, making it hard for users to
determine which stage of the pipeline was running. This fixes in two
ways:

- Moves references to internal file deletion to debug, instead of info.
- Handles the case where we're running CWL-based runs with filesystem
  storage, reading the underlying CWL and providing a useful logging
  message from the baseCommand.

This is an attempt to improve the logging output during cwltoil runs to make it easier for users to identify what stage of the pipeline they were at. In the previous iteration, users could tell jobs were running but had little insight into the current step since all the outputs are references to `_toil_worker` commands, internal jobstore IDs and cleanup of files:
```
Executing command: '_toil_worker /home/chapmanb/drive/work/cwl/test_bcbio_cwl/cwltoil_work/cwltoil_jobstore l/1/jobt5ZNIZ'.
Got message from job at time 07-05-2016 10:34:15: Successfully deleted local copies of file with ID 'k/K/tmpABzeZz.tmp'.
Got message from job at time 07-05-2016 10:34:15: Successfully deleted local copies of file with ID 'T/u/tmpC8PsBX.tmp'.
Executing command: '_toil_worker /home/chapmanb/drive/work/cwl/test_bcbio_cwl/cwltoil_work/cwltoil_jobstore v/i/jobxQaXXO'.
```
After the change, the output looks like:
```
Executing command: 'bcbio_nextgen.py runfn prep_samples cwl'.
Executing command: 'bcbio_nextgen.py runfn prep_align_inputs cwl'.
Jobstore directory is: /home/chapmanb/drive/work/cwl/test_bcbio_cwl/cwltoil_work/cwltoil_jobstore
Executing command: '_toil_worker file:/home/chapmanb/drive/work/cwl/test_bcbio_cwl/cwltoil_work/cwltoil_jobstore K/2/jobVgjucx'.
Executing command: '_toil_worker file:/home/chapmanb/drive/work/cwl/test_bcbio_cwl/cwltoil_work/cwltoil_jobstore 6/n/job2ND5wI'.
Executing command: 'bcbio_nextgen.py runfn process_alignment cwl'.
Executing command: 'bcbio_nextgen.py runfn process_alignment cwl'.
```
I'm happy for suggestions to make this better and more generalized. Right now it would only work for filesystem-based JobStores and CWL runs. I was not able to understand the abstractions to know the best way to get these commands for all cases so it will fall back to the previous method where it is not these cases. You can see that behavior in the new example above where it falls back to the old method when executing non CWLTool commands (like workflows and scatter operations). Thanks much for looking at this.