### PR TITLE
CWL: test update and fixes for v1.0 support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,8 @@ Toil is a workflow engine entirely written in Python. It features:
 
 * `Common Workflow Language`_ (`CWL`_) support
 
-  Complete support for the draft-3 CWL specification, allowing it to execute
-  CWL workflows.
+  Nearly complete support for the stable CWL v1.0 specification,
+  allowing it to execute CWL workflows.
 
 * Cross platform support
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -44,11 +44,24 @@ workflows that are portable across multiple workflow engines and platforms.  To
 run workflows written using CWL, first ensure that Toil is installed with the
 "cwl" extra as described in :ref:`installation-ref`.  This will install the
 executables ``cwl-runner`` and ``cwltoil`` (these are identical, where
-``cwl-runner`` is the portable name for the default system CWL runner).  To
-learn more about CWL, see the `CWL User Guide`_.
+``cwl-runner`` is the portable name for the default system CWL runner).
 
-To run in local batch mode, simply provide the CWL file and the input object
-file::
+To learn more about CWL, see the `CWL User Guide`_. Toil has nearly full support
+for the stable v1.0 specification, only lacking the following features:
+
+- `Directory <http://www.commonwl.org/v1.0/CommandLineTool.html#Directory>`_
+  inputs and outputs in pipelines. Currently you need to enumerate directory
+  inputs as Files.
+- `InitialWorkDirRequirement
+  <http://www.commonwl.org/v1.0/CommandLineTool.html#InitialWorkDirRequirement>`_
+  to create files together within a specific work directory. Collecting
+  associated files using `secondaryFiles
+  <http://www.commonwl.org/v1.0/CommandLineTool.html#CommandInputParameter>`_ is
+  a good workaround.
+- `File literals <http://www.commonwl.org/v1.0/CommandLineTool.html#File>`_ that
+  specify only ``contents`` to a File without an explicit file name.
+
+To run in local batch mode, provide the CWL file and the input object file::
 
     cwltoil example.cwl example-job.yml
 
@@ -57,7 +70,7 @@ command line parameters to select and configure the batch system to use.
 Consult the appropriate sections.
 
 .. _Common Workflow Language: http://commonwl.org
-.. _CWL User Guide: http://commonwl.org/draft-3/UserGuide.html
+.. _CWL User Guide: http://www.commonwl.org/v1.0/UserGuide.html
 
 .. _runningDetail:
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
             'gcs_oauth2_boto_plugin==1.9',
             botoRequirement],
         'cwl': [
-            'cwltool==1.0.20160712154127']},
+            'cwltool==1.0.20160714182449']},
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=['*.test']),
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
             'gcs_oauth2_boto_plugin==1.9',
             botoRequirement],
         'cwl': [
-            'cwltool==1.0.20160427142240']},
+            'cwltool==1.0.20160708190014']},
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=['*.test']),
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
             'gcs_oauth2_boto_plugin==1.9',
             botoRequirement],
         'cwl': [
-            'cwltool==1.0.20160708190014']},
+            'cwltool==1.0.20160712154127']},
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=['*.test']),
     entry_points={

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -21,11 +21,13 @@ from toil.version import version
 from toil.lib.bioio import setLoggingFromOptions
 
 from argparse import ArgumentParser
+import cwltool.load_tool
 import cwltool.main
 import cwltool.workflow
 import cwltool.expression
 import cwltool.builder
-from cwltool.process import adjustFiles, shortname, adjustFilesWithSecondary, fillInDefaults
+from cwltool.pathmapper import adjustFiles
+from cwltool.process import shortname, adjustFilesWithSecondary, fillInDefaults
 from cwltool.utils import aslist
 import schema_salad.validate as validate
 import schema_salad.ref_resolver
@@ -165,6 +167,21 @@ def writeFile(writeFunc, index, x):
             raise
     return index[x]
 
+def locToPath(p):
+    """Back compatibility -- handle converting locations into paths.
+    """
+    if "path" not in p and "location" in p:
+        p["path"] = p["location"].replace("file:", "")
+
+def pathToLoc(p):
+    """Associate path with location.
+
+    v1.0 should be specifying location but older YAML uses path
+    provide back compatibility
+    """
+    if "path" in p:
+        p["location"] = p["path"]
+
 class ResolveIndirect(Job):
     def __init__(self, cwljob):
         super(ResolveIndirect, self).__init__()
@@ -211,11 +228,13 @@ class CWLJob(Job):
 
         # Run the tool
         output = cwltool.main.single_job_executor(self.cwltool, cwljob,
-                                                  os.getcwd(), None,
+                                                  basedir=os.getcwd(),
                                                   outdir=outdir,
                                                   tmpdir=tmpdir,
+                                                  tmpdir_prefix="tmp",
                                                   **self.executor_options)
-
+        cwltool.builder.adjustDirObjs(output, locToPath)
+        cwltool.builder.adjustFileObjs(output, locToPath)
         # Copy output files into the global file store.
         adjustFiles(output, functools.partial(writeFile, fileStore.writeGlobalFile, {}))
 
@@ -238,42 +257,36 @@ class CWLScatter(Job):
         super(CWLScatter, self).__init__()
         self.step = step
         self.cwljob = cwljob
-        self.valueFrom = {shortname(i["id"]): i["valueFrom"] for i in step.tool["inputs"] if "valueFrom" in i}
         self.executor_options = kwargs
 
-    def valueFromFunc(self, k, v):
-        if k in self.valueFrom:
-            return cwltool.expression.do_eval(self.valueFrom[k], self.vfinputs, self.step.requirements,
-                                              None, None, {}, context=v)
-        else:
-            return v
-
-    def flat_crossproduct_scatter(self, joborder, scatter_keys, outputs):
+    def flat_crossproduct_scatter(self, joborder, scatter_keys, outputs, postScatterEval):
         scatter_key = shortname(scatter_keys[0])
         l = len(joborder[scatter_key])
         for n in xrange(0, l):
             jo = copy.copy(joborder)
-            jo[scatter_key] = self.valueFromFunc(scatter_key, joborder[scatter_key][n])
+            jo[scatter_key] = joborder[scatter_key][n]
             if len(scatter_keys) == 1:
+                jo = postScatterEval(jo)
                 (subjob, followOn) = makeJob(self.step.embedded_tool, jo, **self.executor_options)
                 self.addChild(subjob)
                 outputs.append(followOn.rv())
             else:
-                self.flat_crossproduct_scatter(jo, scatter_keys[1:], outputs)
+                self.flat_crossproduct_scatter(jo, scatter_keys[1:], outputs, postScatterEval)
 
-    def nested_crossproduct_scatter(self, joborder, scatter_keys):
+    def nested_crossproduct_scatter(self, joborder, scatter_keys, postScatterEval):
         scatter_key = shortname(scatter_keys[0])
         l = len(joborder[scatter_key])
         outputs = []
         for n in xrange(0, l):
             jo = copy.copy(joborder)
-            jo[scatter_key] = self.valueFromFunc(scatter_key, joborder[scatter_key][n])
+            jo[scatter_key] = joborder[scatter_key][n]
             if len(scatter_keys) == 1:
+                jo = postScatterEval(jo)
                 (subjob, followOn) = makeJob(self.step.embedded_tool, jo, **self.executor_options)
                 self.addChild(subjob)
                 outputs.append(followOn.rv())
             else:
-                outputs.append(self.nested_crossproduct_scatter(jo, scatter_keys[1:]))
+                outputs.append(self.nested_crossproduct_scatter(jo, scatter_keys[1:], postScatterEval))
         return outputs
 
     def run(self, fileStore):
@@ -289,25 +302,33 @@ class CWLScatter(Job):
             scatterMethod = "dotproduct"
         outputs = []
 
-        self.vfinputs = cwljob
+        valueFrom = {i["id"]: i["valueFrom"] for i in self.step.tool["inputs"] if "valueFrom" in i}
+        def postScatterEval(io):
+            shortio = {shortname(k): v for k, v in io.iteritems()}
+            def valueFromFunc(k, v):
+                if k in valueFrom:
+                    return cwltool.expression.do_eval(
+                            valueFrom[k], shortio, self.step.requirements,
+                            None, None, {}, context=v)
+                else:
+                    return v
+            return {k: valueFromFunc(k, v) for k,v in io.items()}
 
-        shortscatter = [shortname(s) for s in scatter]
-        cwljob = {k: self.valueFromFunc(k, v) if k not in shortscatter else v
-                    for k,v in cwljob.items()}
 
         if scatterMethod == "dotproduct":
             for i in xrange(0, len(cwljob[shortname(scatter[0])])):
                 copyjob = copy.copy(cwljob)
-                for sc in scatter:
-                    scatter_key = shortname(sc)
-                    copyjob[scatter_key] = self.valueFromFunc(scatter_key, cwljob[scatter_key][i])
+                for sc in [shortname(x) for x in scatter]:
+                    copyjob[sc] = cwljob[sc][i]
+                import pprint
+                copyjob = postScatterEval(copyjob)
                 (subjob, followOn) = makeJob(self.step.embedded_tool, copyjob, **self.executor_options)
                 self.addChild(subjob)
                 outputs.append(followOn.rv())
         elif scatterMethod == "nested_crossproduct":
-            outputs = self.nested_crossproduct_scatter(cwljob, scatter)
+            outputs = self.nested_crossproduct_scatter(cwljob, scatter, postScatterEval)
         elif scatterMethod == "flat_crossproduct":
-            self.flat_crossproduct_scatter(cwljob, scatter, outputs)
+            self.flat_crossproduct_scatter(cwljob, scatter, outputs, postScatterEval)
         else:
             if scatterMethod:
                 raise validate.ValidationException(
@@ -485,7 +506,7 @@ class CWLWorkflow(Job):
 
         outobj = {}
         for out in self.cwlwf.tool["outputs"]:
-            outobj[shortname(out["id"])] = (shortname(out["source"]), promises[out["source"]].rv())
+            outobj[shortname(out["id"])] = (shortname(out["outputSource"]), promises[out["outputSource"]].rv())
 
         return IndirectDict(outobj)
 
@@ -545,9 +566,7 @@ def main(args=None, stdout=sys.stdout):
     uri = options.cwljob if urlparse.urlparse(options.cwljob).scheme else "file://" + os.path.abspath(options.cwljob)
 
     try:
-        t = cwltool.main.load_tool(options.cwltool, False, True,
-                                   cwltool.workflow.defaultMakeTool,
-        True)
+        t = cwltool.load_tool.load_tool(options.cwltool, cwltool.workflow.defaultMakeTool)
     except cwltool.process.UnsupportedRequirement as e:
         logging.error(e)
         return 33
@@ -560,6 +579,8 @@ def main(args=None, stdout=sys.stdout):
         loader = schema_salad.ref_resolver.Loader(jobloaderctx)
 
     job, _ = loader.resolve_ref(uri)
+    cwltool.builder.adjustDirObjs(job, pathToLoc)
+    cwltool.builder.adjustFileObjs(job, pathToLoc)
 
     if type(t) == int:
         return t
@@ -569,7 +590,8 @@ def main(args=None, stdout=sys.stdout):
     if options.conformance_test:
         adjustFiles(job, lambda x: x.replace("file://", ""))
         stdout.write(json.dumps(
-            cwltool.main.single_job_executor(t, job, options.basedir, options,
+            cwltool.main.single_job_executor(t, job, basedir=options.basedir,
+                                             tmpdir_prefix="tmp",
                                              conformance_test=True, use_container=use_container,
                                              preserve_environment=options.preserve_environment), indent=4))
         return 0
@@ -581,14 +603,22 @@ def main(args=None, stdout=sys.stdout):
 
     with Toil(options) as toil:
         def importDefault(tool):
+            cwltool.builder.adjustDirObjs(tool, locToPath)
+            cwltool.builder.adjustFileObjs(tool, locToPath)
             adjustFiles(tool, lambda x: "file://%s" % x if not urlparse.urlparse(x).scheme else x)
             adjustFiles(tool, functools.partial(writeFile, toil.importFile, {}))
             return tool
         t.visit(importDefault)
 
-        builder = t._init_job(job, os.path.dirname(os.path.abspath(options.cwljob)))
+        basedir = os.path.dirname(os.path.abspath(options.cwljob))
+        builder = t._init_job(job, basedir=basedir)
         (wf1, wf2) = makeJob(t, {}, use_container=use_container, preserve_environment=options.preserve_environment)
-        adjustFiles(builder.job, lambda x: "file://%s" % x if not urlparse.urlparse(x).scheme else x)
+        cwltool.builder.adjustDirObjs(builder.job, locToPath)
+        cwltool.builder.adjustFileObjs(builder.job, locToPath)
+        adjustFiles(builder.job, lambda x: "file://%s" % os.path.abspath(os.path.join(basedir, x))
+                    if not urlparse.urlparse(x).scheme else x)
+        cwltool.builder.adjustDirObjs(builder.job, pathToLoc)
+        cwltool.builder.adjustFileObjs(builder.job, pathToLoc)
         adjustFiles(builder.job, functools.partial(writeFile, toil.importFile, {}))
         wf1.cwljob = builder.job
 

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -31,6 +31,8 @@ class CWLTest(ToilTest):
                             os.path.join(rootDir, jobfile)],
                      stdout=st)
         out = json.loads(st.getvalue())
+        # locations are internal objects in output for CWL
+        out["output"].pop("location", None)
         self.assertEquals(out, expect)
 
     def test_run_revsort(self):
@@ -42,6 +44,7 @@ class CWLTest(ToilTest):
             # less noisy diff in case the assertion fails.
             u'output': {
                 u'path': unicode(os.path.join(outDir, 'output.txt')),
+                u'basename': unicode("output.txt"),
                 u'size': 1111,
                 u'class': u'File',
                 u'checksum': u'sha1$b9214658cc453331b62c2282b772a5c063dbd284'}})
@@ -54,6 +57,6 @@ class CWLTest(ToilTest):
             subprocess.call(["git", "fetch"], cwd=cwlSpec)
         else:
             subprocess.check_call(["git", "clone", "https://github.com/common-workflow-language/common-workflow-language.git", cwlSpec])
-        subprocess.check_call(["git", "checkout", "4daac6db94ccf626c4509fe0c3e645ceda23f50a"], cwd=cwlSpec)
+        subprocess.check_call(["git", "checkout", "c256c08247dc4feded93e5103a503c5459a8315e"], cwd=cwlSpec)
         subprocess.check_call(["git", "clean", "-f", "-x", "."], cwd=cwlSpec)
-        subprocess.check_call(["./run_test.sh", "RUNNER=cwltoil", "DRAFT=draft-3"], cwd=cwlSpec)
+        subprocess.check_call(["./run_test.sh", "RUNNER=cwltoil", "DRAFT=v1.0"], cwd=cwlSpec)

--- a/src/toil/test/cwl/revsort.cwl
+++ b/src/toil/test/cwl/revsort.cwl
@@ -2,13 +2,13 @@
 # This is a two-step workflow which uses "revtool" and "sorttool" defined above.
 #
 class: Workflow
-description: "Reverse the lines in a document, then sort those lines."
-cwlVersion: "cwl:draft-3"
+doc: "Reverse the lines in a document, then sort those lines."
+cwlVersion: v1.0
 
-# Requirements specify prerequisites and extensions to the workflow.
+# Requirements & hints specify prerequisites and extensions to the workflow.
 # In this example, DockerRequirement specifies a default Docker container
 # in which the command line tools will execute.
-requirements:
+hints:
   - class: DockerRequirement
     dockerPull: debian:8
 
@@ -20,13 +20,13 @@ requirements:
 # field "reverse_sort" is not provided in the input object, the default value will
 # be used.
 inputs:
-  - id: "#input"
+  input:
     type: File
-    description: "The input file to be processed."
-  - id: "#reverse_sort"
+    doc: "The input file to be processed."
+  reverse_sort:
     type: boolean
     default: true
-    description: "If true, reverse (decending) sort"
+    doc: "If true, reverse (decending) sort"
 
 # The "outputs" array defines the structure of the output object that describes
 # the outputs of the workflow.
@@ -35,10 +35,10 @@ inputs:
 # steps using the "connect" field.  Here, the parameter "#output" of the
 # workflow comes from the "#sorted" output of the "sort" step.
 outputs:
-  - id: "#output"
+  output:
     type: File
-    source: "#sorted.output"
-    description: "The output with the lines reversed and sorted."
+    outputSource: sorted/output
+    doc: "The output with the lines reversed and sorted."
 
 # The "steps" array lists the executable steps that make up the workflow.
 # The tool to execute each step is listed in the "run" field.
@@ -51,17 +51,15 @@ outputs:
 # parameter "#reversed" from the first step to the input parameter of the
 # tool "sorttool.cwl#input".
 steps:
-  - id: "#rev"
-    inputs:
-      - { id: "#rev.input", source: "#input" }
-    outputs:
-      - { id: "#rev.output" }
-    run: { "$import": revtool.cwl }
+  rev:
+    in:
+      input: input
+    out: [output]
+    run: revtool.cwl
 
-  - id: "#sorted"
-    inputs:
-      - { id: "#sorted.input", source: "#rev.output" }
-      - { id: "#sorted.reverse", source: "#reverse_sort" }
-    outputs:
-      - { id: "#sorted.output" }
-    run: { "$import": sorttool.cwl }
+  sorted:
+    in:
+      input: rev/output
+      reverse: reverse_sort
+    out: [output]
+    run: sorttool.cwl

--- a/src/toil/test/cwl/revtool.cwl
+++ b/src/toil/test/cwl/revtool.cwl
@@ -1,40 +1,37 @@
-    #
-    # Simplest example command line program wrapper for the Unix tool "rev".
-    #
-    class: CommandLineTool
-    description: "Reverse each line using the `rev` command"
+#
+# Simplest example command line program wrapper for the Unix tool "rev".
+#
+class: CommandLineTool
+cwlVersion: v1.0
+doc: "Reverse each line using the `rev` command"
 
-    requirements:
-      - class: ResourceRequirement
-        ramMax: 256
+# The "inputs" array defines the structure of the input object that describes
+# the inputs to the underlying program.  Here, there is one input field
+# defined that will be called "input" and will contain a "File" object.
+#
+# The input binding indicates that the input value should be turned into a
+# command line argument.  In this example inputBinding is an empty object,
+# which indicates that the file name should be added to the command line at
+# a default location.
+inputs:
+  input:
+    type: File
+    inputBinding: {}
 
-    # The "inputs" array defines the structure of the input object that describes
-    # the inputs to the underlying program.  Here, there is one input field
-    # defined that will be called "input" and will contain a "File" object.
-    #
-    # The input binding indicates that the input value should be turned into a
-    # command line argument.  In this example inputBinding is an empty object,
-    # which indicates that the file name should be added to the command line at
-    # a default location.
-    inputs:
-      - id: "#input"
-        type: File
-        inputBinding: {}
+# The "outputs" array defines the structure of the output object that
+# describes the outputs of the underlying program.  Here, there is one
+# output field defined that will be called "output", must be a "File" type,
+# and after the program executes, the output value will be the file
+# output.txt in the designated output directory.
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: output.txt
 
-    # The "outputs" array defines the structure of the output object that
-    # describes the outputs of the underlying program.  Here, there is one
-    # output field defined that will be called "output", must be a "File" type,
-    # and after the program executes, the output value will be the file
-    # output.txt in the designated output directory.
-    outputs:
-      - id: "#output"
-        type: File
-        outputBinding:
-          glob: output.txt
+# The actual program to execute.
+baseCommand: rev
 
-    # The actual program to execute.
-    baseCommand: rev
-
-    # Specify that the standard output stream must be redirected to a file called
-    # output.txt in the designated output directory.
-    stdout: output.txt
+# Specify that the standard output stream must be redirected to a file called
+# output.txt in the designated output directory.
+stdout: output.txt

--- a/src/toil/test/cwl/sorttool.cwl
+++ b/src/toil/test/cwl/sorttool.cwl
@@ -1,34 +1,35 @@
-    # Example command line program wrapper for the Unix tool "sort"
-    # demonstrating command line flags.
-    class: CommandLineTool
-    description: "Sort lines using the `sort` command"
+# Example command line program wrapper for the Unix tool "sort"
+# demonstrating command line flags.
+class: CommandLineTool
+doc: "Sort lines using the `sort` command"
+cwlVersion: v1.0
 
-    # This example is similar to the previous one, with an additional input
-    # parameter called "reverse".  It is a boolean parameter, which is
-    # intepreted as a command line flag.  The value of "prefix" is used for
-    # flag to put on the command line if "reverse" is true, if "reverse" is
-    # false, no flag is added.
-    #
-    # This example also introduced the "position" field.  This indicates the
-    # sorting order of items on the command line.  Lower numbers are placed
-    # before higher numbers.  Here, the "--reverse" flag (if present) will be
-    # added to the command line before the input file path.
-    inputs:
-      - id: "#reverse"
-        type: boolean
-        inputBinding:
-          position: 1
-          prefix: "--reverse"
-      - id: "#input"
-        type: File
-        inputBinding:
-          position: 2
+# This example is similar to the previous one, with an additional input
+# parameter called "reverse".  It is a boolean parameter, which is
+# intepreted as a command line flag.  The value of "prefix" is used for
+# flag to put on the command line if "reverse" is true, if "reverse" is
+# false, no flag is added.
+#
+# This example also introduced the "position" field.  This indicates the
+# sorting order of items on the command line.  Lower numbers are placed
+# before higher numbers.  Here, the "--reverse" flag (if present) will be
+# added to the command line before the input file path.
+inputs:
+  - id: reverse
+    type: boolean
+    inputBinding:
+      position: 1
+      prefix: "--reverse"
+  - id: input
+    type: File
+    inputBinding:
+      position: 2
 
-    outputs:
-      - id: "#output"
-        type: File
-        outputBinding:
-          glob: output.txt
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: output.txt
 
-    baseCommand: sort
-    stdout: output.txt
+baseCommand: sort
+stdout: output.txt


### PR DESCRIPTION
Update of #1050 which I messed up trying to rebase.

In progress work towards v1.0 support. Current status, failing 19 out of
72 unit tests.

- Apply path/location fixes globally, required for v1.0 support
  (which uses location) and back compatibility with CWL (which uses path).
- Adjusts imports to match cwltool reorganization changes
- Some functions use kwargs instead of default arguments
  (single_job_executor, _init_job).
- Changes from output to outputSource in job outputs.
- Start of work to improve scatter support for valueFrom by applying
  after scatter process. Still in progress.
- Update internal CWL revsort test to v1.0 syntax
- Update conformance test to v1.0