### PR TITLE
Shared caching: re-enable SLURM, SGE, LSF

### DIFF
--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -206,7 +206,7 @@ class GridengineBatchSystem(BatchSystemSupport):
 
     @classmethod
     def supportsWorkerCleanup(cls):
-        return False
+        return True
 
     @classmethod
     def supportsHotDeployment(cls):

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -129,7 +129,7 @@ class LSFBatchSystem(BatchSystemSupport):
     """
     @classmethod
     def supportsWorkerCleanup(cls):
-        return False
+        return True
 
     @classmethod
     def supportsHotDeployment(cls):

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -243,7 +243,7 @@ class SlurmBatchSystem(BatchSystemSupport):
 
     @classmethod
     def supportsWorkerCleanup(cls):
-        return False
+        return True
 
     @classmethod
     def supportsHotDeployment(cls):


### PR DESCRIPTION
The current version of Toil does not run CWL with batch schedulers like
SLURM, SGE, and LSF since the disableSharedCache flag has been removed
(https://github.com/BD2KGenomics/toil/pull/1032/files#diff-ec7c0fff4aad88175b4920cd3d1e5f8fR653).
Following the previous discussion (https://github.com/BD2KGenomics/toil/issues/928#issuecomment-223639111),
this enables these schedulers to work provided files are staged into a
shared filesystem directory, allowing Toil to work for these cases.