### PR TITLE
Add singleMachine disk tracking (resolves #770)

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -28,5 +28,5 @@ f=s.f_frsize * s.f_bavail
 sys.exit(1 if f < min_free_in_GiB << 30 else 0)
 "
 export TMPDIR
-make test tests=src/toil/test/batchSystems/batchSystemTest.py::SingleMachineBatchSystemJobTest
+make $make_targets
 rm -rf $TMPDIR

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -28,5 +28,5 @@ f=s.f_frsize * s.f_bavail
 sys.exit(1 if f < min_free_in_GiB << 30 else 0)
 "
 export TMPDIR
-make $make_targets
+make test tests=src/toil/test/batchSystems/batchSystemTest.py::SingleMachineBatchSystemJobTest
 rm -rf $TMPDIR

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -77,3 +77,12 @@ def physicalMemory():
         return os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
     except ValueError:
         return int(check_output(['sysctl', '-n', 'hw.memsize']).strip())
+
+
+def physicalDisk(config, toilWorkflowDir=None):
+    if toilWorkflowDir is None:
+        from toil.common import Toil
+        toilWorkflowDir = Toil.getWorkflowDir(config.workflowID, config.workDir)
+    diskStats = os.statvfs(toilWorkflowDir)
+    return diskStats.f_frsize * diskStats.f_bavail
+

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -352,5 +352,6 @@ class InsufficientSystemResources(Exception):
         self.resource = resource
 
     def __str__(self):
-        return 'Requesting more {} than available. Requested: {}, Available: {}' \
-               ''.format(self.resource, self.requested, self.available)
+        return 'Requesting more {} than either physically available, or enforced by --max{}. ' \
+               'Requested: {}, Available: {}'.format(self.resource, self.resource.capitalize(),
+                                                     self.requested, self.available)

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -284,7 +284,7 @@ class SingleMachineBatchSystemTest(hidden.AbstractBatchSystemTest):
 
     def createBatchSystem(self):
         return SingleMachineBatchSystem(config=self.config,
-                                        maxCores=numCores, maxMemory=1e9, maxDisk=1001)
+                                        maxCores=numCores, maxMemory=1e9, maxDisk=2001)
 
 
 class MaxCoresSingleMachineBatchSystemTest(ToilTest):


### PR DESCRIPTION
resolves #770 


Adding this to 3.3.1 as a patch to 3.3.0 will help @fnothaft overcome the "unable to free up enough space for caching" error in his pipeline.