### PR TITLE
disableCaching: avoid batch error message when set

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -681,7 +681,7 @@ class Toil(object):
         else:
             raise RuntimeError('Unrecognised batch system: %s' % config.batchSystem)
 
-        if not batchSystemClass.supportsWorkerCleanup():
+        if not config.disableCaching and not batchSystemClass.supportsWorkerCleanup():
             raise RuntimeError('%s currently does not support shared caching.  Set the '
                                '--disableCaching flag if you want to '
                                'use this batch system.' % config.batchSystem)


### PR DESCRIPTION
@cket @arkal @hannes-ucsc -- thank you for all the work on implementing disableCaching for the batch schedulers. I tested on SLURM and all works great with the exception of this small problem with the initial sanity checks. Thank you again for tackling this.

During testing of #1072 #1079, batch schedulers would error out with a
warning to add `--disableCaching` even when set. This corrects the check
to include the status of that flag.