### PR TITLE
Add native flags support for SLURM, via TOIL_SLURM_ARGS, (resolves issue #918)

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -87,3 +87,10 @@ Here are some additional useful arguments that don't fit into another category.
 * ``--sseKey`` accepts a path to a 32-byte key that is used for server-side encryption when using the AWS job store.
 * ``--cseKey`` accepts a path to a 256-bit key to be used for client-side encryption on Azure job store.
 * ``--setEnv <NAME=VALUE>`` sets an environment variable early on in the worker
+
+For implementation-specific flags for schedulers like timelimits, queues, accounts, etc.. An environment variable can be
+defined before launching the Job, i.e:
+
+```
+export TOIL_SLURM_ARGS="-t 1:00:00 -q fatq"
+```

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -193,6 +193,15 @@ class Worker(Thread):
         if cpu is not None:
             sbatch_line.append('--cpus-per-task={}'.format(int(math.ceil(cpu))))
 
+        # "Native extensions" for SLURM (see DRMAA or SAGA)
+        nativeConfig = os.getenv('TOIL_SLURM_ARGS')
+        if nativeConfig is not None:
+            logger.debug("Native SLURM options appended to sbatch from TOIL_SLURM_RESOURCES env. variable: {}".format(nativeConfig))
+            if "--mem" or "--cpus-per-task" in nativeConfig:
+                raise ValueError("Some resource arguments are incompatible: {}".format(nativeConfig))
+
+            sbatch_line.extend([nativeConfig])
+
         return sbatch_line
 
     def sbatch(self, sbatch_line):


### PR DESCRIPTION
This supports SLURM native flags in a similar way [SGE does](https://github.com/BD2KGenomics/toil/blob/master/src/toil/batchSystems/gridengine.py#L177).

This is hopefully a continuation and closer to closing issue #918 and siblings.

@chapmanb 