### PR TITLE
GridEngine: adjust qsub with TOIL_GRIDENGINE_ARGS

### DIFF
--- a/docs/batchSystem.rst
+++ b/docs/batchSystem.rst
@@ -4,9 +4,22 @@ The batch system interface
 ==========================
 
 The batch system interface is used by Toil to abstract over different ways of running
-batches of jobs, for example GridEngine, Mesos, Parasol and a single node. The 
+batches of jobs, for example Slurm, GridEngine, Mesos, Parasol and a single node. The 
 :class:`toil.batchSystems.abstractBatchSystem.AbstractBatchSystem` API is implemented to
 run jobs using a given job management system, e.g. Mesos.
+
+Environmental variables allow passing of scheduler specific parameters. 
+
+For SLURM::
+
+    export TOIL_SLURM_ARGS="-t 1:00:00 -q fatq"
+
+For GridEngine (SGE, UGE), there is an additional environmental variable to define the
+`parallel environment <https://blogs.oracle.com/templedf/entry/configuring_a_new_parallel_environment>`_
+for running multicore jobs::
+
+    export TOIL_GRIDENGINE_PE='smp'
+    export TOIL_GRIDENGINE_ARGS='-q batch.q'
 
 .. autoclass:: toil.batchSystems.abstractBatchSystem::AbstractBatchSystem
    :members:  

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -544,6 +544,12 @@ class GridEngineBatchSystemTest(hidden.AbstractBatchSystemTest):
         return GridengineBatchSystem(config=self.config, maxCores=numCores, maxMemory=1000e9,
                                      maxDisk=1e9)
 
+    def tearDown(self):
+        super(GridEngineBatchSystemTest, self).tearDown()
+        # Cleanup Gridengine output log file from qsub
+        from glob import glob
+        for f in glob('toil_job*.o*'):
+            os.unlink(f)
 
 @needs_slurm
 class SlurmBatchSystemTest(hidden.AbstractBatchSystemTest):


### PR DESCRIPTION
- Provides support for specifying TOIL_GRIDENGINE_ARGS to pass
  queue and other information to qsub. Environmental variable
  approach synchronized with #1101
- Documentation on environmental variables
- Fix and allows debugging on qsub command line. Previous version
  was missing -V so would not pass through environmental variables, and
  also swallowed all qsub error output making it hard to debug problems.

SGE with cwltoil works cleanly with these improvements.