### PR TITLE
Eliminate double autoscaling by fixing issued job code (resolves #1086)

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -355,6 +355,12 @@ def _addOptions(addGroupFn, config):
     addOptionFn("--scaleInterval", dest="scaleInterval", default=None,
                 help=("The interval (seconds) between assessing if the scale of"
                       " the cluster needs to change. default=%s" % config.scaleInterval))
+    addOptionFn("--slackPreemptablePreference", dest="slackPreemptablePreference",
+                default=None,
+                help=("The preference for the autoscaler to replace non-preemptable nodes"
+                      " with preemptable nodes, when preemptable nodes cannot be started."
+                      " Defaults to %s. This value must be between 0 and 1,"
+                      " inclusive." % config.slackPreemptablePreference))
 
     #
     #Resource requirements

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -77,6 +77,7 @@ class Config(object):
         self.alphaPacking = 0.8
         self.betaInertia = 1.2
         self.scaleInterval = 10
+        self.slackPreemptablePreference = 0.0
 
         #Resource requirements
         self.defaultMemory = 2147483648
@@ -195,6 +196,7 @@ class Config(object):
         setOption("alphaPacking", float)
         setOption("betaInertia", float)
         setOption("scaleInterval", float)
+        setOption("slackPreemptablePreference", float)
 
         #Resource requirements
         setOption("defaultMemory", h2b, iC(1))

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -28,6 +28,14 @@ from toil.provisioners.abstractProvisioner import AbstractProvisioner, Shape
 
 logger = logging.getLogger(__name__)
 
+# slack exists when we have more jobs that can run on preemptable nodes than
+# we have preemptable nodes. in order to not block these jobs, we want to scale
+# up the number of non-preemptable nodes that we have. however, we may still
+# prefer waiting for preemptable instances to come available.
+#
+# to accomodate this, we set the slack to the delta between requested and
+# provisioned preemptable nodes times a preemptible node preference factor.
+_preemptableQueueSlack = 0
 
 class RecentJobShapes(object):
     """
@@ -282,6 +290,10 @@ class ScalerThread(ExceptionalThread):
         self.maxNodes = scaler.config.maxPreemptableNodes if preemptable else scaler.config.maxNodes
 
     def tryRun(self):
+
+        # we will make reference to the global preemptable slack variable
+        global _preemptableQueueSlack
+
         if isinstance(self.scaler.jobBatcher.batchSystem, AbstractScalableBatchSystem):
             totalNodes = len(self.scaler.jobBatcher.batchSystem.getNodes(self.preemptable))
         else:
@@ -292,6 +304,12 @@ class ScalerThread(ExceptionalThread):
                 # Calculate the approx. number nodes needed
                 # TODO: Correct for jobs already running which can be considered fractions of a job
                 queueSize = self.scaler.jobBatcher.getNumberOfJobsIssued(preemptable=self.preemptable)
+
+                # if we're in the non-preemptable queue, we need to see if we have any slack
+                # coming over from the preemptable queue
+                if not self.preemptable:
+                    queueSize += _preemptableQueueSlack
+
                 recentJobShapes = self.jobShapes.get()
                 assert len(recentJobShapes) > 0
                 nodesToRunRecentJobs = binPacking(recentJobShapes, self.nodeShape)
@@ -331,6 +349,26 @@ class ScalerThread(ExceptionalThread):
                                 estimatedNodes)
                     totalNodes = self.scaler.provisioner.setNodeCount(numNodes=estimatedNodes,
                                                                       preemptable=self.preemptable)
+                    
+                    # if we were scaling up the number of preemptable nodes and failed to
+                    # meet our target, we need to update the slack so that non-preemptable
+                    # nodes will be allocated and we won't block. if we _did_ meet our target,
+                    # we need to reset the slack to 0
+                    if totalNodes < estimatedNodes and self.preemptable:
+                        
+                        # slack is derived from the delta (the number of nodes we did _not_ allocate)
+                        # times a preference for preemptable nodes
+                        require(self.scaler.config.slackPreemptablePreference >= 0.0 and
+                                self.scaler.config.slackPreemptablePreference <= 1.0,
+                                "Slack preference for preemptable nodes (%f) must be >= 0.0 and <= 1.0" % self.scaler.config.slackPreemptablePreference)
+                        nonPreemptablePreference = 1.0 - self.scaler.config.slackPreemptablePreference
+                        delta = estimatedNodes - totalNodes
+                        _preemptableQueueSlack = int(round(delta * nonPreemptablePreference))
+                        logger.debug('Had delta of %d, setting slack to %d.',
+                                     delta, _preemptableQueueSlack)
+                    else:
+                        _preemptableQueueSlack = 0
+                    
         logger.info('Forcing provisioner to reduce cluster size to zero.')
         totalNodes = self.scaler.provisioner.setNodeCount(numNodes=0,
                                                           preemptable=self.preemptable,

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -291,7 +291,7 @@ class ScalerThread(ExceptionalThread):
             with throttle(self.scaler.config.scaleInterval):
                 # Calculate the approx. number nodes needed
                 # TODO: Correct for jobs already running which can be considered fractions of a job
-                queueSize = self.scaler.jobBatcher.getNumberOfJobsIssued()
+                queueSize = self.scaler.jobBatcher.getNumberOfJobsIssued(preemptable=self.preemptable)
                 recentJobShapes = self.jobShapes.get()
                 assert len(recentJobShapes) > 0
                 nodesToRunRecentJobs = binPacking(recentJobShapes, self.nodeShape)

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -361,13 +361,13 @@ class ScalerThread(ExceptionalThread):
                     # meet our target, we need to update the slack so that non-preemptable
                     # nodes will be allocated and we won't block. if we _did_ meet our target,
                     # we need to reset the slack to 0
-                    if totalNodes < estimatedNodes and self.preemptable:
-                        
-                        # slack is derived from the delta (the number of nodes we did _not_ allocate)
-                        _delta = estimatedNodes - totalNodes
-                        logger.debug('Preemptable thread had delta of %d.', _delta)
-                    else:
-                        _delta = 0
+                    if self.preemptable:
+                        if totalNodes < estimatedNodes:
+                            # slack is derived from the delta (the number of nodes we did _not_ allocate)
+                            _delta = estimatedNodes - totalNodes
+                            logger.debug('Preemptable thread had delta of %d.', _delta)
+                        else:
+                            _delta = 0
                     
         logger.info('Forcing provisioner to reduce cluster size to zero.')
         totalNodes = self.scaler.provisioner.setNodeCount(numNodes=0,

--- a/src/toil/test/provisioners/cgcloud/provisionerTest.py
+++ b/src/toil/test/provisioners/cgcloud/provisionerTest.py
@@ -97,10 +97,6 @@ class AbstractCGCloudProvisionerTest(ToilTest, CgcloudTestCase):
     instanceType = 'm3.large'
     leaderInstanceType = instanceType
 
-    # The spot bid to use for preemptable instances. A safe bet is the on-demand price for the
-    # selected instance type.
-    spotBid = '0.133'
-
     @classmethod
     def setUpClass(cls):
         logging.basicConfig(level=logging.INFO)
@@ -135,7 +131,11 @@ class AbstractCGCloudProvisionerTest(ToilTest, CgcloudTestCase):
             os.environ['CGCLOUD_PLUGINS'] = self.saved_cgcloud_plugins
         super(AbstractCGCloudProvisionerTest, self).tearDown()
 
-    def _test(self, autoScaled=False, spotInstances=False):
+    def _test(self,
+              autoScaled=False,
+              spotInstances=False,
+              spotBid = '0.133',
+              slackPreference=None):
         self.assertTrue(not spotInstances or autoScaled,
                         'This test does not support a static cluster of spot instances.')
         if self.createCluster:
@@ -169,11 +169,14 @@ class AbstractCGCloudProvisionerTest(ToilTest, CgcloudTestCase):
                                     '--logDebug'])
             if spotInstances:
                 toilOptions.extend([
-                    '--preemptableNodeType=%s:%s' % (self.instanceType, self.spotBid),
+                    '--preemptableNodeType=%s:%s' % (self.instanceType, spotBid),
                     # The RNASeq pipeline does not specify a preemptability requirement so we
                     # need to specify a default, otherwise jobs would never get scheduled.
                     '--defaultPreemptable',
                     '--maxPreemptableNodes=%s' % self.numWorkers])
+
+            if slackPreference:
+                toilOptions.extend(['--slackPreemptablePreference', slackPreference])
 
             self._runScript(toilOptions)
 
@@ -296,3 +299,25 @@ class CGCloudRNASeqTest(AbstractCGCloudProvisionerTest):
     @integrative
     def testAutoScaledSpotCluster(self):
         self._test(autoScaled=True, spotInstances=True)
+
+    @integrative
+    def testAutoScaledSpotClusterWithLowSlack(self):
+        # the spot market should never fulfill a spot bid of one hundredth of
+        # one cent for m3.large (avg bid price ~$0.02)
+        self._test(autoScaled=True,
+                   spotInstances=True,
+                   spotBid="0.0001",
+                   slackPreference=0.0)
+        # slack preference of 0.0 means that we immediately roll over all
+        # unfulfilled preemptable requests to non-preemptable nodes
+
+    @integrative
+    def testAutoScaledSpotClusterWithMediumSlack(self):
+        # the spot market should never fulfill a spot bid of one hundredth of
+        # one cent for m3.large (avg bid price ~$0.02)
+        self._test(autoScaled=True,
+                   spotInstances=True,
+                   spotBid="0.0001",
+                   slackPreference=0.5)
+        # slack preference of 0.5 means we only reissue half of unfulfilled
+        # preemptable requests as non-preemptable requests


### PR DESCRIPTION
Currently, the autoscaler launches both a preemptable and a non-preemptable instance when growing the cluster. This occurs because both cluster scaler threads looks at the total number of issued jobs, instead of just looking at the specific number of (non-)preemptable jobs issued. This commit changes the `toil.leader.JobBatcher` `getNumberOfJobsIssued` method to add a preemptable flag. This flag is then used by the two cluster scalers so that each thread looks only at their specific type of job.