### PR TITLE
Implement support for deferred functions (resolves #987)

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -23,6 +23,7 @@ from collections import namedtuple
 from bd2k.util.objects import abstractclassmethod
 
 from toil.common import Toil, cacheDirName
+from toil.fileStore import shutdownCache
 
 # A class containing the information required for worker cleanup on shutdown of the batch system.
 WorkerCleanupInfo = namedtuple('WorkerCleanupInfo', (
@@ -290,6 +291,7 @@ class BatchSystemSupport(AbstractBatchSystem):
         assert isinstance(info, WorkerCleanupInfo)
         workflowDir = Toil.getWorkflowDir(info.workflowID, info.workDir)
         workflowDirContents = os.listdir(workflowDir)
+        shutdownCache(os.path.join(workflowDir, cacheDirName(info.workflowID)))
         if (info.cleanWorkDir == 'always'
             or info.cleanWorkDir in ('onSuccess', 'onError')
             and workflowDirContents in ([], [cacheDirName(info.workflowID)])):

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -477,6 +477,35 @@ class Job(object):
                 if len(y._children) != 0 and len(y._followOns) != 0 and len(y._services) != 0:
                     raise JobGraphDeadlockException("New checkpoint job %s is not a leaf in the job graph" % y)
 
+    def defer(self, callable, *args, **kwargs):
+        """
+        Register a deferred function, i.e. a callable that will be invoked after the current attempt
+        at running this job concludes. A job attempt is said to conclude when the job function (or
+        the Job.run method for class-based jobs) returns, raises an exception or after the process
+        running it terminates abnormally. A deferred function will be called on the node that
+        attempted to run the job, even if a subsequent attempt is made on another node. A deferred
+        function should be idempotent because it may be called multiple times on the same node or
+        even in the same process. More than one deferred function may be registered per job attempt
+        by calling this method repeatedly with different arguments. If the same callable is
+        registered twice, it will be called twice per job attempt.
+
+        The functions one would typically provide here are cleanup functions that handle
+        Toil-external events upon a failure within Toil (killing Docker containers, etc).
+
+        :param function callable: The function to be run after this job.
+        :param list args: The arguments to the function
+        :param dict kwargs: The keyword arguments to the function
+        :return: None
+        """
+        try:
+            getattr(self, 'fileStore')
+        except AttributeError:
+            raise RuntimeError('A deferred function may only be registered from within the job it '
+                               'is being registered with. "%s" was illegally registered.',
+                               callable.__name__)
+        self.fileStore._registerDeferredFunction(callable, *args, **kwargs)
+
+
     ####################################################
     #The following nested classes are used for
     #creating jobtrees (Job.Runner),

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -79,8 +79,18 @@ class hidden:
         def supportsWallTime(self):
             return False
 
-        def _createDummyConfig(self):
-            return Config()
+        @staticmethod
+        def _createDummyConfig():
+            """
+            Returns a dummy config for the batch system tests.  We need a workflowID to be set up
+            since we are running tests without setting up a jobstore.
+
+            :rtype: toil.common.Config
+            """
+            config = Config()
+            from uuid import uuid4
+            config.workflowID = str(uuid4())
+            return config
 
         @classmethod
         def setUpClass(cls):
@@ -374,12 +384,12 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
                     jobs = int(maxCores / coresPerJob * load)
                     if jobs >= 1 and minCores <= coresPerJob < maxCores:
                         self.assertEquals(maxCores, float(maxCores))
-                        bs = SingleMachineBatchSystem(config=Config(),
-                                                      maxCores=float(maxCores),
-                                                      # Ensure that memory or disk requirements
-                                                      # don't get in the way.
-                                                      maxMemory=jobs * 10,
-                                                      maxDisk=jobs * 10)
+                        bs = SingleMachineBatchSystem(
+                            config=hidden.AbstractBatchSystemTest._createDummyConfig(),
+                            maxCores=float(maxCores),
+                            # Ensure that memory or disk requirements don't get in the way.
+                            maxMemory=jobs * 10,
+                            maxDisk=jobs * 10)
                         try:
                             jobIds = set()
                             for i in range(0, int(jobs)):

--- a/src/toil/test/src/jobCacheTest.py
+++ b/src/toil/test/src/jobCacheTest.py
@@ -28,7 +28,7 @@ from struct import pack, unpack
 from uuid import uuid4
 
 from toil.job import Job
-from toil.fileStore import IllegalDeletionCacheError
+from toil.fileStore import IllegalDeletionCacheError, FileStore
 from toil.test import ToilTest, needs_aws, needs_azure, needs_google, experimental
 from toil.leader import FailedJobsException
 from toil.jobStores.abstractJobStore import NoSuchFileException
@@ -717,7 +717,7 @@ class hidden:
             state file is equal to the values we expect.
             """
             with job.fileStore._CacheState.open(job.fileStore) as cacheInfo:
-                jobState = cacheInfo.jobState[job.fileStore.hashedJobCommand]
+                jobState = cacheInfo.jobState[job.fileStore.jobID]
                 # cached should have a value only if the job store is on a different file system
                 # than the cache
                 if cacheInfo.nlink != 2:
@@ -870,6 +870,283 @@ class hidden:
                 job.fileStore.readGlobalFile('bogus')
             except NoSuchFileException:
                 pass
+
+        # These tests don't test the cache functions but they test code that heavily inherits cache
+        # code
+        def testDeferredFunctionRunsWithMethod(self):
+            """
+            Refer docstring in _testDeferredFunctionRuns.
+            Test with Method
+            """
+            self._testDeferredFunctionRuns(self._writeNonLocalFilesMethod)
+
+        def testDeferredFunctionRunsWithClassMethod(self):
+            """
+            Refer docstring in _testDeferredFunctionRuns.
+            Test with Class Method
+            """
+            self._testDeferredFunctionRuns(self._writeNonLocalFilesClassMethod)
+
+        def testDeferredFunctionRunsWithLambda(self):
+            """
+            Refer docstring in _testDeferredFunctionRuns.
+            Test with Lambda
+            """
+            self._testDeferredFunctionRuns(self._writeNonLocalFilesLambda)
+
+        def _testDeferredFunctionRuns(self, callableFn):
+            """
+            Create 2 files. Make a job that writes data to them. Register a deferred function that
+            deletes the two files (one passed as an arg, adn one as a kwarg) and later assert that
+            the files have been deleted.
+
+            :param function callableFn: The function to use in the test.
+            :return: None
+            """
+            workdir = self._createTempDir(purpose='nonLocalDir')
+            nonLocalFile1 = os.path.join(workdir, str(uuid4()))
+            nonLocalFile2 = os.path.join(workdir, str(uuid4()))
+            open(nonLocalFile1, 'w').close()
+            open(nonLocalFile2, 'w').close()
+            assert os.path.exists(nonLocalFile1)
+            assert os.path.exists(nonLocalFile2)
+            A = Job.wrapJobFn(callableFn, files=(nonLocalFile1, nonLocalFile2))
+            Job.Runner.startToil(A, self.options)
+            assert not os.path.exists(nonLocalFile1)
+            assert not os.path.exists(nonLocalFile2)
+
+        @staticmethod
+        def _writeNonLocalFilesMethod(job, files):
+            """
+            Write some data to 2 files.  Pass them to a registered deferred method.
+
+            :param tuple files: the tuple of the two files to work with
+            :return: None
+            """
+            for nlf in files:
+                with open(nlf, 'w') as nonLocalFileHandle:
+                    nonLocalFileHandle.write(os.urandom(1 * 1024 * 1024))
+            job.defer(_deleteMethods._deleteFileMethod, files[0], nlf=files[1])
+            return None
+
+        @staticmethod
+        def _writeNonLocalFilesClassMethod(job, files):
+            """
+            Write some data to 2 files.  Pass them to a registered deferred class method.
+
+            :param tuple files: the tuple of the two files to work with
+            :return: None
+            """
+            for nlf in files:
+                with open(nlf, 'w') as nonLocalFileHandle:
+                    nonLocalFileHandle.write(os.urandom(1 * 1024 * 1024))
+            job.defer(_deleteMethods._deleteFileClassMethod, files[0], nlf=files[1])
+            return None
+
+        @staticmethod
+        def _writeNonLocalFilesLambda(job, files):
+            """
+            Write some data to 2 files.  Pass them to a registered deferred Lambda.
+
+            :param tuple files: the tuple of the two files to work with
+            :return: None
+            """
+            lmd = lambda x, nlf: [os.remove(x), os.remove(nlf)]
+            for nlf in files:
+                with open(nlf, 'w') as nonLocalFileHandle:
+                    nonLocalFileHandle.write(os.urandom(1 * 1024 * 1024))
+            job.defer(lmd, files[0], nlf=files[1])
+            return None
+
+        def testDeferredFunctionRunsWithFailures(self):
+            """
+            Create 2 non local filesto use as flags.  Create a job that registers a function that
+            deletes one non local file.  If that file exists, the job SIGKILLs itself. If it doesn't
+            exist, the job registers a second deferred function to delete the second non local file
+            and exits normally.
+
+            Initially the first file exists, so the job should SIGKILL itself and neither deferred
+            function will run (in fact, the second should not even be registered). On the restart,
+            the first deferred function should run and the first file should not exist, but the
+            second one should.  We assert the presence of the second, then register the second
+            deferred function and exit normally.  At the end of the test, neither file should exist.
+
+            Incidentally, this also tests for multiple registered deferred functions, and the case
+            where a deferred function fails (since the first file doesn't exist on the retry).
+            """
+            self.options.retryCount = 1
+            workdir = self._createTempDir(purpose='nonLocalDir')
+            nonLocalFile1 = os.path.join(workdir, str(uuid4()))
+            nonLocalFile2 = os.path.join(workdir, str(uuid4()))
+            open(nonLocalFile1, 'w').close()
+            open(nonLocalFile2, 'w').close()
+            assert os.path.exists(nonLocalFile1)
+            assert os.path.exists(nonLocalFile2)
+            A = Job.wrapJobFn(self._deferredFunctionRunsWithFailuresFn,
+                              files=(nonLocalFile1, nonLocalFile2))
+            Job.Runner.startToil(A, self.options)
+            assert not os.path.exists(nonLocalFile1)
+            assert not os.path.exists(nonLocalFile2)
+
+        @staticmethod
+        def _deferredFunctionRunsWithFailuresFn(job, files):
+            """
+            Refer testDeferredFunctionRunsWithFailures
+
+            :param tuple files: the tuple of the two files to work with
+            :return: None
+            """
+            job.defer(hidden.AbstractCacheTest._deleteFile, files[0])
+            if os.path.exists(files[0]):
+                os.kill(os.getpid(), signal.SIGKILL)
+            else:
+                assert os.path.exists(files[1])
+                job.defer(hidden.AbstractCacheTest._deleteFile, files[1])
+
+        @staticmethod
+        def _deleteFile(nonLocalFile, nlf=None):
+            """
+            Delete nonLocalFile and nlf
+            :param str nonLocalFile:
+            :param str nlf:
+            :return: None
+            """
+            os.remove(nonLocalFile)
+            if nlf is not None:
+                os.remove(nlf)
+
+        def testNewJobsCanHandleOtherJobDeaths(self):
+            """
+            Create 2 non-local files and then create 2 jobs. The first job registers a deferred job
+            to delete the second non-local file, deletes the first non-local file and then kills
+            itself.  The second job waits for the first file to be deleted, then sleeps for a few
+            seconds and then spawns a child. the child of the second does nothing. However starting
+            it should handle the untimely demise of the first job and run the registered deferred
+            function that deletes the first file.  We assert the absence of the two files at the
+            end of the run.
+            """
+            # There can be no retries
+            self.options.retryCount = 0
+            workdir = self._createTempDir(purpose='nonLocalDir')
+            nonLocalFile1 = os.path.join(workdir, str(uuid4()))
+            nonLocalFile2 = os.path.join(workdir, str(uuid4()))
+            open(nonLocalFile1, 'w').close()
+            open(nonLocalFile2, 'w').close()
+            assert os.path.exists(nonLocalFile1)
+            assert os.path.exists(nonLocalFile2)
+            files = [nonLocalFile1, nonLocalFile2]
+            root = Job()
+            A = Job.wrapJobFn(self._testNewJobsCanHandleOtherJobDeaths_A, files=files)
+            B = Job.wrapJobFn(self._testNewJobsCanHandleOtherJobDeaths_B, files=files)
+            C = Job.wrapJobFn(self._testNewJobsCanHandleOtherJobDeaths_C, files=files,
+                              expectedResult=False)
+            root.addChild(A)
+            root.addChild(B)
+            B.addChild(C)
+            try:
+                Job.Runner.startToil(root, self.options)
+            except FailedJobsException as e:
+                pass
+
+        @staticmethod
+        def _testNewJobsCanHandleOtherJobDeaths_A(job, files):
+            """
+            Defer deletion of files[1], then wait for _testNewJobsCanHandleOtherJobDeaths_B to
+            start up, and finally delete files[0] before sigkilling self.
+
+            :param tuple files: the tuple of the two files to work with
+            :return: None
+            """
+            # Write the pid to files[1] such that we can be sure that this process has died before
+            # we spawn the next job that will do the cleanup.
+            with open(files[1], 'w') as fileHandle:
+                fileHandle.write(str(os.getpid()))
+            job.defer(hidden.AbstractCacheTest._deleteFile, files[1])
+            while os.stat(files[0]).st_size == 0:
+                time.sleep(0.5)
+            os.remove(files[0])
+            os.kill(os.getpid(), signal.SIGKILL)
+
+        @staticmethod
+        def _testNewJobsCanHandleOtherJobDeaths_B(job, files):
+            # Write something to files[0] such that we can be sure that this process has started
+            # before _testNewJobsCanHandleOtherJobDeaths_A kills itself.
+            with open(files[0], 'w') as fileHandle:
+                fileHandle.write(str(os.getpid()))
+            while os.path.exists(files[0]):
+                time.sleep(0.5)
+            # Get the pid of _testNewJobsCanHandleOtherJobDeaths_A and wait for it to truly be dead.
+            with open(files[1], 'r') as fileHandle:
+                meeseeksPID = int(fileHandle.read())
+            while FileStore.HarbingerFile._pidExists(meeseeksPID):
+                time.sleep(0.5)
+            # Now that we are convinced that_testNewJobsCanHandleOtherJobDeaths_A has died, we can
+            # spawn the next job
+            return None
+
+        @staticmethod
+        def _testNewJobsCanHandleOtherJobDeaths_C(job, files, expectedResult):
+            """
+            Asserts whether the files exist or not.
+
+            :param Job job: Job
+            :param list files: list of files to test
+            :param bool expectedResult: Are we expecting the files to exist or not?
+            """
+            for testFile in files:
+                assert os.path.exists(testFile) is expectedResult
+
+        def testBatchSystemCleanupCanHandleWorkerDeaths(self):
+            """
+            Create a non-local files. Create a job that registers a deferred job to delete the file
+            and then kills itself.
+
+            Assert that the file is missing after the pipeline fails.
+            """
+            # There can be no retries
+            self.options.retryCount = 0
+            workdir = self._createTempDir(purpose='nonLocalDir')
+            nonLocalFile1 = os.path.join(workdir, str(uuid4()))
+            nonLocalFile2 = os.path.join(workdir, str(uuid4()))
+            # The first file has to be non zero or meseeks will go into an infinite sleep
+            file1 = open(nonLocalFile1, 'w')
+            file1.write('test')
+            file1.close()
+            open(nonLocalFile2, 'w').close()
+            assert os.path.exists(nonLocalFile1)
+            assert os.path.exists(nonLocalFile2)
+            A = Job.wrapJobFn(self._testNewJobsCanHandleOtherJobDeaths_A,
+                              files=(nonLocalFile1, nonLocalFile2))
+            try:
+                Job.Runner.startToil(A, self.options)
+            except FailedJobsException:
+                pass
+            assert not os.path.exists(nonLocalFile1)
+            assert not os.path.exists(nonLocalFile2)
+
+
+class _deleteMethods(object):
+    @staticmethod
+    def _deleteFileMethod(nonLocalFile, nlf=None):
+        """
+        Delete nonLocalFile and nlf
+
+        :return: None
+        """
+        os.remove(nonLocalFile)
+        if nlf is not None:
+            os.remove(nlf)
+
+    @classmethod
+    def _deleteFileClassMethod(cls, nonLocalFile, nlf=None):
+        """
+        Delete nonLocalFile and nlf
+
+        :return: None
+        """
+        os.remove(nonLocalFile)
+        if nlf is not None:
+            os.remove(nlf)
 
 
 class FileJobStoreCacheTest(hidden.AbstractCacheTest):


### PR DESCRIPTION
resolves #987
related to #922

Jobs can now register deferred functions -- functions that are run when the
job finishes, when the job crashes and is restarted or upon batch system
shutdown.
Every job now tests the state of other jobs on the node and can handle
cleanup of other jobs that have failed.
Added 4 tests for the deferred functions (it works, it works on restart,
jobs can handle other dead jobs, worker cleanup handles dead jobs)