### PR TITLE
Allow Job.Service to access the underlying Toil Job (resolves #1191)

### DIFF
--- a/src/toil/test/src/jobServiceTest.py
+++ b/src/toil/test/src/jobServiceTest.py
@@ -200,22 +200,22 @@ class TestService(Job.Service):
         Job.Service.__init__(self, *args, **kwargs)
         self.messageInt = messageInt
 
-    def start(self, fileStore):
+    def start(self, job):
         assert self.disk is not None
         assert self.memory is not None
         assert self.cores is not None
         self.terminate = Event()
         self.error = Event()
-        inJobStoreID = fileStore.jobStore.getEmptyFileStoreID()
-        outJobStoreID = fileStore.jobStore.getEmptyFileStoreID()
+        inJobStoreID = job.fileStore.jobStore.getEmptyFileStoreID()
+        outJobStoreID = job.fileStore.jobStore.getEmptyFileStoreID()
         self.serviceThread = Thread(target=self.serviceWorker,
-                                    args=(fileStore.jobStore, self.terminate, self.error,
+                                    args=(job.fileStore.jobStore, self.terminate, self.error,
                                           inJobStoreID, outJobStoreID,
                                           self.messageInt))
         self.serviceThread.start()
         return (inJobStoreID, outJobStoreID)
 
-    def stop(self, fileStore):
+    def stop(self, job):
         self.terminate.set()
         self.serviceThread.join()
 
@@ -301,10 +301,10 @@ class TestServiceSerialization(Job.Service):
         Job.Service.__init__(self, *args, **kwargs)
         self.messageInt = messageInt
 
-    def start(self, fileStore):
+    def start(self, job):
         return self.messageInt
 
-    def stop(self, fileStore):
+    def stop(self, job):
         pass
 
     def check(self):


### PR DESCRIPTION
Changes the `Job.Service` `start` and `stop` methods to pass `job` instead of `fileStore`, which allows `Job.Service` instances to register defer methods, etc. To do this, we also modify `ServiceJob.run` to set `self.fileStore` within the service job, which was previously not exposed.