### PR TITLE
Delete SDB domains on failed jobstore bucket creation (resolves #1202)

### DIFF
--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -100,6 +100,10 @@ class JobStoreExistsException(Exception):
             "the job store with 'toil clean' to start the workflow from scratch" % locator)
 
 
+class JobStoreBucketExistsException(Exception):
+    def __init__(self, message):
+        super(JobStoreBucketExistsException, self).__init__(message)
+
 class AbstractJobStore(object):
     """ 
     Represents the physical storage for the jobs and files in a Toil workflow.

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -100,9 +100,12 @@ class JobStoreExistsException(Exception):
             "the job store with 'toil clean' to start the workflow from scratch" % locator)
 
 
-class JobStoreBucketExistsException(Exception):
-    def __init__(self, message):
-        super(JobStoreBucketExistsException, self).__init__(message)
+class BucketLocationConflictException(Exception):
+    def __init__(self, bucketRegion):
+        message = ('A bucket with the same name as the jobstore was found in another region (%s). '
+                   'Cannot proceed as the unique bucket name is already in use.' % bucketRegion)
+        super(BucketLocationConflictException, self).__init__(message)
+
 
 class AbstractJobStore(object):
     """ 

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -48,7 +48,7 @@ from toil.jobStores.abstractJobStore import (AbstractJobStore,
                                              ConcurrentFileModificationException,
                                              NoSuchFileException,
                                              NoSuchJobStoreException,
-                                             JobStoreBucketExistsException,
+                                             BucketLocationConflictException,
                                              JobStoreExistsException)
 from toil.jobStores.aws.utils import (SDBHelper,
                                       retry_sdb,
@@ -202,10 +202,15 @@ class AWSJobStore(AbstractJobStore):
         if self._registered:
             raise JobStoreExistsException(self.locator)
         self._registered = None
-        self._bind(create=True)
-        super(AWSJobStore, self).initialize(config)
-        # Only register after job store has been full initialized
-        self._registered = True
+        try:
+            self._bind(create=True)
+        except:
+            with panic(log):
+                self.destroy()
+        else:
+            super(AWSJobStore, self).initialize(config)
+            # Only register after job store has been full initialized
+            self._registered = True
 
     @property
     def sseKeyPath(self):
@@ -222,6 +227,9 @@ class AWSJobStore(AbstractJobStore):
             assert len(name) <= self.maxNameLen
             return self.namePrefix + self.nameSeparator + name
 
+        # The order in which this sequence of events happens is important.  We can easily handle the
+        # inability to bind a domain, but it is a little harder to handle some cases of binding the
+        # jobstore bucket.  Maintaining this order allows for an easier `destroy` method.
         if self.jobsDomain is None:
             self.jobsDomain = self._bindDomain(qualify('jobs'), create=create, block=block)
         if self.filesDomain is None:
@@ -686,21 +694,13 @@ class AWSJobStore(AbstractJobStore):
                         # This is raised if the user attempts to get a bucket in a region outside
                         # the specified one, if the specified one is not `us-east-1`.  The us-east-1
                         # server allows a user to use buckets from any region.
-                        if self.region == 'us-east-1':
-                            message = ('Region is us-east-1 but 301 error was raised when '
-                                       'attempting to create the bucket. 301 Errors are usually '
-                                       'raised when a non-us-east-1 connection attempts to get a '
-                                       'bucket from another region. Cannot proceed further.')
-                        else:
-                            b = self.s3.get_bucket(bucket_name, validate=False)
-                            message = ('A bucket with the same name as the jobstore was found in '
-                                       'another region (%s). Cannot proceed further as the unique '
-                                       'jobstore name is already claimed.' % b.get_location())
-                        raise JobStoreBucketExistsException(message)
+                        bucket = self.s3.get_bucket(bucket_name, validate=False)
+                        raise BucketLocationConflictException(self.__getBucketRegion(bucket))
                     else:
                         raise
                 else:
-                    assert self.__getBucketRegion(bucket) == self.region
+                    if self.__getBucketRegion(bucket) != self.region:
+                        raise BucketLocationConflictException(self.__getBucketRegion(bucket))
                     assert versioning is self.__getBucketVersioning(bucket)
                     log.debug("Using existing job store bucket '%s'.", bucket_name)
                     return bucket
@@ -1271,7 +1271,14 @@ class AWSJobStore(AbstractJobStore):
     def destroy(self):
         # FIXME: Destruction of encrypted stores only works after initialize() or .resume()
         # See https://github.com/BD2KGenomics/toil/issues/1041
-        self._bind(create=False, block=False)
+        try:
+            self._bind(create=False, block=False)
+        except BucketLocationConflictException:
+            # If the unique jobstore bucket name existed, _bind would have raised a
+            # BucketLocationConflictException before calling destroy.  Calling _bind here again
+            # would reraise the same exception so we need to catch and ignore that exception.
+            pass
+        # TODO: Add other failure cases to be ignored here.
         self._registered = None
         if self.filesBucket is not None:
             self._delete_bucket(self.filesBucket)

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -36,10 +36,11 @@ from bd2k.util.exceptions import panic
 # (installed by `make prepare`)
 from mock import patch
 
-from toil.common import Config
+from toil.common import Config, Toil
+from toil.job import Job
 from toil.jobStores.abstractJobStore import (AbstractJobStore,
                                              NoSuchJobException,
-                                             NoSuchFileException)
+                                             NoSuchFileException, JobStoreBucketExistsException)
 from toil.jobStores.aws.utils import region_to_bucket_location
 from toil.jobStores.fileJobStore import FileJobStore
 from toil.test import (ToilTest,
@@ -838,6 +839,49 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
         from toil.jobStores.aws.jobStore import AWSJobStore
         assert isinstance(self.master, AWSJobStore)  # type hinting
         self.master.filesBucket.delete()
+
+    def testSDBDomainsDeletedOnFailedJobstoreBucketCreation(self):
+        """
+        This test ensures that SDB domains bound to a jobstore are deleted if the jobstore bucket
+        failed to be created.  We simulate a failed jobstore bucket creation by using a bucket in a
+        different region with the same name.
+
+        :returns: None
+        """
+        from boto.sdb import connect_to_region
+        from boto.s3.connection import Location, S3Connection
+        aws_west_regions = {'us-west-1': Location.USWest,
+                            'us-west-2': Location.USWest2}
+        externalAWSRegion = [R for r, R in aws_west_regions.items() if r != self.awsRegion()][0]
+
+        testJobStoreUUID = str(uuid.uuid4())
+        # Create the nucket at the external region
+        s3 = S3Connection()
+        bucket = s3.create_bucket('domain-test-' + testJobStoreUUID + '--files',
+                                  location=externalAWSRegion)
+        options = Job.Runner.getDefaultOptions('aws:' + self.awsRegion() + ':domain-test-' +
+                                               testJobStoreUUID)
+        try:
+            with Toil(options) as toil:
+                pass
+        except JobStoreBucketExistsException:
+            # Catch the expected JobStoreBucketExistsException and ensure that the bound domains
+            # don't exist in SDB
+            sdb = connect_to_region(self.awsRegion())
+            next_token = None
+            allDomainNames = []
+            while True:
+                domains = sdb.get_all_domains(max_domains=100, next_token=next_token)
+                allDomainNames.extend([x.name for x in domains])
+                next_token = domains.next_token
+                if next_token is None:
+                    break
+            # Will the user ever have 0 domains?
+            self.assertTrue(allDomainNames)
+            self.assertFalse([d for d in allDomainNames if testJobStoreUUID in d])
+        finally:
+            s3.delete_bucket(bucket=bucket)
+
 
     def testInlinedFiles(self):
         from toil.jobStores.aws.jobStore import AWSJobStore


### PR DESCRIPTION
resolves #1202

We see a lot of leaked `jobstore-test-UUID` and `cache-test-UUID` domains in SDB
and those are due to the domains being bound before creating the s3 bucket for the
jobstore. If the bucket creation fails, Toil exited without removing the domains. This
PR adds a flag to ensure the jobstore is properly initialized, and adds logic to handle
the deletion of a failed fresh jobstore.

Added a test for this feature.