### PR TITLE
DOC: fix syntax error in dynamic example

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -335,7 +335,7 @@ For example::
 
     from toil.job import Job
     
-    def binaryStringFn(job, message="", depth):
+    def binaryStringFn(job, message="", depth=0):
         if depth > 0:
             job.addChildJobFn(binaryStringFn, message + "0", depth-1)
             job.addChildJobFn(binaryStringFn, message + "1", depth-1)


### PR DESCRIPTION
Dynamic example in toil/docs/developing.rst has a syntax error:

```
$ python dynamic.py
  File "dynamic.py", line 3
    def binaryStringFn(job, message="", depth):
SyntaxError: non-default argument follows default argument
```