### PR TITLE
Use stub servers for import tests (resolves #1226)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ check_build_reqs:
 
 
 prepare: check_venv
-	$(pip) install sphinx==1.4.1 mock==1.0.1 pytest==2.8.3
+	$(pip) install sphinx==1.4.1 mock==1.0.1 pytest==2.8.3 stubserver==1.0.1
 
 
 check_venv:

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -14,9 +14,11 @@
 
 from __future__ import absolute_import
 
+import SocketServer
 import hashlib
 import logging
-
+import threading
+import SimpleHTTPServer
 import os
 import shutil
 import tempfile
@@ -24,6 +26,7 @@ import time
 import urllib2
 import urlparse
 import uuid
+from stubserver import FTPStubServer
 from Queue import Queue
 from abc import abstractmethod, ABCMeta
 from itertools import chain, islice, count
@@ -456,17 +459,33 @@ class AbstractJobStoreTest:
                        otherCls=activeTestClassesByName)
 
         def testImportHttpFile(self):
-            srcUrl, srcHash = ('https://raw.githubusercontent.com/BD2KGenomics/toil'
-                               '/12c711ff91caa5d8fb37a072bad376f447faa797/Makefile',
-                               '16a38fd7ae233616083d43d81159d4e8')
-            with self.master.readFileStream(self.master.importFile(srcUrl)) as f:
-                self.assertEqual(hashlib.md5(f.read()).hexdigest(), srcHash)
+            http = SocketServer.TCPServer(('', 0), StubHttpRequestHandler)
+            try:
+                httpThread = threading.Thread(target=http.serve_forever)
+                httpThread.start()
+                try:
+                    assignedPort = http.server_address[1]
+                    url = 'http://localhost:%d' % assignedPort
+                    with self.master.readFileStream(self.master.importFile(url)) as readable:
+                        self.assertEqual(readable.read(), StubHttpRequestHandler.fileContents)
+                finally:
+                    http.shutdown()
+                    httpThread.join()
+            finally:
+                http.server_close()
 
         def testImportFtpFile(self):
-            srcUrl, srcHash = ('ftp://speedtest.tele2.net/512KB.zip',
-                               '59071590099d21dd439896592338bf95')
-            with self.master.readFileStream(self.master.importFile(srcUrl)) as f:
-                self.assertEqual(hashlib.md5(f.read()).hexdigest(), srcHash)
+            file = {'name':'foo', 'content':'foo bar baz qux'}
+            ftp = FTPStubServer(0)
+            ftp.run()
+            try:
+                ftp.add_file(**file)
+                assignedPort = ftp.server.server_address[1]
+                url = 'ftp://user1:passwd@localhost:%d/%s' % (assignedPort, file['name'])
+                with self.master.readFileStream(self.master.importFile(url)) as readable:
+                    self.assertEqual(readable.read(), file['content'])
+            finally:
+                ftp.stop()
 
         def testFileDeletion(self):
             """
@@ -1103,6 +1122,16 @@ class EncryptedAWSJobStoreTest(AWSJobStoreTest, AbstractEncryptedJobStoreTest.Te
 @needs_encryption
 class EncryptedAzureJobStoreTest(AzureJobStoreTest, AbstractEncryptedJobStoreTest.Test):
     pass
+
+
+class StubHttpRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    fileContents = 'A good programmer looks both ways before crossing a one-way street'
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/plain")
+        self.send_header("Content-length", len(self.fileContents))
+        self.end_headers()
+        self.wfile.write(self.fileContents)
 
 
 AbstractJobStoreTest.Test.makeImportExportTests()


### PR DESCRIPTION
@hannes-ucsc I ended up going with [stubserver](https://github.com/tarttelin/Python-Stub-Server) for the FTP test. I think it is better because it does not rely on any particular file system and would not require writing a test file to said file system.

With that same reasoning I subclassed the built-in http mock server into a stub server. Please let me know what you think!  
