### PR TITLE
Avoid importing AWSJobStore without AWS extra installed (resolves #1115)

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,6 +4,7 @@
 # separated list of Makefile targets to invoke.
 
 # Passing --system-site-packages ensures that mesos.native and mesos.interface are included
+# Passing --never-download prevents silent upgrades to pip, wheel and setuptools
 virtualenv --system-site-packages --never-download venv
 . venv/bin/activate
 

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -31,7 +31,6 @@ from bd2k.util.expando import Expando
 
 from toil import resolveEntryPoint
 from toil.jobStores.abstractJobStore import NoSuchJobException
-from toil.jobStores.aws.jobStore import AWSJobStore
 from toil.lib.bioio import getTotalCpuTime, logStream
 from toil.provisioners.clusterScaler import ClusterScaler
 
@@ -283,7 +282,8 @@ class JobBatcher:
             try:
                 jobWrapper = self.jobStore.load(jobStoreID)
             except NoSuchJobException:
-                if isinstance(self.jobStore, AWSJobStore):
+                # Avoid importing AWSJobStore as the corresponding extra might be missing
+                if self.jobStore.__class__.__name__ == 'AWSJobStore':
                     # We have a ghost job - the job has been deleted but a stale read from
                     # SDB gave us a false positive when we checked for its existence.
                     # Process the job from here as any other job removed from the job store.

--- a/src/toil/test/src/resourceTest.py
+++ b/src/toil/test/src/resourceTest.py
@@ -67,7 +67,8 @@ class ResourceTest(ToilTest):
         dirPath = self._createTempDir()
         if virtualenv:
             self.assertTrue(inVirtualEnv())
-            check_call(['virtualenv', dirPath])
+            # Passing --never-download prevents silent upgrades to pip, wheel and setuptools
+            check_call(['virtualenv', '--never-download', dirPath])
             sitePackages = os.path.join(dirPath, 'lib', 'python2.7', 'site-packages')
             # tuple assignment is necessary to make this line immediately precede the try:
             oldPrefix, sys.prefix, dirPath = sys.prefix, dirPath, sitePackages


### PR DESCRIPTION
Backports 8e5fd0feca3c75fd44ccd71339340656198a4d1b to 3.3.x