### PR TITLE
Add test to show children of failed jobs in a DAG are run on restart

### DIFF
--- a/src/toil/test/src/restartJobTest.py
+++ b/src/toil/test/src/restartJobTest.py
@@ -1,0 +1,175 @@
+# Copyright (C) 2015-2016 Regents of the University of California
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from toil.common import Toil
+from toil.job import Job
+from toil.leader import FailedJobsException
+from toil.test import ToilTest
+
+import inspect
+import os
+import shutil
+import signal
+
+
+class RestartJobTest(ToilTest):
+    """
+    Tests that restarted job DAGs don't run children of jobs that failed in the first run till the
+    parent completes successfully in the restart.
+    """
+    def setUp(self):
+        super(RestartJobTest, self).setUp()
+        self.tempDir = self._createTempDir(purpose='tempDir')
+        self.testJobStore = self._getTestJobStorePath()
+
+    def tearDown(self):
+        super(RestartJobTest, self).tearDown()
+        shutil.rmtree(self.testJobStore)
+
+    def testRestartedWorkflowSchedulesCorrectJobsOnFailedParent(self):
+        self._testRestartedWorkflowSchedulesCorrectJobs('raise')
+
+    def testRestartedWorkflowSchedulesCorrectJobsOnKilledParent(self):
+        self._testRestartedWorkflowSchedulesCorrectJobs('kill')
+
+    def _testRestartedWorkflowSchedulesCorrectJobs(self, failType):
+        """
+        Creates a diamond DAG
+            /->passingParent-\
+        root                 |-->child
+           \->failingParent--/
+
+        where root and passingParent are guaranteed to pass, while failingParent will fail.
+        child should not run on start or restart and we assert that by ensuring that a file create
+        iff child is run is not present on the system.
+
+        :param str failType: Does failingParent fail on an assertionError, or is it killed.
+        """
+        # Specify options
+        options = Job.Runner.getDefaultOptions(self.testJobStore)
+        options.logLevel = 'INFO'
+        options.retryCount = 0
+        options.clean = "never"
+
+        parentFile = os.path.join(self.tempDir, 'parent')
+        childFile = os.path.join(self.tempDir, 'child')
+
+        # Make the first job
+        root = Job.wrapJobFn(self._passingFn)
+        passingParent = Job.wrapJobFn(self._passingFn)
+        failingParent = Job.wrapJobFn(self._failingFn, failType=failType, fileName=parentFile)
+        child = Job.wrapJobFn(self._passingFn, fileName=childFile)
+
+        # define the DAG
+        root.addChild(passingParent)
+        root.addChild(failingParent)
+        passingParent.addChild(child)
+        failingParent.addChild(child)
+
+        failReasons = []
+
+        # Run the test
+        for runMode in 'start', 'restart':
+            self.errorRaised = None
+            try:
+                with Toil(options) as toil:
+                    if runMode == 'start':
+                        toil.start(root)
+                    else:
+                        toil.restart()
+            except FailedJobsException as e:
+                self.errorRaised = e
+            except AssertionError as e:
+                self.errorRaised = e
+            finally:
+                # The processing of an AssertionError and FailedJobsException is the same so we do
+                # it together in this finally clause.
+                if self.errorRaised is not None:
+                    if not os.path.exists(parentFile):
+                        failReasons.append('The failing parent file did not exist on toil "%s".'
+                                           % runMode)
+                    if os.path.exists(childFile):
+                        failReasons.append('The child file existed.  i.e. the child was run on '
+                                           'toil "%s".' % runMode)
+                    if isinstance(self.errorRaised, FailedJobsException):
+                        if self.errorRaised.numberOfFailedJobs != 1:
+                            failReasons.append('FailedJobsException was raised on toil "%s" but '
+                                               'the number of failed jobs (%s) was not 1.'
+                                               % (runMode, self.errorRaised.numberOfFailedJobs))
+                    else:
+                        failReasons.append('Toil raised an AssertionError instead of a '
+                                           'FailedJobsException on toil "%s".' % runMode)
+                    options.restart = True
+                else:
+                    self.fail('No errors were raised on toil "%s".' % runMode)
+        if failReasons:
+            self.fail('Test failed for (%s) reasons:\n\t%s' % (len(failReasons),
+                                                             '\n\t'.join(failReasons)))
+
+    @staticmethod
+    def _passingFn(job, fileName=None):
+        """
+        This function is guaranteed to pass as it does nothing out of the ordinary.  If fileName is
+        provided, it will be created.
+
+        :param str fileName: The name of a file that must be created if provided.
+        """
+        if fileName is not None:
+            # Emulates system touch.
+            open(fileName, 'w').close()
+
+    @staticmethod
+    def _testFileExists(filePath):
+        """
+        Test whether filePath exists or not
+        :param filePath: Path to a file
+        :return: True if exists else False
+        :rtype: bool
+        """
+        return os.path.exists()
+
+
+    @staticmethod
+    def _failingFn(job, failType, fileName):
+        """
+        This function is guaranteed to fail via a raised assertion, or an os.kill
+
+        :param job: Job
+        :param str failType: 'raise' or 'kill
+        :param str fileName: The name of a file that must be created.
+        """
+        assert failType in ('raise', 'kill')
+        # Use that function to avoid code redundancy
+        RestartJobTest._passingFn(job, fileName)
+
+        if failType == 'raise':
+            assert False
+        else:
+            os.kill(os.getpid(), signal.SIGKILL)
+
+
+def _exportStaticMethodAsGlobalFunctions(cls):
+    """
+    Define utility functions because Toil can't pickle static methods. Note that this relies on
+    the convention that the first argument of a job function is named 'job'.
+    """
+    for name, kind, clazz, value in inspect.classify_class_attrs(cls):
+        if kind == 'static method':
+            method = value.__func__
+            args = inspect.getargspec(method).args
+            if args and args[0] == 'job':
+                globals()[name] = method
+
+_exportStaticMethodAsGlobalFunctions(RestartJobTest)


### PR DESCRIPTION
connected to #1289

Also, Toil raises an `AssertionError` on workflow failure instead of `FailedJobsException`.
This is also a bug that is caught by this test.