### PR TITLE
Fix misformatted filename for grid engine and slurm with CWL (resolves #1261)

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -286,10 +286,13 @@ class BatchSystemSupport(AbstractBatchSystem):
 
     def _getResultsFileName(self, toilPath):
         """
-        Get a path for the batch systems to store results. GridEngine
-        and LSF currently use this.
+        Get a path for the batch systems to store results. GridEngine, slurm,
+        and LSF currently use this and only work if locator is file.
         """
-        return os.path.join(toilPath, "results.txt")
+        # Use  parser to extract the path and type
+        locator, filePath = Toil.parseLocator(toilPath)
+        assert locator == "file"
+        return os.path.join(filePath, "results.txt")
 
     @staticmethod
     def workerCleanup(info):

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -222,9 +222,7 @@ class GridengineBatchSystem(BatchSystemSupport):
 
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         super(GridengineBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
-        prefix = 'file:'
-        assert config.jobStore.startswith(prefix)
-        self.gridengineResultsFile = self._getResultsFileName(config.jobStore[len(prefix):])
+        self.gridengineResultsFile = self._getResultsFileName(config.jobStore)
         # Reset the job queue and results (initially, we do this again once we've killed the jobs)
         self.gridengineResultsFileHandle = open(self.gridengineResultsFile, 'w')
         # We lose any previous state in this file, and ensure the files existence

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -288,7 +288,8 @@ class hidden:
             """
             Tests that the result file name is formatted properly
             """
-            fileName = BatchSystemSupport._getResultsFileName(self._createConfig().jobStore)
+            # noinspection PyUnresolvedReferences
+            fileName = self.batchSystem._getResultsFileName(self._createConfig().jobStore)
             locator = self.config.jobStore
             self.assertTrue(locator.startswith('file:'))
             self.assertEqual(locator[len('file:'):], fileName)


### PR DESCRIPTION
First commit updates tests which should cause failure. Second commit should fix failure.