### PR TITLE
Test serially by default (fixes #1284)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ The 'docs' target uses Sphinx to create HTML documentation in the docs/_build di
 
 The 'test' target runs Toil's unit tests serially with pytest.
 
-The 'test-parallel' target runs Toil's unit tests in parallel and generates a test report
+The 'test_parallel' target runs Toil's unit tests in parallel and generates a test report
 from the results. Set the 'tests' variable to run a particular test, e.g.
 
-	make test-parallel tests=src/toil/test/sort/sortTest.py::SortTest::testSort
+	make test_parallel tests=src/toil/test/sort/sortTest.py::SortTest::testSort
 
 The 'pypi' target publishes the current commit of Toil to PyPI after enforcing that the working
 copy and the index are clean.
@@ -129,7 +129,7 @@ test: check_venv check_build_reqs docker
 	    $(python) -m pytest -vv src
 
 
-test-parallel: check_venv check_build_reqs docker
+test_parallel: check_venv check_build_reqs docker
 	$(python) run_tests.py test $(tests)
 
 

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,12 @@ uploaded to PyPI.
 
 The 'docs' target uses Sphinx to create HTML documentation in the docs/_build directory
 
-The 'test-serially' target runs Toil's unit tests serially with pytest.
+The 'test' target runs Toil's unit tests serially with pytest.
 
-The 'test' target runs Toil's unit tests in parallel and generates a test report
+The 'test-parallel' target runs Toil's unit tests in parallel and generates a test report
 from the results. Set the 'tests' variable to run a particular test, e.g.
 
-	make test tests=src/toil/test/sort/sortTest.py::SortTest::testSort
+	make test-parallel tests=src/toil/test/sort/sortTest.py::SortTest::testSort
 
 The 'pypi' target publishes the current commit of Toil to PyPI after enforcing that the working
 copy and the index are clean.
@@ -124,12 +124,12 @@ clean_sdist:
 	- rm src/toil/version.py
 
 
-test-serially: check_venv check_build_reqs docker
+test: check_venv check_build_reqs docker
 	TOIL_APPLIANCE_SELF=$(docker_registry)/$(docker_base_name):$(docker_tag) \
 	    $(python) -m pytest -vv src
 
 
-test: check_venv check_build_reqs docker
+test-parallel: check_venv check_build_reqs docker
 	$(python) run_tests.py test $(tests)
 
 


### PR DESCRIPTION
Rename target 'test-serially' to 'test' and 'test' to 'test-parallel'