### PR TITLE
CWL: migrate to latest cwltool

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -65,6 +65,8 @@ support for the stable v1.0 specification, only lacking the following features:
   a good workaround.
 - `File literals <http://www.commonwl.org/v1.0/CommandLineTool.html#File>`_ that
   specify only ``contents`` to a File without an explicit file name.
+- Complex file inputs -- from ExpressionTool or a default value, both of which do not yet
+  get cleanly staged into Toil file management.
 
 To run in local batch mode, provide the CWL file and the input object file::
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def runSetup():
                 'gcs_oauth2_boto_plugin==1.9',
                 botoRequirement],
             'cwl': [
-                'cwltool==1.0.20160714182449']},
+                'cwltool==1.0.20161221171240']},
         package_dir={'': 'src'},
         packages=find_packages(where='src',
                                # Note that we intentionally include the top-level `test` package for

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -88,7 +88,7 @@ class CWLTest(ToilTest):
             subprocess.call(["git", "fetch"], cwd=cwlSpec)
         else:
             subprocess.check_call(["git", "clone", "https://github.com/common-workflow-language/common-workflow-language.git", cwlSpec])
-        subprocess.check_call(["git", "checkout", "1d5714dc434ffd6ac45ec64f1535475fa163be09"], cwd=cwlSpec)
+        subprocess.check_call(["git", "checkout", "87d982f7793fe08d4f4af5555d551c272eaa809c"], cwd=cwlSpec)
         subprocess.check_call(["git", "clean", "-f", "-x", "."], cwd=cwlSpec)
         try:
             subprocess.check_output(["./run_test.sh", "RUNNER=cwltoil", "DRAFT=v1.0"], cwd=cwlSpec,


### PR DESCRIPTION
Work in progress to update CWL support to use the latest version of
cwltool, as work to fix any ongoing CWL support issues in Toil.

This passes many standard runs including bcbio CWL, but currently fails
5 CWL conformance tests I'm stuck at how to fix; starting this branch/PR
to solicit help from @mr-c @tetron and any other CWL folks.

The PR includes these updates:

- Dump Jobs to pickles with pickle avoiding the HIGHEST_PROTOCOL.
  The cPickle/HIGHEST_PROTOCOL will not serialize CWLWorkflow objects
  which contain sub-workflow steps and avro/schema-salad classes
  (they fail with `Can't pickle <type 'instancemethod'>: attribute
  lookup __builtin__.instancemethod failed find problem attribute`)
- Ensure generalized resolver used for loading tools
- logging debugging with new pickling and Job object representation.
- Update to latest CWL conformance testing