### PR TITLE
Fix miss-formatted filename for CWL Slurm (resolves #1261)

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -286,10 +286,13 @@ class BatchSystemSupport(AbstractBatchSystem):
 
     def _getResultsFileName(self, toilPath):
         """
-        Get a path for the batch systems to store results. GridEngine
-        and LSF currently use this.
+        Get a path for the batch systems to store results. GridEngine, slurm,
+        and LSF currently use this and only work if locator is file.
         """
-        return os.path.join(toilPath, "results.txt")
+        # Use  parser to extract the path and type
+        locator, filePath = Toil.parseLocator(toilPath)
+        assert locator == "file"
+        return os.path.join(filePath, "results.txt")
 
     @staticmethod
     def workerCleanup(info):

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -222,9 +222,7 @@ class GridengineBatchSystem(BatchSystemSupport):
 
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         super(GridengineBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
-        prefix = 'file:'
-        assert config.jobStore.startswith(prefix)
-        self.gridengineResultsFile = self._getResultsFileName(config.jobStore[len(prefix):])
+        self.gridengineResultsFile = self._getResultsFileName(config.jobStore)
         # Reset the job queue and results (initially, we do this again once we've killed the jobs)
         self.gridengineResultsFileHandle = open(self.gridengineResultsFile, 'w')
         # We lose any previous state in this file, and ensure the files existence

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -79,11 +79,12 @@ class hidden:
         def supportsWallTime(self):
             return False
 
-        @staticmethod
-        def _createDummyConfig():
+        @classmethod
+        def createConfig(cls):
             """
             Returns a dummy config for the batch system tests.  We need a workflowID to be set up
-            since we are running tests without setting up a jobstore.
+            since we are running tests without setting up a jobstore. This is the class version
+            to be used when an instance is not available.
 
             :rtype: toil.common.Config
             """
@@ -92,6 +93,15 @@ class hidden:
             config.workflowID = str(uuid4())
             return config
 
+        def _createConfig(self):
+            """
+            Returns a dummy config for the batch system tests.  We need a workflowID to be set up
+            since we are running tests without setting up a jobstore.
+
+            :rtype: toil.common.Config
+            """
+            return self.createConfig()
+
         @classmethod
         def setUpClass(cls):
             super(hidden.AbstractBatchSystemTest, cls).setUpClass()
@@ -99,7 +109,7 @@ class hidden:
 
         def setUp(self):
             super(hidden.AbstractBatchSystemTest, self).setUp()
-            self.config = self._createDummyConfig()
+            self.config = self._createConfig()
             self.batchSystem = self.createBatchSystem()
             self.tempDir = self._createTempDir('testFiles')
 
@@ -271,6 +281,29 @@ class hidden:
                 _, maxValue = getCounters(counterPath)
                 self.assertEqual(maxValue, self.cpuCount / coresPerJob)
 
+    class AbstractGridEngineBatchSystemTest(AbstractBatchSystemTest):
+        """
+        An abstract class to reduce redundancy between Grid Engine, Slurm, and other similar batch
+        systems
+        """
+
+        def _createConfig(self):
+            config = super(hidden.AbstractGridEngineBatchSystemTest, self)._createConfig()
+            # can't use _getTestJobStorePath since that method removes the directory
+            config.jobStore = 'file:' + self._createTempDir('jobStore')
+            return config
+
+        def testResultFile(self):
+            """
+            Tests that the result file name is formatted properly
+            """
+            # noinspection PyUnresolvedReferences
+            fileName = self.batchSystem._getResultsFileName(self.config.jobStore)
+            filePath, _ = os.path.split(fileName)  # removes file so dir matches config.jobStore
+            locator = self.config.jobStore
+            self.assertTrue(locator.startswith('file:'))
+            self.assertEqual(locator[len('file:'):], filePath)
+
 
 @needs_mesos
 class MesosBatchSystemTest(hidden.AbstractBatchSystemTest, MesosTestSupport):
@@ -394,7 +427,7 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
                     if jobs >= 1 and minCores <= coresPerJob < maxCores:
                         self.assertEquals(maxCores, float(maxCores))
                         bs = SingleMachineBatchSystem(
-                            config=hidden.AbstractBatchSystemTest._createDummyConfig(),
+                            config=hidden.AbstractBatchSystemTest.createConfig(),
                             maxCores=float(maxCores),
                             # Ensure that memory or disk requirements don't get in the way.
                             maxMemory=jobs * 10,
@@ -488,8 +521,8 @@ class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport)
     def supportsWallTime(self):
         return True
 
-    def _createDummyConfig(self):
-        config = super(ParasolBatchSystemTest, self)._createDummyConfig()
+    def _createConfig(self):
+        config = super(ParasolBatchSystemTest, self)._createConfig()
         # can't use _getTestJobStorePath since that method removes the directory
         config.jobStore = self._createTempDir('jobStore')
         return config
@@ -555,16 +588,10 @@ class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport)
 
 
 @needs_gridengine
-class GridEngineBatchSystemTest(hidden.AbstractBatchSystemTest):
+class GridEngineBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
     """
     Tests against the GridEngine batch system
     """
-
-    def _createDummyConfig(self):
-        config = super(GridEngineBatchSystemTest, self)._createDummyConfig()
-        # can't use _getTestJobStorePath since that method removes the directory
-        config.jobStore = 'file:'+ self._createTempDir('jobStore')
-        return config
 
     def createBatchSystem(self):
         from toil.batchSystems.gridengine import GridengineBatchSystem
@@ -579,16 +606,10 @@ class GridEngineBatchSystemTest(hidden.AbstractBatchSystemTest):
             os.unlink(f)
 
 @needs_slurm
-class SlurmBatchSystemTest(hidden.AbstractBatchSystemTest):
+class SlurmBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
     """
     Tests against the Slurm batch system
     """
-
-    def _createDummyConfig(self):
-        config = super(SlurmBatchSystemTest, self)._createDummyConfig()
-        # can't use _getTestJobStorePath since that method removes the directory
-        config.jobStore = self._createTempDir('jobStore')
-        return config
 
     def createBatchSystem(self):
         from toil.batchSystems.slurm import SlurmBatchSystem


### PR DESCRIPTION
First commit adds test to check file name. Second commit will fix results filename and shall past tests.