### PR TITLE
Improve Python 3 compatibility

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import os
 import textwrap
 
@@ -52,7 +53,7 @@ motd = heredoc('''
 # Prepare motd to be echoed in the Dockerfile using a RUN statement that uses bash's print
 motd = ''.join(l + '\\n\\\n' for l in motd.splitlines())
 
-print heredoc('''
+print(heredoc('''
     FROM ubuntu:14.04
 
     RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" \
@@ -101,4 +102,4 @@ print heredoc('''
 
     RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc \
         && printf '{motd}' > /etc/motd
-''')
+'''))

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ def runSetup():
         url="https://github.com/BD2KGenomics/toil",
         install_requires=[
             'bd2k-python-lib>=1.14a1.dev35',
-            'dill==0.2.5'],
+            'dill==0.2.5',
+            'six>=1.10.0'],
         extras_require={
             'mesos': [
                 'psutil==3.0.1'],

--- a/src/toil/batchSystems/__init__.py
+++ b/src/toil/batchSystems/__init__.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+import sys
 
+if sys.version_info >= (3, 0):
+
+    # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
+    def cmp(a, b):
+        return (a > b) - (a < b)
 
 class MemoryString:
     def __init__(self, string):

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -19,10 +19,10 @@ from pipes import quote
 import subprocess
 import time
 import math
-from Queue import Queue, Empty
 from threading import Thread
 
 # Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 from six import iteritems
 
 from toil.batchSystems import MemoryString

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -22,6 +22,9 @@ import math
 from Queue import Queue, Empty
 from threading import Thread
 
+# Python 3 compatibility imports
+from six import iteritems
+
 from toil.batchSystems import MemoryString
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
 
@@ -165,7 +168,7 @@ class Worker(Thread):
         if self.boss.environment:
             qsubline.append('-v')
             qsubline.append(','.join(k + '=' + quote(os.environ[k] if v is None else v)
-                                     for k, v in self.boss.environment.iteritems()))
+                                     for k, v in iteritems(self.boss.environment)))
 
         reqline = list()
         if mem is not None:

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -21,9 +21,11 @@ from __future__ import absolute_import
 import logging
 import subprocess
 import time
-from Queue import Queue, Empty
 from threading import Thread
 from datetime import date
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 
 from toil.batchSystems import MemoryString
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -21,7 +21,6 @@ import pickle
 import pwd
 import socket
 import time
-from Queue import Queue, Empty
 from collections import defaultdict
 from operator import attrgetter
 from struct import unpack
@@ -29,6 +28,7 @@ from struct import unpack
 import itertools
 
 # Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 from six import iteritems
 
 import mesos.interface

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -27,6 +27,10 @@ from operator import attrgetter
 from struct import unpack
 
 import itertools
+
+# Python 3 compatibility imports
+from six import iteritems
+
 import mesos.interface
 import mesos.native
 from bd2k.util import strict_bool
@@ -533,7 +537,7 @@ class MesosBatchSystem(BatchSystemSupport,
         nodeAddress = message.pop('address')
         executor = self._registerNode(nodeAddress, slaveId.value)
         # Handle optional message fields
-        for k, v in message.iteritems():
+        for k, v in iteritems(message):
             if k == 'nodeInfo':
                 assert isinstance(v, dict)
                 executor.nodeInfo = NodeInfo(**v)
@@ -554,7 +558,7 @@ class MesosBatchSystem(BatchSystemSupport,
 
     def getNodes(self, preemptable=None):
         return {nodeAddress: executor.nodeInfo
-                for nodeAddress, executor in self.executors.iteritems()
+                for nodeAddress, executor in iteritems(self.executors)
                 if time.time() - executor.lastSeen < 600
                 and (preemptable is None
                      or preemptable == (executor.slaveId not in self.nonPreemptibleNodes))}

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -24,6 +24,9 @@ from Queue import Empty
 from Queue import Queue
 from threading import Thread
 
+# Python 3 compatibility imports
+from six import itervalues
+
 from bd2k.util.iterables import concat
 from bd2k.util.processes import which
 
@@ -234,7 +237,7 @@ class ParasolBatchSystem(BatchSystemSupport):
         created by other users.
         """
         issuedJobs = set()
-        for resultsFile in self.resultsFiles.itervalues():
+        for resultsFile in itervalues(self.resultsFiles):
             issuedJobs.update(self.getJobIDsForResultsFile(resultsFile))
 
         return list(issuedJobs)
@@ -352,7 +355,7 @@ class ParasolBatchSystem(BatchSystemSupport):
 
     def shutdown(self):
         self.killBatchJobs(self.getIssuedBatchJobIDs())  # cleanup jobs
-        for results in self.resultsFiles.itervalues():
+        for results in itervalues(self.resultsFiles):
             exitValue = self._runParasol(['-results=' + results, 'clear', 'sick'],
                                          autoRetry=False)[0]
             if exitValue is not None:

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -20,11 +20,10 @@ import sys
 import subprocess
 import tempfile
 import time
-from Queue import Empty
-from Queue import Queue
 from threading import Thread
 
 # Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 from six import itervalues
 
 from bd2k.util.iterables import concat

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -24,6 +24,9 @@ from threading import Thread
 from threading import Lock, Condition
 from Queue import Queue, Empty
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 import toil
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport, InsufficientSystemResources
 

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -22,9 +22,9 @@ import time
 import math
 from threading import Thread
 from threading import Lock, Condition
-from Queue import Queue, Empty
 
 # Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 from six.moves import xrange
 from six import iteritems
 

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -26,6 +26,7 @@ from Queue import Queue, Empty
 
 # Python 3 compatibility imports
 from six.moves import xrange
+from six import iteritems
 
 import toil
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport, InsufficientSystemResources
@@ -258,7 +259,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
 
     def getRunningBatchJobIDs(self):
         now = time.time()
-        return {jobID: now - info.time for jobID, info in self.runningJobs.iteritems()}
+        return {jobID: now - info.time for jobID, info in iteritems(self.runningJobs)}
 
     def shutdown(self):
         """

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -19,10 +19,10 @@ from pipes import quote
 import subprocess
 import time
 import math
-from Queue import Queue, Empty
 from threading import Thread
 
 # Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 from six import iteritems
 
 from toil.batchSystems import MemoryString

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -22,6 +22,9 @@ import math
 from Queue import Queue, Empty
 from threading import Thread
 
+# Python 3 compatibility imports
+from six import iteritems
+
 from toil.batchSystems import MemoryString
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
 
@@ -183,7 +186,7 @@ class Worker(Thread):
         sbatch_line = ['sbatch', '-Q', '-J', 'toil_job_{}'.format(jobID)]
 
         if self.boss.environment:
-            for k, v in self.boss.environment.iteritems():
+            for k, v in iteritems(self.boss.environment):
                 quoted_value = quote(os.environ[k] if v is None else v)
                 sbatch_line.append('--export={}={}'.format(k, quoted_value))
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -24,6 +24,9 @@ import time
 from argparse import ArgumentParser
 from threading import Thread
 
+# Python 3 compatibility imports
+from six import iteritems
+
 from bd2k.util.exceptions import require
 from bd2k.util.humanize import bytes2human
 
@@ -887,7 +890,7 @@ class Toil(object):
         Sets the environment variables required by the job store and those passed on command line.
         """
         for envDict in (self._jobStore.getEnv(), self.config.environment):
-            for k, v in envDict.iteritems():
+            for k, v in iteritems(envDict):
                 self._batchSystem.setEnv(k, v)
 
     def _serialiseEnv(self):

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-import cPickle
 import logging
 import os
 import re
@@ -25,6 +24,7 @@ from argparse import ArgumentParser
 from threading import Thread
 
 # Python 3 compatibility imports
+from six.moves import cPickle
 from six import iteritems
 
 from bd2k.util.exceptions import require

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -42,7 +42,7 @@ import functools
 
 # Python 3 compatibility imports
 from six.moves import xrange
-from six import iteritems
+from six import iteritems, string_types
 import six.moves.urllib.parse as urlparse
 
 cwllogger = logging.getLogger("cwltool")
@@ -317,7 +317,7 @@ class CWLScatter(Job):
     def run(self, fileStore):
         cwljob = resolve_indirect(self.cwljob)
 
-        if isinstance(self.step.tool["scatter"], basestring):
+        if isinstance(self.step.tool["scatter"], string_types):
             scatter = [self.step.tool["scatter"]]
         else:
             scatter = self.step.tool["scatter"]

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -39,11 +39,11 @@ import logging
 import copy
 import shutil
 import functools
-import urlparse
 
 # Python 3 compatibility imports
 from six.moves import xrange
 from six import iteritems
+import six.moves.urllib.parse as urlparse
 
 cwllogger = logging.getLogger("cwltool")
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -43,6 +43,7 @@ import urlparse
 
 # Python 3 compatibility imports
 from six.moves import xrange
+from six import iteritems
 
 cwllogger = logging.getLogger("cwltool")
 
@@ -105,7 +106,7 @@ def resolve_indirect_inner(d):
 def resolve_indirect(d):
     inner = IndirectDict() if isinstance(d, IndirectDict) else {}
     needEval = False
-    for k, v in d.iteritems():
+    for k, v in iteritems(d):
         if isinstance(v, StepValueFrom):
             inner[k] = v.inner
             needEval = True
@@ -114,7 +115,7 @@ def resolve_indirect(d):
     res = resolve_indirect_inner(inner)
     if needEval:
         ev = {}
-        for k, v in d.iteritems():
+        for k, v in iteritems(d):
             if isinstance(v, StepValueFrom):
                 ev[k] = v.do_eval(res, res[k])
             else:
@@ -328,7 +329,7 @@ class CWLScatter(Job):
 
         valueFrom = {shortname(i["id"]): i["valueFrom"] for i in self.step.tool["inputs"] if "valueFrom" in i}
         def postScatterEval(io):
-            shortio = {shortname(k): v for k, v in io.iteritems()}
+            shortio = {shortname(k): v for k, v in iteritems(io)}
             def valueFromFunc(k, v):
                 if k in valueFrom:
                     return cwltool.expression.do_eval(

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -41,6 +41,9 @@ import shutil
 import functools
 import urlparse
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 cwllogger = logging.getLogger("cwltool")
 
 # The job object passed into CWLJob and CWLWorkflow

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -857,7 +857,7 @@ class CachingFileStore(FileStore):
             # will be renamed into the cache for this node.
             personalCacheDir = ''.join([os.path.dirname(self.localCacheDir), '/.ctmp-',
                                         str(uuid.uuid4())])
-            os.mkdir(personalCacheDir, 0755)
+            os.mkdir(personalCacheDir, 0o755)
             self._createCacheLockFile(personalCacheDir)
             try:
                 os.rename(personalCacheDir, self.localCacheDir)
@@ -1384,7 +1384,7 @@ class CachingFileStore(FileStore):
             with open(self.harbingerFileName + '.tmp', 'w') as harbingerFile:
                 harbingerFile.write(str(os.getpid()))
             # Make this File read only to prevent overwrites
-            os.chmod(self.harbingerFileName + '.tmp', 0444)
+            os.chmod(self.harbingerFileName + '.tmp', 0o444)
             os.rename(self.harbingerFileName + '.tmp', self.harbingerFileName)
 
         def waitOnDownload(self, lockFileHandle):

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -37,6 +37,9 @@ from hashlib import sha1
 from Queue import Queue, Empty
 from threading import Thread, Semaphore, Event
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from bd2k.util.humanize import bytes2human
 from toil.common import cacheDirName, getDirSizeRecursively
 from toil.lib.bioio import makePublicDir

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -34,10 +34,10 @@ from contextlib import contextmanager
 from fcntl import flock, LOCK_EX, LOCK_UN
 from functools import partial
 from hashlib import sha1
-from Queue import Queue, Empty
 from threading import Thread, Semaphore, Event
 
 # Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 from six.moves import xrange
 
 from bd2k.util.humanize import bytes2human

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import, print_function
 
-import cPickle
 import collections
 import importlib
 import inspect
@@ -31,6 +30,7 @@ from contextlib import contextmanager
 from io import BytesIO
 
 # Python 3 compatibility imports
+from six.moves import cPickle
 from six import iteritems
 
 from bd2k.util.exceptions import require

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -31,7 +31,7 @@ from io import BytesIO
 
 # Python 3 compatibility imports
 from six.moves import cPickle
-from six import iteritems
+from six import iteritems, string_types
 
 from bd2k.util.exceptions import require
 from bd2k.util.expando import Expando
@@ -1330,7 +1330,7 @@ class FunctionWrappingJob(Job):
                     # ... and finally fall back to a default value.
                     value = default
             # Optionally, convert strings with metric or binary prefixes.
-            if dehumanize and isinstance(value, basestring):
+            if dehumanize and isinstance(value, string_types):
                 value = human2bytes(value)
             return value
 

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -30,6 +30,9 @@ from argparse import ArgumentParser
 from contextlib import contextmanager
 from io import BytesIO
 
+# Python 3 compatibility imports
+from six import iteritems
+
 from bd2k.util.exceptions import require
 from bd2k.util.expando import Expando
 from bd2k.util.humanize import human2bytes
@@ -894,7 +897,7 @@ class Job(JobLikeObject):
         """
         Sets the values for promises using the return values from this job's run() function.
         """
-        for path, promiseFileStoreIDs in self._rvs.iteritems():
+        for path, promiseFileStoreIDs in iteritems(self._rvs):
             if not path:
                 # Note that its possible for returnValues to be a promise, not an actual return
                 # value. This is the case if the job returns a promise from another job. In

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -24,6 +24,9 @@ from contextlib import contextmanager, closing
 from datetime import timedelta
 from uuid import uuid4
 
+# Python 3 compatibility imports
+from six import itervalues
+
 from bd2k.util.retry import retry_http
 
 from toil.job import JobException
@@ -446,7 +449,7 @@ class AbstractJobStore(object):
 
         def getJobs():
             if jobCache is not None:
-                return jobCache.itervalues()
+                return itervalues(jobCache)
             else:
                 return self.jobs()
 

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 from __future__ import absolute_import
 
-import urllib2
-import urlparse
-
 import shutil
 
 import re
@@ -26,6 +23,8 @@ from uuid import uuid4
 
 # Python 3 compatibility imports
 from six import itervalues
+from six.moves.urllib.request import urlopen
+import six.moves.urllib.parse as urlparse
 
 from bd2k.util.retry import retry_http
 
@@ -964,5 +963,5 @@ class JobStoreSupport(AbstractJobStore):
     def _readFromUrl(cls, url, writable):
         for attempt in retry_http():
             with attempt:
-                with closing(urllib2.urlopen(url.geturl())) as readable:
+                with closing(urlopen(url.geturl())) as readable:
                     shutil.copyfileobj(readable, writable)

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -22,14 +22,13 @@ from multiprocessing import cpu_count
 import os
 import re
 import uuid
-import cPickle
 import base64
 import hashlib
 import itertools
 import repr as reprlib
 
 # Python 3 compatibility imports
-from six.moves import xrange
+from six.moves import xrange, cPickle
 from six import iteritems
 
 from bd2k.util import strict_bool

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -24,10 +24,9 @@ import uuid
 import base64
 import hashlib
 import itertools
-import repr as reprlib
 
 # Python 3 compatibility imports
-from six.moves import xrange, cPickle, StringIO
+from six.moves import xrange, cPickle, StringIO, reprlib
 from six import iteritems
 
 from bd2k.util import strict_bool

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-from StringIO import StringIO
 from contextlib import contextmanager, closing
 import logging
 from multiprocessing import cpu_count
@@ -28,7 +27,7 @@ import itertools
 import repr as reprlib
 
 # Python 3 compatibility imports
-from six.moves import xrange, cPickle
+from six.moves import xrange, cPickle, StringIO
 from six import iteritems
 
 from bd2k.util import strict_bool

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -30,6 +30,7 @@ import repr as reprlib
 
 # Python 3 compatibility imports
 from six.moves import xrange
+from six import iteritems
 
 from bd2k.util import strict_bool
 from bd2k.util.exceptions import panic
@@ -1137,7 +1138,7 @@ class AWSJobStore(AbstractJobStore):
                     srcKey.version_id = self.version
                     with attempt:
                         headers = {k.replace('amz-', 'amz-copy-source-', 1): v
-                                   for k, v in self._s3EncryptionHeaders().iteritems()}
+                                   for k, v in iteritems(self._s3EncryptionHeaders())}
                         self._copyKey(srcKey=srcKey,
                                       dstBucketName=dstKey.bucket.name,
                                       dstKeyName=dstKey.name,

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -28,6 +28,9 @@ import hashlib
 import itertools
 import repr as reprlib
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from bd2k.util import strict_bool
 from bd2k.util.exceptions import panic
 from bd2k.util.objects import InnerClass

--- a/src/toil/jobStores/aws/utils.py
+++ b/src/toil/jobStores/aws/utils.py
@@ -22,6 +22,9 @@ import types
 import errno
 from ssl import SSLError
 
+# Python 3 compatibility imports
+from six import iteritems
+
 from bd2k.util.retry import retry
 from boto.exception import (SDBResponseError,
                             BotoServerError,
@@ -145,7 +148,7 @@ class SDBHelper(object):
         :rtype: (str|None,int)
         :return: the binary data and the number of chunks it was composed from
         """
-        chunks = [(int(k), v) for k, v in attributes.iteritems() if cls._isValidChunkName(k)]
+        chunks = [(int(k), v) for k, v in iteritems(attributes) if cls._isValidChunkName(k)]
         chunks.sort()
         numChunks = len(chunks)
         if numChunks:

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 
 import bz2
-import httplib
 import inspect
 import logging
 import os
@@ -29,6 +28,7 @@ from datetime import datetime, timedelta
 
 # Python 3 compatibility imports
 from six.moves import cPickle
+from six.moves.http_client import HTTPException
 
 from azure.common import AzureMissingResourceHttpError, AzureException
 from azure.storage import SharedAccessPolicy, AccessPolicy
@@ -797,7 +797,7 @@ def defaultRetryPredicate(exception):
     True
     >>> defaultRetryPredicate(socket.gaierror())
     True
-    >>> defaultRetryPredicate(httplib.HTTPException())
+    >>> defaultRetryPredicate(HTTPException())
     True
     >>> defaultRetryPredicate(requests.ConnectionError())
     True
@@ -814,7 +814,7 @@ def defaultRetryPredicate(exception):
     """
     return (isinstance(exception, (socket.error,
                                    socket.gaierror,
-                                   httplib.HTTPException,
+                                   HTTPException,
                                    requests.ConnectionError))
             or isinstance(exception, AzureException) and
             any(message in str(exception).lower() for message in (

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 
 import bz2
-import cPickle
 import httplib
 import inspect
 import logging
@@ -27,6 +26,9 @@ from ConfigParser import RawConfigParser, NoOptionError
 from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+
+# Python 3 compatibility imports
+from six.moves import cPickle
 
 from azure.common import AzureMissingResourceHttpError, AzureException
 from azure.storage import SharedAccessPolicy, AccessPolicy

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -21,7 +21,6 @@ import os
 import re
 import socket
 import uuid
-from ConfigParser import RawConfigParser, NoOptionError
 from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime, timedelta
@@ -29,6 +28,7 @@ from datetime import datetime, timedelta
 # Python 3 compatibility imports
 from six.moves import cPickle
 from six.moves.http_client import HTTPException
+from six.moves.configparser import RawConfigParser, NoOptionError
 
 from azure.common import AzureMissingResourceHttpError, AzureException
 from azure.storage import SharedAccessPolicy, AccessPolicy

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -24,6 +24,9 @@ import tempfile
 import stat
 import errno
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from bd2k.util.exceptions import require
 
 from toil.lib.bioio import absSymPath

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -3,14 +3,13 @@ from contextlib import contextmanager
 import hashlib
 import os
 import uuid
-from StringIO import StringIO
 from bd2k.util.threading import ExceptionalThread
 import boto
 import logging
 import time
 
 # Python 3 compatibility imports
-from six.moves import cPickle
+from six.moves import cPickle, StringIO
 
 from toil.jobStores.abstractJobStore import (AbstractJobStore, NoSuchJobException,
                                              NoSuchFileException,

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -7,8 +7,11 @@ from StringIO import StringIO
 from bd2k.util.threading import ExceptionalThread
 import boto
 import logging
-import cPickle
 import time
+
+# Python 3 compatibility imports
+from six.moves import cPickle
+
 from toil.jobStores.abstractJobStore import (AbstractJobStore, NoSuchJobException,
                                              NoSuchFileException,
                                              ConcurrentFileModificationException)

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -17,10 +17,12 @@ The leader script (of the leader/worker pair) for running jobs.
 """
 from __future__ import absolute_import
 
-import cPickle
 import logging
 import time
 from collections import namedtuple
+
+# Python 3 compatibility imports
+from six.moves import cPickle
 
 from bd2k.util.expando import Expando
 

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -291,7 +291,7 @@ def makePublicDir(dirName):
     """
     if not os.path.exists(dirName):
         os.mkdir(dirName)
-        os.chmod(dirName, 0777)
+        os.chmod(dirName, 0o777)
     return dirName
 
 def getTempFile(suffix="", rootDir=None):
@@ -304,5 +304,5 @@ def getTempFile(suffix="", rootDir=None):
     else:
         tmpFile = os.path.join(rootDir, "tmp_" + getRandomAlphaNumericString() + suffix)
         open(tmpFile, 'w').close()
-        os.chmod(tmpFile, 0777) #Ensure everyone has access to the file.
+        os.chmod(tmpFile, 0o777) #Ensure everyone has access to the file.
         return tmpFile

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -27,6 +27,10 @@ import shutil
 from argparse import ArgumentParser
 from optparse import OptionContainer, OptionGroup
 import subprocess
+
+# Python 3 compatibility imports
+from six.moves import xrange
+
 import xml.etree.cElementTree as ET
 from xml.dom import minidom  # For making stuff pretty
 

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -30,6 +30,7 @@ import subprocess
 
 # Python 3 compatibility imports
 from six.moves import xrange
+from six import string_types
 
 import xml.etree.cElementTree as ET
 from xml.dom import minidom  # For making stuff pretty
@@ -167,7 +168,7 @@ def system(command):
     :type command: str | sequence[string]
     """
     logger.debug('Running: %r', command)
-    subprocess.check_call(command, shell=isinstance(command,basestring), bufsize=-1)
+    subprocess.check_call(command, shell=isinstance(command, string_types), bufsize=-1)
 
 def getTotalCpuTimeAndMemoryUsage():
     """Gives the total cpu time and memory usage of itself and its children.

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -19,6 +19,10 @@ import logging
 import time
 
 import sys
+
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from bd2k.util import memoize
 from boto.ec2.blockdevicemapping import BlockDeviceMapping, BlockDeviceType
 from boto.exception import BotoServerError, EC2ResponseError

--- a/src/toil/provisioners/cgcloud/provisioner.py
+++ b/src/toil/provisioners/cgcloud/provisioner.py
@@ -19,6 +19,9 @@ import time
 from collections import Iterable
 from urllib2 import urlopen
 
+# Python 3 compatibility imports
+from six import iterkeys, itervalues
+
 import boto.ec2
 from bd2k.util import memoize, parse_iso_utc, less_strict_bool
 from bd2k.util.exceptions import require
@@ -215,12 +218,12 @@ class CGCloudProvisioner(AbstractProvisioner):
                     # Get all nodes to be safe, not just the ones whose preemptability matches,
                     # in case there's a problem with a node determining its own preemptability.
                     nodes = self.batchSystem.getNodes()
-                    for nodeAddress in nodes.iterkeys():
+                    for nodeAddress in iterkeys(nodes):
                         instancesByAddress.pop(nodeAddress, None)
             if instancesByAddress:
                 log.warn('%i instance(s) out of %i did not join the cluster as worker nodes. They '
                          'will be terminated.', len(instancesByAddress), numInstancesAdded)
-                instanceIds = [i.id for i in instancesByAddress.itervalues()]
+                instanceIds = [i.id for i in itervalues(instancesByAddress)]
                 self._logAndTerminate(instanceIds)
                 numInstancesAdded -= len(instanceIds)
             else:

--- a/src/toil/provisioners/cgcloud/provisioner.py
+++ b/src/toil/provisioners/cgcloud/provisioner.py
@@ -17,10 +17,10 @@ import os
 import re
 import time
 from collections import Iterable
-from urllib2 import urlopen
 
 # Python 3 compatibility imports
 from six import iterkeys, itervalues
+from six.moves.urllib.request import urlopen
 
 import boto.ec2
 from bd2k.util import memoize, parse_iso_utc, less_strict_bool

--- a/src/toil/realtimeLogger.py
+++ b/src/toil/realtimeLogger.py
@@ -22,9 +22,11 @@ import os.path
 import json
 import logging
 import logging.handlers
-import SocketServer
 import socket
 import threading
+
+# Python 3 compatibility imports
+from six.moves import socketserver as SocketServer
 
 import toil.lib.bioio
 

--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -27,8 +27,10 @@ from contextlib import closing
 from io import BytesIO
 from pydoc import locate
 from tempfile import mkdtemp
-from urllib2 import urlopen
 from zipfile import ZipFile, PyZipFile
+
+# Python 3 compatibility imports
+from six.moves.urllib.request import urlopen
 
 from bd2k.util import strict_bool
 from bd2k.util.iterables import concat

--- a/src/toil/serviceManager.py
+++ b/src/toil/serviceManager.py
@@ -16,8 +16,10 @@ from __future__ import absolute_import
 
 import logging
 import time
-from Queue import Queue, Empty
 from threading import Thread, Event
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 
 logger = logging.getLogger( __name__ )
 

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -33,6 +33,9 @@ from textwrap import dedent
 from unittest.util import strclass
 from urllib2 import urlopen
 
+# Python 3 compatibility imports
+from six import iteritems, itervalues
+
 from bd2k.util import less_strict_bool, memoize
 from bd2k.util.files import mkdir_p
 from bd2k.util.iterables import concat
@@ -573,7 +576,7 @@ def make_tests(generalMethod, targetClass=None, **kwargs):
 
         :return: the popped key, value tuple
         """
-        k, v = next(iter(kwargs.iteritems()))
+        k, v = next(iter(iteritems(kwargs)))
         d.pop(k)
         return k, v
 
@@ -717,7 +720,7 @@ class ApplianceTestSupport(ToilTest):
             """
             :param ApplianceTestSupport outer:
             """
-            assert all(' ' not in v for v in mounts.itervalues()), 'No spaces allowed in mounts'
+            assert all(' ' not in v for v in itervalues(mounts)), 'No spaces allowed in mounts'
             super(ApplianceTestSupport.Appliance, self).__init__()
             self.outer = outer
             self.mounts = mounts
@@ -734,7 +737,7 @@ class ApplianceTestSupport(ToilTest):
                                    '--net=host',
                                    '-i',
                                    '--name=' + self.containerName,
-                                   ['--volume=%s:%s' % mount for mount in self.mounts.iteritems()],
+                                   ['--volume=%s:%s' % mount for mount in iteritems(self.mounts)],
                                    image,
                                    self._containerCommand()))
                 log.info('Running %r', args)
@@ -781,7 +784,7 @@ class ApplianceTestSupport(ToilTest):
             """
             # Delete all files within each mounted directory, but not the directory itself.
             cmd = 'shopt -s dotglob && rm -rf ' + ' '.join(v + '/*'
-                                                           for k, v in self.mounts.iteritems()
+                                                           for k, v in iteritems(self.mounts)
                                                            if os.path.isdir(k))
             self.outer._run('docker', 'run',
                             '--rm',

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -31,10 +31,10 @@ from inspect import getsource
 from subprocess import PIPE, Popen, CalledProcessError, check_output
 from textwrap import dedent
 from unittest.util import strclass
-from urllib2 import urlopen
 
 # Python 3 compatibility imports
 from six import iteritems, itervalues
+from six.moves.urllib.request import urlopen
 
 from bd2k.util import less_strict_bool, memoize
 from bd2k.util.files import mkdir_p

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -16,7 +16,9 @@ import json
 import os
 import subprocess
 import re
-import StringIO
+
+# Python 3 compatibility imports
+from six.moves import StringIO
 
 from toil.test import ToilTest, needs_cwl
 
@@ -26,7 +28,7 @@ class CWLTest(ToilTest):
     def _tester(self, cwlfile, jobfile, outDir, expect):
         from toil.cwl import cwltoil
         rootDir = self._projectRootPath()
-        st = StringIO.StringIO()
+        st = StringIO()
         cwltoil.main(['--outdir', outDir,
                             os.path.join(rootDir, cwlfile),
                             os.path.join(rootDir, jobfile)],

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -19,6 +19,7 @@ import re
 
 # Python 3 compatibility imports
 from six.moves import StringIO
+from six import u as unicode
 
 from toil.test import ToilTest, needs_cwl
 

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -27,13 +27,13 @@ import urllib2
 import urlparse
 import uuid
 from stubserver import FTPStubServer
-from Queue import Queue
 from abc import abstractmethod, ABCMeta
 from itertools import chain, islice, count
 from threading import Thread
 from unittest import skip
 
 # Python 3 compatibility imports
+from six.moves.queue import Queue
 from six.moves import xrange
 from six import iteritems
 

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-import SocketServer
 import hashlib
 import logging
 import threading
@@ -32,7 +31,7 @@ from unittest import skip
 
 # Python 3 compatibility imports
 from six.moves.queue import Queue
-from six.moves import xrange
+from six.moves import xrange, socketserver as SocketServer
 from six import iteritems
 import six.moves.urllib.parse as urlparse
 from six.moves.urllib.request import urlopen, Request

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -33,6 +33,9 @@ from itertools import chain, islice, count
 from threading import Thread
 from unittest import skip
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from bd2k.util import memoize
 from bd2k.util.exceptions import panic
 # noinspection PyPackageRequirements

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 import hashlib
 import logging
 import threading
-import SimpleHTTPServer
 import os
 import shutil
 import tempfile
@@ -31,7 +30,7 @@ from unittest import skip
 
 # Python 3 compatibility imports
 from six.moves.queue import Queue
-from six.moves import xrange, socketserver as SocketServer
+from six.moves import xrange, socketserver as SocketServer, SimpleHTTPServer
 from six import iteritems
 import six.moves.urllib.parse as urlparse
 from six.moves.urllib.request import urlopen, Request

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -35,6 +35,7 @@ from unittest import skip
 
 # Python 3 compatibility imports
 from six.moves import xrange
+from six import iteritems
 
 from bd2k.util import memoize
 from bd2k.util.exceptions import panic
@@ -407,7 +408,7 @@ class AbstractJobStoreTest:
 
         @classmethod
         def cleanUpExternalStores(cls):
-            for test, store in cls.externalStoreCache.iteritems():
+            for test, store in iteritems(cls.externalStoreCache):
                 logger.info('Cleaning up external store for %s.', test)
                 test._cleanUpExternalStore(store)
 

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -23,8 +23,6 @@ import os
 import shutil
 import tempfile
 import time
-import urllib2
-import urlparse
 import uuid
 from stubserver import FTPStubServer
 from abc import abstractmethod, ABCMeta
@@ -36,6 +34,8 @@ from unittest import skip
 from six.moves.queue import Queue
 from six.moves import xrange
 from six import iteritems
+import six.moves.urllib.parse as urlparse
+from six.moves.urllib.request import urlopen, Request
 
 from bd2k.util import memoize
 from bd2k.util.exceptions import panic
@@ -649,7 +649,7 @@ class AbstractJobStoreTest:
                 self.assertTrue(os.path.exists(path))
             else:
                 try:
-                    urllib2.urlopen(urllib2.Request(url))
+                    urlopen(Request(url))
                 except:
                     self.fail()
 

--- a/src/toil/test/provisioners/cgcloud/provisionerTest.py
+++ b/src/toil/test/provisioners/cgcloud/provisionerTest.py
@@ -20,8 +20,10 @@ import subprocess
 from abc import abstractmethod, ABCMeta
 from inspect import getsource
 from textwrap import dedent
-from urlparse import urlparse
 from uuid import uuid4
+
+# Python 3 compatibility imports
+import six.moves.urllib.parse as urlparse
 
 from bd2k.util.iterables import concat
 from cgcloud.lib.test import CgcloudTestCase
@@ -254,7 +256,7 @@ class CGCloudRNASeqTest(AbstractCGCloudProvisionerTest):
         self.numSamples = 2
 
     def _getScript(self):
-        toilScripts = urlparse(self.toilScripts)
+        toilScripts = urlparse.urlparse(self.toilScripts)
         if toilScripts.netloc:
             self._leader('mkdir toil-scripts'
                          '; curl -L ' + toilScripts.geturl() +

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -21,6 +21,7 @@ import random
 
 # Python 3 compatibility imports
 from six.moves import xrange
+from six import iteritems
 
 from bd2k.util.objects import InnerClass
 
@@ -222,7 +223,7 @@ class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisi
 
     # Stub out all AbstractBatchSystem methods since they are never called
 
-    for name, value in AbstractBatchSystem.__dict__.iteritems():
+    for name, value in iteritems(AbstractBatchSystem.__dict__):
         if getattr(value, '__isabstractmethod__', False):
             exec 'def %s(): pass' % name
         # Without this, the class would end up with .name and .value attributes

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -19,6 +19,9 @@ from Queue import Queue, Empty
 import logging
 import random
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from bd2k.util.objects import InnerClass
 
 from toil.job import JobNode

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -15,11 +15,11 @@
 from __future__ import absolute_import
 import time
 from threading import Thread, Event
-from Queue import Queue, Empty
 import logging
 import random
 
 # Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 from six.moves import xrange
 from six import iteritems
 

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -19,6 +19,10 @@ import random
 from uuid import uuid4
 import logging
 import subprocess
+
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from toil import resolveEntryPoint
 
 from toil.batchSystems.parasolTestSupport import ParasolTestSupport

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import unittest
 import os
 import random
@@ -301,7 +301,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
             l = open(tempFile, 'r').read()
             fileSize = os.path.getsize(tempFile)
             midPoint = getMidPoint(tempFile, 0, fileSize)
-            print "the mid point is %i of a file of %i bytes" % (midPoint, fileSize)
+            print("the mid point is %i of a file of %i bytes" % (midPoint, fileSize))
             assert midPoint < fileSize
             assert l[midPoint] == '\n'
             assert midPoint >= 0

--- a/src/toil/test/src/fileStoreTest.py
+++ b/src/toil/test/src/fileStoreTest.py
@@ -33,6 +33,8 @@ import signal
 import time
 import unittest
 
+# Python 3 compatibility imports
+from six.moves import xrange
 
 # Some tests take too long on the AWS and Azure Job stores and are unquitable for CI.  They can be
 # be run during manual tests by setting this to False.

--- a/src/toil/test/src/jobFileStoreTest.py
+++ b/src/toil/test/src/jobFileStoreTest.py
@@ -16,6 +16,9 @@ import random
 import os
 import errno
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from toil.common import Toil
 from toil.job import Job
 from toil.test import ToilTest

--- a/src/toil/test/src/jobServiceTest.py
+++ b/src/toil/test/src/jobServiceTest.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import random
 import unittest
@@ -88,7 +88,7 @@ class JobServiceTest(ToilTest):
             try:
                 self.runToil(makeWorkflow(), badWorker=0.0, maxServiceJobs=2, deadlockWait=5)
             except DeadlockException:
-                print "Got expected deadlock exception"
+                print("Got expected deadlock exception")
             else:
                 assert 0
                 

--- a/src/toil/test/src/jobServiceTest.py
+++ b/src/toil/test/src/jobServiceTest.py
@@ -16,6 +16,9 @@ import os
 import random
 import unittest
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from toil.lib.bioio import getTempFile
 from toil.job import Job
 from toil.test import ToilTest

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -16,6 +16,9 @@ import unittest
 import os
 import random
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from toil.common import Toil
 from toil.leader import FailedJobsException
 from toil.lib.bioio import getTempFile

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import unittest
 import os
 import random
@@ -317,10 +317,10 @@ class JobTest(ToilTest):
                         adjacencyList[int(j)].add(i)
             # Check the ordering retains an acyclic graph
             if not self.isAcyclic(adjacencyList):
-                print "ORDERING", ordering
-                print "CHILD EDGES", childEdges
-                print "FOLLOW ON EDGES", followOnEdges
-                print "ADJACENCY LIST", adjacencyList
+                print("ORDERING", ordering)
+                print("CHILD EDGES", childEdges)
+                print("FOLLOW ON EDGES", followOnEdges)
+                print("ADJACENCY LIST", adjacencyList)
             self.assertTrue(self.isAcyclic(adjacencyList))
 
     @staticmethod

--- a/src/toil/test/src/miscTests.py
+++ b/src/toil/test/src/miscTests.py
@@ -21,6 +21,9 @@ import os
 import random
 import tempfile
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 
 class MiscTests(ToilTest):
     """

--- a/src/toil/test/src/resourceTest.py
+++ b/src/toil/test/src/resourceTest.py
@@ -212,7 +212,7 @@ class ResourceTest(ToilTest):
         shebang = '#! %s\n' % sys.executable
         with tempFileContaining(shebang + scriptBody) as scriptPath:
             self.assertFalse(scriptPath.endswith(('.py', '.pyc')))
-            os.chmod(scriptPath, 0755)
+            os.chmod(scriptPath, 0o755)
             jobStorePath = scriptPath + '.jobStore'
             process = Popen([scriptPath, jobStorePath], stderr=PIPE)
             stdout, stderr = process.communicate()

--- a/src/toil/test/src/resumabilityTest.py
+++ b/src/toil/test/src/resumabilityTest.py
@@ -15,6 +15,10 @@
 from __future__ import absolute_import
 import os
 from StringIO import StringIO
+
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from toil.job import Job
 from toil.test import ToilTest
 from toil.jobStores.abstractJobStore import NoSuchFileException

--- a/src/toil/test/src/resumabilityTest.py
+++ b/src/toil/test/src/resumabilityTest.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 import os
-from StringIO import StringIO
 
 # Python 3 compatibility imports
 from six.moves import xrange

--- a/src/toil/utils/toilMain.py
+++ b/src/toil/utils/toilMain.py
@@ -4,6 +4,8 @@ import pkg_resources
 import os
 import sys
 
+# Python 3 compatibility imports
+from six import iteritems, iterkeys
 
 def main():
     modules = loadModules()
@@ -34,8 +36,8 @@ def main():
 def loadModules():
     # noinspection PyUnresolvedReferences
     from toil.utils import toilKill, toilStats, toilStatus, toilClean, toilLaunchCluster, toilDestroyCluster, toilSSHCluster, toilRsyncCluster
-    commandMapping = {name[4:].lower(): module for name, module in locals().iteritems()}
-    commandMapping = {name[:-7]+'-'+name[-7:] if name.endswith('cluster') else name: module for name, module in commandMapping.iteritems()}
+    commandMapping = {name[4:].lower(): module for name, module in iteritems(locals())}
+    commandMapping = {name[:-7]+'-'+name[-7:] if name.endswith('cluster') else name: module for name, module in iteritems(commandMapping)}
     return commandMapping
 
 def printHelp(modules):
@@ -46,5 +48,5 @@ def printHelp(modules):
              "where COMMAND is one of the following:\n\n{descriptions}\n\n")
     print(usage.format(
         name=os.path.basename(sys.argv[0]),
-        commands='|'.join(modules.iterkeys()),
-        descriptions='\n'.join("%s - %s" % (n, m.__doc__.strip()) for n, m in modules.iteritems())))
+        commands='|'.join(iterkeys(modules)),
+        descriptions='\n'.join("%s - %s" % (n, m.__doc__.strip()) for n, m in iteritems(modules))))

--- a/src/toil/utils/toilStats.py
+++ b/src/toil/utils/toilStats.py
@@ -16,7 +16,7 @@
 Reports statistical data about a given Toil workflow.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 from functools import partial
 import logging
 import json
@@ -55,7 +55,7 @@ class ColumnWidths(object):
     def report(self):
         for c in self.categories:
             for f in self.fields:
-                print '%s %s %d' % (c, f, self.getWidth(c, f))
+                print('%s %s %d' % (c, f, self.getWidth(c, f)))
 
 def initializeOptions(parser):
     parser.add_argument("jobStore", type=str,
@@ -588,7 +588,7 @@ def reportData(tree, options):
         fileHandle.write(out_str)
         fileHandle.close()
     # Now dump onto the screen
-    print out_str
+    print(out_str)
 
 def main():
     """ Reports stats on the workflow, use with --stats option to toil.

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import sys
 import copy
@@ -207,7 +207,7 @@ def main():
     try:
 
         #Put a message at the top of the log, just to make sure it's working.
-        print "---TOIL WORKER OUTPUT LOG---"
+        print("---TOIL WORKER OUTPUT LOG---")
         sys.stdout.flush()
         
         #Log the number of open file descriptors so we can tell if we're leaking

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -145,7 +145,7 @@ def main():
         
     # Dir to put all this worker's temp files in.
     localWorkerTempDir = tempfile.mkdtemp(dir=toilWorkflowDir)
-    os.chmod(localWorkerTempDir, 0755)
+    os.chmod(localWorkerTempDir, 0o755)
 
     ##########################################
     #Setup the logging

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -24,9 +24,12 @@ import traceback
 import time
 import socket
 import logging
-import cPickle
 import shutil
 from threading import Thread
+
+# Python 3 compatibility imports
+from six.moves import cPickle
+
 from bd2k.util.expando import Expando, MagicExpando
 from toil.common import Toil
 from toil.fileStore import FileStore

--- a/version_template.py
+++ b/version_template.py
@@ -118,7 +118,7 @@ def dirty():
 
 
 def expand_(name=None):
-    variables = {k: v for k, v in globals().iteritems()
+    variables = {k: v for k, v in globals().items()
                  if not k.startswith('_') and not k.endswith('_')}
 
     def resolve(k):
@@ -128,7 +128,7 @@ def expand_(name=None):
         return v
 
     if name is None:
-        return ''.join("%s = %s\n" % (k, repr(resolve(k))) for k, v in variables.iteritems())
+        return ''.join("%s = %s\n" % (k, repr(resolve(k))) for k, v in variables.items())
     else:
         return resolve(name)
 


### PR DESCRIPTION
This PR includes following changes:

- Adds [`six`](https://pypi.python.org/pypi/six) as a dependency.
- Replaces Python incompatible imports with equivalent `six` imports.
- Replaces `print` statements with `print` function calls.
- Replaces old-style ocatal literals (`0...`) with new-style literals (`0o...`).