### PR TITLE
Add docker_call to core Toil (resolves #1387)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ The 'pypi' target publishes the current commit of Toil to PyPI after enforcing t
 copy and the index are clean.
 
 The 'docker' target builds the Docker images that make up the Toil appliance. You may set the
-TOIL_DOCKER_REGISTRY variable to override the default registry that the 'docker_push' target pushes
+TOIL_DOCKER_REGISTRY variable to override the default registry that the 'push_docker' target pushes
 the appliance images to, for example:
 
 	TOIL_DOCKER_REGISTRY=quay.io/USER make docker
@@ -84,7 +84,11 @@ docker_tag:=$(shell $(python) version_template.py dockerTag)
 default_docker_registry:=$(shell $(python) version_template.py dockerRegistry)
 docker_path:=$(strip $(shell which docker))
 ifdef docker_path
-    export TOIL_DOCKER_REGISTRY?=$(default_docker_registry)
+    ifdef docker_registry
+        export TOIL_DOCKER_REGISTRY?=$(docker_registry)
+    else
+        export TOIL_DOCKER_REGISTRY?=$(default_docker_registry)
+    endif
 else
     $(warning Cannot find 'docker' executable. Docker-related targets will be skipped.)
     export TOIL_DOCKER_REGISTRY:=

--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -26,6 +26,7 @@ dependencies = ' '.join(['libffi-dev',  # For client side encryption for 'azure'
                          'libssl-dev',
                          'wget',
                          'curl',
+                         'openssh-server',
                          'mesos=1.0.0-2.0.89.ubuntu1404',
                          'rsync',
                          'screen'])
@@ -62,6 +63,13 @@ print heredoc('''
         && apt-get -y update \
         && apt-get -y install {dependencies} \
         && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+    RUN mkdir /root/.ssh && \
+        chmod 700 /root/.ssh
+
+    ADD waitForKey.sh /usr/bin/waitForKey.sh
+
+    RUN chmod 777 /usr/bin/waitForKey.sh
 
     # The stock pip is too old and can't install from sdist with extras
     RUN pip install --upgrade pip==8.1.2

--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import os
 import textwrap
 
@@ -54,7 +55,7 @@ motd = heredoc('''
 # Prepare motd to be echoed in the Dockerfile using a RUN statement that uses bash's print
 motd = ''.join(l + '\\n\\\n' for l in motd.splitlines())
 
-print heredoc('''
+print(heredoc('''
     FROM ubuntu:14.04
 
     RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" \
@@ -113,4 +114,4 @@ print heredoc('''
 
     RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc \
         && printf '{motd}' > /etc/motd
-''')
+'''))

--- a/docker/waitForKey.sh
+++ b/docker/waitForKey.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+while [ ! -f "$1" ]; do sleep 2; done; mesos-slave "${@:2}"

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -596,6 +596,85 @@ Example::
 
             toil.exportFile(outputFileID, 'file:///some/other/local/path')
 
+
+Using Docker containers in Toil
+-------------------------------
+
+Docker containers are commonly used with Toil. The combination of Toil and Docker
+allows for pipelines to be fully portable between any platform that has both Toil
+and Docker installed. Docker eliminates the need for the user to do any other tool
+installation or environment setup.
+
+In order to use Docker containers with Toil, Docker must be installed on all
+workers of the cluster. Instructions for installing Docker can be found on the
+`Docker`_ website.
+
+.. _Docker: https://docs.docker.com/engine/getstarted/step_one/
+
+When using CGCloud or Toil-based autoscaling, Docker will be automatically set up
+on the cluster's worker nodes, so no additional installation steps are necessary.
+Further information on using Toil-based autoscaling can be found in the `Toil
+autoscaling documentation <Autoscaling>`.
+
+In order to use docker containers in a Toil workflow, the container can be built
+locally or downloaded in real time from an online docker repository like Quay_. If
+the container is not in a repository, the container's layers must be accessible on
+each node of the cluster.
+
+.. _Quay: quay.io
+
+When invoking docker containers from within a Toil workflow, it is strongly
+recommended that you use :func:`dockerCall`, a toil job function provided in
+``toil.lib.docker``. ``dockerCall`` provides a layer of abstraction over using the
+``subprocess`` module to call Docker directly, and provides container cleanup on
+job failure. When docker containers are run without this feature, failed jobs can
+result in resource leaks.
+
+In order to use ``dockerCall``, your installation of Docker must be set up to run
+without ``sudo``. Instructions for setting this up can be found here_.
+
+.. _here: https://docs.docker.com/engine/installation/linux/ubuntulinux/#/create-a-docker-group
+
+An example of a basic ``dockerCall`` is below:
+
+    dockerCall(job=job,
+                tool='quay.io/ucsc_cgl/bwa',
+                work_dir=job.fileStore.getLocalTempDir(),
+                parameters=['index', '/data/reference.fa'])
+
+``dockerCall`` can also be added to workflows like any other job function:
+
+     from toil.job import Job
+ 
+     align = Job.wrapJobFn(dockerCall,
+                           tool='quay.io/ucsc_cgl/bwa',
+                           work_dir=job.fileStore.getLocalTempDir(),
+                           parameters=['index', '/data/reference.fa']))
+
+     if __name__=="__main__":
+         options = Job.Runner.getDefaultOptions("./toilWorkflowRun")
+         options.logLevel = "INFO"
+         Job.Runner.startToil(align, options)
+
+`cgl-docker-lib`_ contains ``dockerCall``-compatible Dockerized tools that are
+commonly used in bioinformatics analysis. 
+
+.. _cgl-docker-lib: https://github.com/BD2KGenomics/cgl-docker-lib/blob/master/README.md
+
+The documentation provides guidelines for developing your own Docker containers
+that can be used with Toil and ``dockerCall``. In order for a container to be
+compatible with ``dockerCall``, it must have an ``ENTRYPOINT`` set to a wrapper
+script, as described in cgl-docker-lib containerization standards. Alternately,
+the entrypoint to the container can be set using the docker option
+``--entrypoint``. The container should be runnable directly with Docker as:
+
+    $ docker run <docker parameters> <tool name> <tool parameters>
+
+For example:
+
+    $ docker run -d quay.io/ucsc-cgl/bwa -s -o /data/aligned /data/ref.fa'
+
+
 .. _service-dev-ref:
 
 Services

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,7 +80,7 @@ Here's what each extra provides:
    ``easy_install -a <path_to_egg>``. Note that on Ubuntu Trusty you may need
    to upgrade ``protobuf`` via ``pip install --upgrade protobuf`` **before**
    running the above ``easy_install`` command.
-   
+
    If you intend to install Toil with the ``mesos`` extra into a virtualenv, be
    sure to create that virtualenv with
 
@@ -317,6 +317,11 @@ which contains Troubleshooting sections.
       cgcloud ssh toil-leader
 
 At this point, any Toil script can be run on the distributed AWS cluster following instructions in :ref:`runningAWS`.
+
+Finally, if you wish to tear down the cluster and remove all its data
+permanently, cgcloud allows you to do so without logging into the AWS web interface::
+
+      cgcloud terminate-cluster toil
 
 .. _installationAzure:
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -65,6 +65,8 @@ support for the stable v1.0 specification, only lacking the following features:
   a good workaround.
 - `File literals <http://www.commonwl.org/v1.0/CommandLineTool.html#File>`_ that
   specify only ``contents`` to a File without an explicit file name.
+- Complex file inputs -- from ExpressionTool or a default value, both of which do not yet
+  get cleanly staged into Toil file management.
 
 To run in local batch mode, provide the CWL file and the input object file::
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ def runSetup():
         url="https://github.com/BD2KGenomics/toil",
         install_requires=[
             'bd2k-python-lib>=1.14a1.dev35',
-            'dill==0.2.5'],
+            'dill==0.2.5',
+            'six>=1.10.0'],
         extras_require={
             'mesos': [
                 'psutil==3.0.1'],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def runSetup():
                 'gcs_oauth2_boto_plugin==1.9',
                 botoRequirement],
             'cwl': [
-                'cwltool==1.0.20160714182449']},
+                'cwltool==1.0.20161221171240']},
         package_dir={'': 'src'},
         packages=find_packages(where='src',
                                # Note that we intentionally include the top-level `test` package for

--- a/src/toil/batchSystems/__init__.py
+++ b/src/toil/batchSystems/__init__.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+import sys
 
+if sys.version_info >= (3, 0):
+
+    # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
+    def cmp(a, b):
+        return (a > b) - (a < b)
 
 class MemoryString:
     def __init__(self, string):

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -19,8 +19,11 @@ from pipes import quote
 import subprocess
 import time
 import math
-from Queue import Queue, Empty
 from threading import Thread
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
+from six import iteritems
 
 from toil.batchSystems import MemoryString
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
@@ -165,7 +168,7 @@ class Worker(Thread):
         if self.boss.environment:
             qsubline.append('-v')
             qsubline.append(','.join(k + '=' + quote(os.environ[k] if v is None else v)
-                                     for k, v in self.boss.environment.iteritems()))
+                                     for k, v in iteritems(self.boss.environment)))
 
         reqline = list()
         if mem is not None:

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -21,9 +21,11 @@ from __future__ import absolute_import
 import logging
 import subprocess
 import time
-from Queue import Queue, Empty
 from threading import Thread
 from datetime import date
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 
 from toil.batchSystems import MemoryString
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -137,6 +137,9 @@ class LSFBatchSystem(BatchSystemSupport):
     def supportsHotDeployment(cls):
         return False
 
+    def shutdown(self):
+        pass
+
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         super(LSFBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
         self.lsfResultsFile = self._getResultsFileName(config.jobStore)

--- a/src/toil/batchSystems/mesos/__init__.py
+++ b/src/toil/batchSystems/mesos/__init__.py
@@ -42,6 +42,8 @@ class ResourceRequirement( namedtuple('_ResourceRequirement', (
 ToilJob = namedtuple('ToilJob', (
     # A job ID specific to this batch system implementation
     'jobID',
+    # What string to display in the mesos UI
+    'name',
     # A ResourceRequirement tuple describing the resources needed by this job
     'resources',
     # The command to be run on the worker node

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -21,12 +21,16 @@ import pickle
 import pwd
 import socket
 import time
-from Queue import Queue, Empty
 from collections import defaultdict
 from operator import attrgetter
 from struct import unpack
 
 import itertools
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
+from six import iteritems
+
 import mesos.interface
 import mesos.native
 from bd2k.util import strict_bool
@@ -534,7 +538,7 @@ class MesosBatchSystem(BatchSystemSupport,
         nodeAddress = message.pop('address')
         executor = self._registerNode(nodeAddress, slaveId.value)
         # Handle optional message fields
-        for k, v in message.iteritems():
+        for k, v in iteritems(message):
             if k == 'nodeInfo':
                 assert isinstance(v, dict)
                 executor.nodeInfo = NodeInfo(**v)
@@ -556,7 +560,7 @@ class MesosBatchSystem(BatchSystemSupport,
 
     def getNodes(self, preemptable=None):
         return {nodeAddress: executor.nodeInfo
-                for nodeAddress, executor in self.executors.iteritems()
+                for nodeAddress, executor in iteritems(self.executors)
                 if time.time() - executor.lastSeen < 600
                 and (preemptable is None
                      or preemptable == (executor.slaveId not in self.nonPreemptibleNodes))}

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -437,7 +437,7 @@ class MesosBatchSystem(BatchSystemSupport,
             preemptable = False
             for attribute in offer.attributes:
                 if attribute.name == 'preemptable':
-                    preemptable = bool(attribute.scalar.value)
+                    preemptable = strict_bool(attribute.text.value)
             if preemptable:
                 try:
                     self.nonPreemptibleNodes.remove(offer.slave_id.value)

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -538,6 +538,7 @@ class MesosBatchSystem(BatchSystemSupport,
             if k == 'nodeInfo':
                 assert isinstance(v, dict)
                 executor.nodeInfo = NodeInfo(**v)
+                self.executors[nodeAddress] = executor
             else:
                 raise RuntimeError("Unknown message field '%s'." % k)
 

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -146,6 +146,7 @@ class MesosBatchSystem(BatchSystemSupport,
         self.checkResourceRequest(jobNode.memory, jobNode.cores, jobNode.disk)
         jobID = next(self.unusedJobID)
         job = ToilJob(jobID=jobID,
+                      name=str(jobNode),
                       resources=ResourceRequirement(**jobNode._requirements),
                       command=jobNode.command,
                       userScript=self.userScript,
@@ -449,7 +450,7 @@ class MesosBatchSystem(BatchSystemSupport,
         task.task_id.value = str(job.jobID)
         task.slave_id.value = offer.slave_id.value
         # FIXME: what bout
-        task.name = str(job)
+        task.name = job.name
         task.data = pickle.dumps(job)
         task.executor.MergeFrom(self.executor)
 

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -20,9 +20,11 @@ import sys
 import subprocess
 import tempfile
 import time
-from Queue import Empty
-from Queue import Queue
 from threading import Thread
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
+from six import itervalues
 
 from bd2k.util.iterables import concat
 from bd2k.util.processes import which
@@ -234,7 +236,7 @@ class ParasolBatchSystem(BatchSystemSupport):
         created by other users.
         """
         issuedJobs = set()
-        for resultsFile in self.resultsFiles.itervalues():
+        for resultsFile in itervalues(self.resultsFiles):
             issuedJobs.update(self.getJobIDsForResultsFile(resultsFile))
 
         return list(issuedJobs)
@@ -352,7 +354,7 @@ class ParasolBatchSystem(BatchSystemSupport):
 
     def shutdown(self):
         self.killBatchJobs(self.getIssuedBatchJobIDs())  # cleanup jobs
-        for results in self.resultsFiles.itervalues():
+        for results in itervalues(self.resultsFiles):
             exitValue = self._runParasol(['-results=' + results, 'clear', 'sick'],
                                          autoRetry=False)[0]
             if exitValue is not None:

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -120,33 +120,6 @@ class SingleMachineBatchSystem(BatchSystemSupport):
             self.workerThreads.append(worker)
             worker.start()
 
-    def _getDebugCmd(self, jobCommand):
-        """Calculate useful debugging command line, handling CWL runs.
-
-        Tries to print out underlying CWL base command being run if possible,
-        otherwise defaulting to the toil jobCommand.
-        """
-        debug_cmd = jobCommand
-        cmd_args = jobCommand.split()
-        if len(cmd_args) == 3 and cmd_args[0] == "_toil_worker":
-            _, job_store_locator, job_store_id = cmd_args
-            if job_store_locator.startswith("file:") or os.path.exists(job_store_locator):
-                import cPickle
-                import marshal as pickler
-                job_store_locator = job_store_locator.replace("file:", "")
-                job_cmd_file = os.path.join(job_store_locator, "tmp", job_store_id, "job")
-                with open(job_cmd_file) as in_handle:
-                    job = pickler.load(in_handle)
-                if job.get("command"):
-                    command_parts = job["command"].split()
-                    input_pickle_file = os.path.join(job_store_locator, "tmp", command_parts[1])
-                    with open(input_pickle_file) as in_handle:
-                        input = cPickle.load(in_handle)
-                    if (hasattr(input, "cwltool") and hasattr(input.cwltool, "tool")
-                            and "baseCommand" in input.cwltool.tool):
-                        debug_cmd = " ".join(input.cwltool.tool["baseCommand"])
-        return debug_cmd
-
     # Note: The input queue is passed as an argument because the corresponding attribute is reset
     # to None in shutdown()
 
@@ -168,7 +141,6 @@ class SingleMachineBatchSystem(BatchSystemSupport):
                                   jobCores)
                         with self.coreFractions.acquisitionOf(coreFractions):
                             with self.disk.acquisitionOf(jobDisk):
-                                log.debug("Executing command: '%s'.", self._getDebugCmd(jobCommand))
                                 startTime = time.time() #Time job is started
                                 with self.popenLock:
                                     popen = subprocess.Popen(jobCommand,

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -22,7 +22,11 @@ import time
 import math
 from threading import Thread
 from threading import Lock, Condition
-from Queue import Queue, Empty
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
+from six.moves import xrange
+from six import iteritems
 
 import toil
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport, InsufficientSystemResources
@@ -227,7 +231,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
 
     def getRunningBatchJobIDs(self):
         now = time.time()
-        return {jobID: now - info.time for jobID, info in self.runningJobs.iteritems()}
+        return {jobID: now - info.time for jobID, info in iteritems(self.runningJobs)}
 
     def shutdown(self):
         """

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -186,9 +186,13 @@ class Worker(Thread):
         sbatch_line = ['sbatch', '-Q', '-J', 'toil_job_{}'.format(jobID)]
 
         if self.boss.environment:
+            argList = []
+            
             for k, v in iteritems(self.boss.environment):
                 quoted_value = quote(os.environ[k] if v is None else v)
-                sbatch_line.append('--export={}={}'.format(k, quoted_value))
+                argList.append('{}={}'.format(k, quoted_value))
+                
+            sbatch_line.append('--export=' + ','.join(argList))
 
         if mem is not None:
             # memory passed in is in bytes, but slurm expects megabytes
@@ -221,9 +225,23 @@ class Worker(Thread):
         except OSError as e:
             logger.error("sbatch command failed")
             raise e
-
+    
     def getJobExitCode(self, slurmJobID):
         logger.debug("Getting exit code for slurm job %d", slurmJobID)
+        
+        state, rc = self._getJobDetailsFromSacct(slurmJobID)
+        
+        if rc == -999:
+            state, rc = self._getJobDetailsFromScontrol(slurmJobID)
+
+        logger.debug("s job state is %s", state)
+        # If Job is in a running state, return None to indicate we don't have an update                                 
+        if state in ('PENDING', 'RUNNING', 'CONFIGURING', 'COMPLETING', 'RESIZING', 'SUSPENDED'):
+            return None
+
+        return rc
+
+    def _getJobDetailsFromSacct(self, slurmJobID):
         # SLURM job exit codes are obtained by running sacct.
         args = ['sacct',
                 '-n', # no header
@@ -231,7 +249,14 @@ class Worker(Thread):
                 '--format', 'State,ExitCode', # specify output columns
                 '-P', # separate columns with pipes
                 '-S', '1970-01-01'] # override start time limit
+
         process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        rc = process.returncode
+
+        if rc != 0:
+            # no accounting system or some other error
+            return (None, -999)
+
         for line in process.stdout:
             values = line.strip().split('|')
             if len(values) < 2:
@@ -239,14 +264,51 @@ class Worker(Thread):
             state, exitcode = values
             logger.debug("sacct job state is %s", state)
             # If Job is in a running state, return None to indicate we don't have an update
-            if state in ('PENDING', 'RUNNING', 'CONFIGURING', 'COMPLETING', 'RESIZING', 'SUSPENDED'):
-                return None
             status, _ = exitcode.split(':')
             logger.debug("sacct exit code is %s, returning status %s", exitcode, status)
-            return int(status)
+            return (state, int(status))
+        
         logger.debug("Did not find exit code for job in sacct output")
-        return None
+        return (None, None)
 
+    def _getJobDetailsFromScontrol(self, slurmJobID):
+        args = ['scontrol',
+                'show',
+                'job',
+                str(slurmJobID)]
+
+        process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        job = dict()
+        for line in process.stdout:
+            values = line.strip().split()
+
+            # If job information is not available an error is issued:
+            # slurm_load_jobs error: Invalid job id specified
+            # There is no job information, so exit.
+            if len(values)>0 and values[0] == 'slurm_load_jobs':
+                return None
+            
+            # Output is in the form of many key=value pairs, multiple pairs on each line
+            # and multiple lines in the output. Each pair is pulled out of each line and
+            # added to a dictionary
+            for v in values:
+                bits = v.split('=')
+                job[bits[0]] = bits[1]
+
+        state = job['JobState']
+        try:
+            exitcode = job['ExitCode']
+            if exitcode is not None:
+                status, _ = exitcode.split(':')
+                logger.debug("scontrol exit code is %s, returning status %s", exitcode, status)
+                rc = int(status)
+            else:
+                rc = None
+        except KeyError:
+            rc = None
+        
+        return (state, rc)
 
 class SlurmBatchSystem(BatchSystemSupport):
     """

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -19,8 +19,11 @@ from pipes import quote
 import subprocess
 import time
 import math
-from Queue import Queue, Empty
 from threading import Thread
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
+from six import iteritems
 
 from toil.batchSystems import MemoryString
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
@@ -183,7 +186,7 @@ class Worker(Thread):
         sbatch_line = ['sbatch', '-Q', '-J', 'toil_job_{}'.format(jobID)]
 
         if self.boss.environment:
-            for k, v in self.boss.environment.iteritems():
+            for k, v in iteritems(self.boss.environment):
                 quoted_value = quote(os.environ[k] if v is None else v)
                 sbatch_line.append('--export={}={}'.format(k, quoted_value))
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-import cPickle
 import logging
 import os
 import re
@@ -23,6 +22,10 @@ import tempfile
 import time
 from argparse import ArgumentParser
 from threading import Thread
+
+# Python 3 compatibility imports
+from six.moves import cPickle
+from six import iteritems
 
 from bd2k.util.exceptions import require
 from bd2k.util.humanize import bytes2human
@@ -905,7 +908,7 @@ class Toil(object):
         Sets the environment variables required by the job store and those passed on command line.
         """
         for envDict in (self._jobStore.getEnv(), self.config.environment):
-            for k, v in envDict.iteritems():
+            for k, v in iteritems(envDict):
                 self._batchSystem.setEnv(k, v)
 
     def _serialiseEnv(self):

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -117,7 +117,7 @@ def resolve_indirect(d):
             if isinstance(v, StepValueFrom):
                 ev[k] = v.do_eval(res, res[k])
             else:
-                ev[k] = v
+                ev[k] = res[k]
         return ev
     else:
         return res

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -41,7 +41,11 @@ import logging
 import copy
 import shutil
 import functools
-import urlparse
+
+# Python 3 compatibility imports
+from six.moves import xrange
+from six import iteritems, string_types
+import six.moves.urllib.parse as urlparse
 
 cwllogger = logging.getLogger("cwltool")
 
@@ -104,7 +108,7 @@ def resolve_indirect_inner(d):
 def resolve_indirect(d):
     inner = IndirectDict() if isinstance(d, IndirectDict) else {}
     needEval = False
-    for k, v in d.iteritems():
+    for k, v in iteritems(d):
         if isinstance(v, StepValueFrom):
             inner[k] = v.inner
             needEval = True
@@ -113,7 +117,7 @@ def resolve_indirect(d):
     res = resolve_indirect_inner(inner)
     if needEval:
         ev = {}
-        for k, v in d.iteritems():
+        for k, v in iteritems(d):
             if isinstance(v, StepValueFrom):
                 ev[k] = v.do_eval(res, res[k])
             else:
@@ -341,7 +345,7 @@ class CWLScatter(Job):
     def run(self, fileStore):
         cwljob = resolve_indirect(self.cwljob)
 
-        if isinstance(self.step.tool["scatter"], basestring):
+        if isinstance(self.step.tool["scatter"], string_types):
             scatter = [self.step.tool["scatter"]]
         else:
             scatter = self.step.tool["scatter"]
@@ -353,7 +357,7 @@ class CWLScatter(Job):
 
         valueFrom = {shortname(i["id"]): i["valueFrom"] for i in self.step.tool["inputs"] if "valueFrom" in i}
         def postScatterEval(io):
-            shortio = {shortname(k): v for k, v in io.iteritems()}
+            shortio = {shortname(k): v for k, v in iteritems(io)}
             def valueFromFunc(k, v):
                 if k in valueFrom:
                     return cwltool.expression.do_eval(

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -221,12 +221,22 @@ class CWLJob(Job):
         builder.timeout = 0
         builder.resources = {}
         req = tool.evalResources(builder, {})
-        super(CWLJob, self).__init__(cores=req["cores"],
-                     memory=(req["ram"]*1024*1024),
-                     disk=((req["tmpdirSize"]*1024*1024) + (req["outdirSize"]*1024*1024)))
-        #super(CWLJob, self).__init__()
         self.cwltool = tool
+        # pass the default of None if basecommand is empty
+        unitName = self.cwltool.tool.get("baseCommand", None)
+        if isinstance(unitName, (list, tuple)):
+            unitName = ' '.join(unitName)
+        super(CWLJob, self).__init__(cores=req["cores"],
+                                     memory=(req["ram"]*1024*1024),
+                                     disk=((req["tmpdirSize"]*1024*1024) + (req["outdirSize"]*1024*1024)),
+                                     unitName=unitName)
+        #super(CWLJob, self).__init__()
         self.cwljob = cwljob
+        try:
+            self.jobName = str(self.cwltool.tool['id'])
+        except KeyError:
+            # fall back to the Toil defined class name if the tool doesn't have an identifier
+            pass
         self.executor_options = kwargs
 
     def run(self, fileStore):

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -34,8 +34,11 @@ from contextlib import contextmanager
 from fcntl import flock, LOCK_EX, LOCK_UN
 from functools import partial
 from hashlib import sha1
-from Queue import Queue, Empty
 from threading import Thread, Semaphore, Event
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
+from six.moves import xrange
 
 from bd2k.util.humanize import bytes2human
 from toil.common import cacheDirName, getDirSizeRecursively
@@ -855,7 +858,7 @@ class CachingFileStore(FileStore):
             # will be renamed into the cache for this node.
             personalCacheDir = ''.join([os.path.dirname(self.localCacheDir), '/.ctmp-',
                                         str(uuid.uuid4())])
-            os.mkdir(personalCacheDir, 0755)
+            os.mkdir(personalCacheDir, 0o755)
             self._createCacheLockFile(personalCacheDir)
             try:
                 os.rename(personalCacheDir, self.localCacheDir)
@@ -1382,7 +1385,7 @@ class CachingFileStore(FileStore):
             with open(self.harbingerFileName + '.tmp', 'w') as harbingerFile:
                 harbingerFile.write(str(os.getpid()))
             # Make this File read only to prevent overwrites
-            os.chmod(self.harbingerFileName + '.tmp', 0444)
+            os.chmod(self.harbingerFileName + '.tmp', 0o444)
             os.rename(self.harbingerFileName + '.tmp', self.harbingerFileName)
 
         def waitOnDownload(self, lockFileHandle):

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -491,7 +491,7 @@ class CachingFileStore(FileStore):
                                            disk=diskUsed,
                                            humanRequestedDisk=bytes2human(jobReqs),
                                            requestedDisk=jobReqs))
-            self.logToMaster(logString, level=logging.INFO)
+            self.logToMaster(logString, level=logging.DEBUG)
             if diskUsed > jobReqs:
                 self.logToMaster("Job used more disk than requested. Please reconsider modifying "
                                  "the user script to avoid the chance  of failure due to "
@@ -628,7 +628,7 @@ class CachingFileStore(FileStore):
         # userPath. Cache operations can only occur on local files.
         with self.cacheLock() as lockFileHandle:
             if fileIsLocal and self._fileIsCached(fileStoreID):
-                logger.info('CACHE: Cache hit on file with ID \'%s\'.' % fileStoreID)
+                logger.debug('CACHE: Cache hit on file with ID \'%s\'.' % fileStoreID)
                 assert not os.path.exists(localFilePath)
                 if mutable:
                     shutil.copyfile(cachedFileName, localFilePath)
@@ -719,10 +719,10 @@ class CachingFileStore(FileStore):
 
         # If fileStoreID is in the cache provide a handle from the local cache
         if self._fileIsCached(fileStoreID):
-            logger.info('CACHE: Cache hit on file with ID \'%s\'.' % fileStoreID)
+            logger.debug('CACHE: Cache hit on file with ID \'%s\'.' % fileStoreID)
             return open(self.encodedFileID(fileStoreID), 'r')
         else:
-            logger.info('CACHE: Cache miss on file with ID \'%s\'.' % fileStoreID)
+            logger.debug('CACHE: Cache miss on file with ID \'%s\'.' % fileStoreID)
             return self.jobStore.readFileStream(fileStoreID)
 
     def deleteLocalFile(self, fileStoreID):
@@ -797,9 +797,9 @@ class CachingFileStore(FileStore):
                         os.remove(cachedFile)
                         cacheInfo.cached -= fileSize
                 self.logToMaster('Successfully deleted cached copy of file with ID '
-                                 '\'%s\'.' % fileStoreID)
+                                 '\'%s\'.' % fileStoreID, level=logging.DEBUG)
             self.logToMaster('Successfully deleted local copies of file with ID '
-                             '\'%s\'.' % fileStoreID)
+                             '\'%s\'.' % fileStoreID, level=logging.DEBUG)
 
     def deleteGlobalFile(self, fileStoreID):
         jobStateIsPopulated = False
@@ -823,7 +823,7 @@ class CachingFileStore(FileStore):
         # Add the file to the list of files to be deleted once the run method completes.
         self.filesToDelete.add(fileStoreID)
         self.logToMaster('Added file with ID \'%s\' to the list of files to be' % fileStoreID +
-                         ' globally deleted.')
+                         ' globally deleted.', level=logging.DEBUG)
 
     # Cache related methods
     @contextmanager
@@ -1029,11 +1029,11 @@ class CachingFileStore(FileStore):
                     self.returnFileSize(jobStoreFileID, localFilePath, lockFileHandle,
                                         fileAlreadyCached=False)
                 if callingFunc == 'read':
-                    logger.info('CACHE: Read file with ID \'%s\' from the cache.' %
-                                jobStoreFileID)
+                    logger.debug('CACHE: Read file with ID \'%s\' from the cache.' %
+                                 jobStoreFileID)
                 else:
-                    logger.info('CACHE: Added file with ID \'%s\' to the cache.' %
-                                jobStoreFileID)
+                    logger.debug('CACHE: Added file with ID \'%s\' to the cache.' %
+                                 jobStoreFileID)
 
     def returnFileSize(self, fileStoreID, cachedFileSource, lockFileHandle,
                        fileAlreadyCached=False):
@@ -1603,7 +1603,7 @@ class NonCachingFileStore(FileStore):
                                            disk=diskUsed,
                                            humanRequestedDisk=bytes2human(jobReqs),
                                            requestedDisk=jobReqs))
-            self.logToMaster(logString, level=logging.INFO)
+            self.logToMaster(logString, level=logging.DEBUG)
             if diskUsed > jobReqs:
                 self.logToMaster("Job used more disk than requested. Cconsider modifying the user "
                                  "script to avoid the chance of failure due to incorrectly "

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import, print_function
 
-import cPickle
 import collections
 import importlib
 import inspect
@@ -29,6 +28,10 @@ from abc import ABCMeta, abstractmethod
 from argparse import ArgumentParser
 from contextlib import contextmanager
 from io import BytesIO
+
+# Python 3 compatibility imports
+from six.moves import cPickle
+from six import iteritems, string_types
 
 from bd2k.util.exceptions import require
 from bd2k.util.expando import Expando
@@ -894,7 +897,7 @@ class Job(JobLikeObject):
         """
         Sets the values for promises using the return values from this job's run() function.
         """
-        for path, promiseFileStoreIDs in self._rvs.iteritems():
+        for path, promiseFileStoreIDs in iteritems(self._rvs):
             if not path:
                 # Note that its possible for returnValues to be a promise, not an actual return
                 # value. This is the case if the job returns a promise from another job. In
@@ -1327,7 +1330,7 @@ class FunctionWrappingJob(Job):
                     # ... and finally fall back to a default value.
                     value = default
             # Optionally, convert strings with metric or binary prefixes.
-            if dehumanize and isinstance(value, basestring):
+            if dehumanize and isinstance(value, string_types):
                 value = human2bytes(value)
             return value
 

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 from __future__ import absolute_import
 
-import urllib2
-import urlparse
-
 import shutil
 
 import re
@@ -23,6 +20,11 @@ from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager, closing
 from datetime import timedelta
 from uuid import uuid4
+
+# Python 3 compatibility imports
+from six import itervalues
+from six.moves.urllib.request import urlopen
+import six.moves.urllib.parse as urlparse
 
 from bd2k.util.retry import retry_http
 
@@ -446,7 +448,7 @@ class AbstractJobStore(object):
 
         def getJobs():
             if jobCache is not None:
-                return jobCache.itervalues()
+                return itervalues(jobCache)
             else:
                 return self.jobs()
 
@@ -961,5 +963,5 @@ class JobStoreSupport(AbstractJobStore):
     def _readFromUrl(cls, url, writable):
         for attempt in retry_http():
             with attempt:
-                with closing(urllib2.urlopen(url.geturl())) as readable:
+                with closing(urlopen(url.geturl())) as readable:
                     shutil.copyfileobj(readable, writable)

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-from StringIO import StringIO
 from contextlib import contextmanager, closing
 import logging
 from multiprocessing import cpu_count
@@ -22,11 +21,13 @@ from multiprocessing import cpu_count
 import os
 import re
 import uuid
-import cPickle
 import base64
 import hashlib
 import itertools
-import repr as reprlib
+
+# Python 3 compatibility imports
+from six.moves import xrange, cPickle, StringIO, reprlib
+from six import iteritems
 
 from bd2k.util import strict_bool
 from bd2k.util.exceptions import panic
@@ -1134,7 +1135,7 @@ class AWSJobStore(AbstractJobStore):
                     srcKey.version_id = self.version
                     with attempt:
                         headers = {k.replace('amz-', 'amz-copy-source-', 1): v
-                                   for k, v in self._s3EncryptionHeaders().iteritems()}
+                                   for k, v in iteritems(self._s3EncryptionHeaders())}
                         self._copyKey(srcKey=srcKey,
                                       dstBucketName=dstKey.bucket.name,
                                       dstKeyName=dstKey.name,

--- a/src/toil/jobStores/aws/utils.py
+++ b/src/toil/jobStores/aws/utils.py
@@ -22,6 +22,9 @@ import types
 import errno
 from ssl import SSLError
 
+# Python 3 compatibility imports
+from six import iteritems
+
 from bd2k.util.retry import retry
 from boto.exception import (SDBResponseError,
                             BotoServerError,
@@ -145,7 +148,7 @@ class SDBHelper(object):
         :rtype: (str|None,int)
         :return: the binary data and the number of chunks it was composed from
         """
-        chunks = [(int(k), v) for k, v in attributes.iteritems() if cls._isValidChunkName(k)]
+        chunks = [(int(k), v) for k, v in iteritems(attributes) if cls._isValidChunkName(k)]
         chunks.sort()
         numChunks = len(chunks)
         if numChunks:

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -15,18 +15,20 @@
 from __future__ import absolute_import
 
 import bz2
-import cPickle
-import httplib
 import inspect
 import logging
 import os
 import re
 import socket
 import uuid
-from ConfigParser import RawConfigParser, NoOptionError
 from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+
+# Python 3 compatibility imports
+from six.moves import cPickle
+from six.moves.http_client import HTTPException
+from six.moves.configparser import RawConfigParser, NoOptionError
 
 from azure.common import AzureMissingResourceHttpError, AzureException
 from azure.storage import SharedAccessPolicy, AccessPolicy
@@ -795,7 +797,7 @@ def defaultRetryPredicate(exception):
     True
     >>> defaultRetryPredicate(socket.gaierror())
     True
-    >>> defaultRetryPredicate(httplib.HTTPException())
+    >>> defaultRetryPredicate(HTTPException())
     True
     >>> defaultRetryPredicate(requests.ConnectionError())
     True
@@ -812,7 +814,7 @@ def defaultRetryPredicate(exception):
     """
     return (isinstance(exception, (socket.error,
                                    socket.gaierror,
-                                   httplib.HTTPException,
+                                   HTTPException,
                                    requests.ConnectionError))
             or isinstance(exception, AzureException) and
             any(message in str(exception).lower() for message in (

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -24,6 +24,9 @@ import tempfile
 import stat
 import errno
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from bd2k.util.exceptions import require
 
 from toil.lib.bioio import absSymPath

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -3,12 +3,14 @@ from contextlib import contextmanager
 import hashlib
 import os
 import uuid
-from StringIO import StringIO
 from bd2k.util.threading import ExceptionalThread
 import boto
 import logging
-import cPickle
 import time
+
+# Python 3 compatibility imports
+from six.moves import cPickle, StringIO
+
 from toil.jobStores.abstractJobStore import (AbstractJobStore, NoSuchJobException,
                                              NoSuchFileException,
                                              ConcurrentFileModificationException)

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -17,12 +17,14 @@ The leader script (of the leader/worker pair) for running jobs.
 """
 from __future__ import absolute_import
 
-import cPickle
 import logging
 import gzip
 import os
 import time
 from collections import namedtuple
+
+# Python 3 compatibility imports
+from six.moves import cPickle
 
 from bd2k.util.expando import Expando
 from bd2k.util.humanize import bytes2human

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -48,7 +48,7 @@ class FailedJobsException( Exception ):
             for jobNode in failedJobs:
                 job = jobStore.load(jobNode.jobStoreID)
                 if job.logJobStoreFileID:
-                    msg += "\n=========> Failed job %s %s\n" % (jobNode, jobNode.jobStoreID)
+                    msg += "\n=========> Failed job %s \n" % jobNode
                     with job.getLogFileHandle(jobStore) as fH:
                         msg += fH.read()
                     msg += "<=========\n"
@@ -187,8 +187,7 @@ class Leader:
                      ("successfully" if len(self.toilState.totalFailedJobs) == 0 else ("with %s failed jobs" % len(self.toilState.totalFailedJobs))))
 
         if len(self.toilState.totalFailedJobs):
-            logger.info("Failed jobs at end of the run: %s", self.toilState.totalFailedJobs)
-
+            logger.info("Failed jobs at end of the run: %s", ' '.join(str(job) for job in self.toilState.totalFailedJobs))
         # Cleanup
         if len(self.toilState.totalFailedJobs) > 0:
             raise FailedJobsException(self.config.jobStore, self.toilState.totalFailedJobs, self.jobStore)

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -27,6 +27,11 @@ import shutil
 from argparse import ArgumentParser
 from optparse import OptionContainer, OptionGroup
 import subprocess
+
+# Python 3 compatibility imports
+from six.moves import xrange
+from six import string_types
+
 import xml.etree.cElementTree as ET
 from xml.dom import minidom  # For making stuff pretty
 
@@ -163,7 +168,7 @@ def system(command):
     :type command: str | sequence[string]
     """
     logger.debug('Running: %r', command)
-    subprocess.check_call(command, shell=isinstance(command,basestring), bufsize=-1)
+    subprocess.check_call(command, shell=isinstance(command, string_types), bufsize=-1)
 
 def getTotalCpuTimeAndMemoryUsage():
     """Gives the total cpu time and memory usage of itself and its children.
@@ -287,7 +292,7 @@ def makePublicDir(dirName):
     """
     if not os.path.exists(dirName):
         os.mkdir(dirName)
-        os.chmod(dirName, 0777)
+        os.chmod(dirName, 0o777)
     return dirName
 
 def getTempFile(suffix="", rootDir=None):
@@ -300,5 +305,5 @@ def getTempFile(suffix="", rootDir=None):
     else:
         tmpFile = os.path.join(rootDir, "tmp_" + getRandomAlphaNumericString() + suffix)
         open(tmpFile, 'w').close()
-        os.chmod(tmpFile, 0777) #Ensure everyone has access to the file.
+        os.chmod(tmpFile, 0o777) #Ensure everyone has access to the file.
         return tmpFile

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -1,0 +1,248 @@
+"""
+    Module for calling Docker. Assumes `docker` is on the PATH.
+
+    Contains two user-facing functions: dockerCall and dockerCheckOutput
+
+    Uses Toil's defer functionality to ensure containers are shutdown even in case of job or pipeline failure
+
+    Example of using dockerCall in a Toil pipeline to index a FASTA file with SAMtools:
+        def toil_job(job):
+            work_dir = job.fileStore.getLocalTempDir()
+            path = job.fileStore.readGlobalFile(ref_id, os.path.join(work_dir, 'ref.fasta')
+            parameters = ['faidx', path]
+            dockerCall(job, tool='quay.io/ucgc_cgl/samtools:latest', work_dir=work_dir, parameters=parameters)
+"""
+import base64
+import logging
+import subprocess
+
+import os
+from bd2k.util.exceptions import require
+
+_logger = logging.getLogger(__name__)
+
+
+def dockerCall(job,
+               tool,
+               parameters=None,
+               workDir=None,
+               dockerParameters=None,
+               outfile=None,
+               defer=None):
+    """
+    Throws CalledProcessorError if the Docker invocation returns a non-zero exit code
+    This function blocks until the subprocess call to Docker returns
+
+    :param toil.Job.job job: The Job instance for the calling function.
+    :param str tool: Name of the Docker image to be used (e.g. quay.io/ucsc_cgl/samtools:latest).
+    :param list[str] parameters: Command line arguments to be passed to the tool.
+    :param str workDir: Directory to mount into the container via `-v`. Destination convention is /data
+    :param list[str] dockerParameters: Parameters to pass to Docker. Default parameters are `--rm`,
+            `--log-driver none`, and the mountpoint `-v work_dir:/data` where /data is the destination convention.
+             These defaults are removed if docker_parmaters is passed, so be sure to pass them if they are desired.
+    :param file outfile: Pipe output of Docker call to file handle
+    :param int defer: What action should be taken on the container upon job completion?
+           FORGO (0) will leave the container untouched.
+           STOP (1) will attempt to stop the container with `docker stop` (useful for debugging).
+           RM (2) will stop the container and then forcefully remove it from the system
+           using `docker rm -f`. This is the default behavior if defer is set to None.
+    """
+    _docker(job, tool=tool, parameters=parameters, workDir=workDir, dockerParameters=dockerParameters,
+            outfile=outfile, checkOutput=False, defer=defer)
+
+
+def dockerCheckOutput(job,
+                      tool,
+                      parameters=None,
+                      workDir=None,
+                      dockerParameters=None,
+                      defer=None):
+    """
+    Returns the stdout from the Docker invocation (via subprocess.check_output)
+    Throws CalledProcessorError if the Docker invocation returns a non-zero exit code
+    This function blocks until the subprocess call to Docker returns
+
+    :param toil.Job.job job: The Job instance for the calling function.
+    :param str tool: Name of the Docker image to be used (e.g. quay.io/ucsc_cgl/samtools:latest).
+    :param list[str] parameters: Command line arguments to be passed to the tool.
+    :param str workDir: Directory to mount into the container via `-v`. Destination convention is /data
+    :param list[str] dockerParameters: Parameters to pass to Docker. Default parameters are `--rm`,
+            `--log-driver none`, and the mountpoint `-v work_dir:/data` where /data is the destination convention.
+             These defaults are removed if docker_parmaters is passed, so be sure to pass them if they are desired.
+    :param int defer: What action should be taken on the container upon job completion?
+           FORGO (0) will leave the container untouched.
+           STOP (1) will attempt to stop the container with `docker stop` (useful for debugging).
+           RM (2) will stop the container and then forcefully remove it from the system
+           using `docker rm -f`. This is the default behavior if defer is set to None.
+    :returns: Stdout from the docker call
+    :rtype: str
+    """
+    return _docker(job, tool=tool, parameters=parameters, workDir=workDir,
+                   dockerParameters=dockerParameters, checkOutput=True, defer=defer)
+
+
+def _docker(job,
+            tool,
+            parameters=None,
+            workDir=None,
+            dockerParameters=None,
+            outfile=None,
+            checkOutput=False,
+            defer=None):
+    """
+    :param toil.Job.job job: The Job instance for the calling function.
+    :param str tool: Name of the Docker image to be used (e.g. quay.io/ucsc_cgl/samtools).
+    :param list[str] parameters: Command line arguments to be passed to the tool.
+    :param str workDir: Directory to mount into the container via `-v`. Destination convention is /data
+    :param list[str] dockerParameters: Parameters to pass to Docker. Default parameters are `--rm`,
+            `--log-driver none`, and the mountpoint `-v work_dir:/data` where /data is the destination convention.
+             These defaults are removed if docker_parmaters is passed, so be sure to pass them if they are desired.
+    :param file outfile: Pipe output of Docker call to file handle
+    :param bool checkOutput: When True, this function returns docker's output.
+    :param int defer: What action should be taken on the container upon job completion?
+           FORGO (0) will leave the container untouched.
+           STOP (1) will attempt to stop the container with `docker stop` (useful for debugging).
+           RM (2) will stop the container and then forcefully remove it from the system
+           using `docker rm -f`. This is the default behavior if defer is set to None.
+    """
+    if parameters is None:
+        parameters = []
+    if workDir is None:
+        workDir = os.getcwd()
+
+    # Setup the outgoing subprocess call for docker
+    baseDockerCall = ['docker', 'run']
+    if dockerParameters:
+        baseDockerCall += dockerParameters
+    else:
+        baseDockerCall += ['--rm', '--log-driver', 'none', '-v',
+                           os.path.abspath(workDir) + ':/data']
+
+    # Ensure the user has passed a valid value for defer
+    require(defer in (None, FORGO, STOP, RM),
+            'Please provide a valid value for defer.')
+
+    # Get container name which is needed for _dockerKill
+    try:
+        if any('--name' in x for x in baseDockerCall):
+            if any('--name=' in x for x in baseDockerCall):
+                containerName = [x.split('=')[1] for x in baseDockerCall if '--name' in x][0]
+            else:
+                containerName = baseDockerCall[baseDockerCall.index('--name') + 1]
+        else:
+            containerName = _getContainerName(job)
+    except ValueError:
+        containerName = _getContainerName(job)
+        baseDockerCall.extend(['--name', containerName])
+    except IndexError:
+        raise RuntimeError("Couldn't parse Docker's `--name=` option, check parameters: " + str(dockerParameters))
+
+    # Defer the container on-exit action
+    if '--rm' in baseDockerCall and defer is None:
+        defer = RM
+    if '--rm' in baseDockerCall and defer is not RM:
+        _logger.warn('--rm being passed to docker call but defer not set to dockerCall.RM, defer set to: ' + str(defer))
+    job.defer(_dockerKill, containerName, action=defer)
+    # Defer the permission fixing function which will run after this job concludes.
+    # We call this explicitly later on in this function, but we defer it as well to handle unexpected job failure.
+    job.defer(_fixPermissions, tool, workDir)
+
+    # Make subprocess call
+    call = baseDockerCall + [tool] + parameters
+    _logger.info("Calling docker with " + repr(call))
+
+    if outfile:
+        subprocess.check_call(call, stdout=outfile)
+    else:
+        if checkOutput:
+            return subprocess.check_output(call)
+        else:
+            subprocess.check_call(call)
+
+
+FORGO = 0
+STOP = 1
+RM = 2
+
+
+def _dockerKill(containerName, action):
+    """
+    Kills the specified container.
+    :param str containerName: The name of the container created by docker_call
+    :param int action: What action should be taken on the container?  See `defer=` in
+           :func:`docker_call`
+    """
+    running = _containerIsRunning(containerName)
+    if running is None:
+        # This means that the container doesn't exist.  We will see this if the container was run
+        # with --rm and has already exited before this call.
+        _logger.info('The container with name "%s" appears to have already been removed.  Nothing to '
+                  'do.', containerName)
+    else:
+        if action in (None, FORGO):
+            _logger.info('The container with name %s continues to exist as we were asked to forgo a '
+                      'post-job action on it.', containerName)
+        else:
+            _logger.info('The container with name %s exists. Running user-specified defer functions.',
+                         containerName)
+            if running and action >= STOP:
+                _logger.info('Stopping container "%s".', containerName)
+                subprocess.check_call(['docker', 'stop', containerName])
+            else:
+                _logger.info('The container "%s" was not found to be running.', containerName)
+            if action >= RM:
+                # If the container was run with --rm, then stop will most likely remove the
+                # container.  We first check if it is running then remove it.
+                running = _containerIsRunning(containerName)
+                if running is not None:
+                    _logger.info('Removing container "%s".', containerName)
+                    subprocess.check_call(['docker', 'rm', '-f', containerName])
+                else:
+                    _logger.info('The container "%s" was not found on the system.  Nothing to remove.',
+                                 containerName)
+
+
+def _fixPermissions(tool, workDir):
+    """
+    Fix permission of a mounted Docker directory by reusing the tool to change ownership.
+    Docker natively runs as a root inside the container, and files written to the
+    mounted directory are implicitly owned by root.
+
+    :param list baseDockerCall: Docker run parameters
+    :param str tool: Name of tool
+    :param str workDir: Path of work directory to recursively chown
+    """
+    baseDockerCall = ['docker', 'run', '--log-driver=none',
+                      '-v', os.path.abspath(workDir) + ':/data', '--rm', '--entrypoint=chown']
+    stat = os.stat(workDir)
+    command = baseDockerCall + [tool] + ['-R', '{}:{}'.format(stat.st_uid, stat.st_gid), '/data']
+    subprocess.check_call(command)
+
+
+def _getContainerName(job):
+    return '--'.join([str(job),
+                      job.fileStore.jobID,
+                      base64.b64encode(os.urandom(9), '-_')]).replace("'", '').replace('_', '')
+
+
+def _containerIsRunning(container_name):
+    """
+    Checks whether the container is running or not.
+    :param container_name: Name of the container being checked.
+    :returns: True if running, False if not running, None if the container doesn't exist.
+    :rtype: bool
+    """
+    try:
+        output = subprocess.check_output(['docker', 'inspect', '--format', '{{.State.Running}}',
+                                          container_name]).strip()
+    except subprocess.CalledProcessError:
+        # This will be raised if the container didn't exist.
+        _logger.debug("'docker inspect' failed. Assuming container %s doesn't exist.", container_name,
+                   exc_info=True)
+        return None
+    if output == 'true':
+        return True
+    elif output == 'false':
+        return False
+    else:
+        raise RuntimeError("Got unexpected value for State.Running (%s)" % output)

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -139,7 +139,7 @@ class AbstractProvisioner(object):
         the necessary additions or removals of worker nodes, return the resulting number of
         preemptable or non-preemptable nodes currently in the cluster.
 
-        :param int numNodes: Number of nodes to add.
+        :param int numNodes: Desired size of the cluster
 
         :param bool preemptable: whether the added nodes will be preemptable, i.e. whether they
                may be removed spontaneously by the underlying platform at any time.

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -157,12 +157,12 @@ class AbstractProvisioner(object):
         numCurrentNodes = len(workerInstances)
         delta = numNodes - numCurrentNodes
         if delta > 0:
-            log.info('Adding %i nodes to get to desired cluster size of %i.', delta, numNodes)
+            log.info('Adding %i %s nodes to get to desired cluster size of %i.', delta, 'preemptable' if preemptable else 'non-preemptable', numNodes)
             numNodes = numCurrentNodes + self._addNodes(workerInstances,
                                                         numNodes=delta,
                                                         preemptable=preemptable)
         elif delta < 0:
-            log.info('Removing %i nodes to get to desired cluster size of %i.', -delta, numNodes)
+            log.info('Removing %i %s nodes to get to desired cluster size of %i.', -delta, 'preemptable' if preemptable else 'non-preemptable', numNodes)
             numNodes = numCurrentNodes - self._removeNodes(workerInstances,
                                                            numNodes=-delta,
                                                            preemptable=preemptable,
@@ -178,24 +178,30 @@ class AbstractProvisioner(object):
             nodes = self.batchSystem.getNodes(preemptable)
             # Join nodes and instances on private IP address.
             nodes = [(instance, nodes.get(instance.private_ip_address)) for instance in instances]
+            log.debug('Nodes considered to terminate: %s', ' '.join(map(str, nodes)))
             # Unless forced, exclude nodes with runnning workers. Note that it is possible for
             # the batch system to report stale nodes for which the corresponding instance was
             # terminated already. There can also be instances that the batch system doesn't have
             # nodes for yet. We'll ignore those, too, unless forced.
-            nodes = [(instance, nodeInfo)
-                     for instance, nodeInfo in nodes
-                     if force or nodeInfo is not None and nodeInfo.workers < 1]
+            nodesToTerminate = []
+            for instance, nodeInfo in nodes:
+                if force:
+                    nodesToTerminate.append((instance, nodeInfo))
+                elif nodeInfo is not None and nodeInfo.workers < 1:
+                    nodesToTerminate.append((instance, nodeInfo))
+                else:
+                    log.debug('Not terminating instances %s. Node info: %s', instance, nodeInfo)
             # Sort nodes by number of workers and time left in billing cycle
-            nodes.sort(key=lambda (instance, nodeInfo): (
+            nodesToTerminate.sort(key=lambda (instance, nodeInfo): (
                 nodeInfo.workers if nodeInfo else 1,
                 self._remainingBillingInterval(instance)))
-            nodes = nodes[:numNodes]
+            nodesToTerminate = nodesToTerminate[:numNodes]
             if log.isEnabledFor(logging.DEBUG):
-                for instance, nodeInfo in nodes:
+                for instance, nodeInfo in nodesToTerminate:
                     log.debug("Instance %s is about to be terminated. Its node info is %r. It "
                               "would be billed again in %s minutes.", instance.id, nodeInfo,
                               60 * self._remainingBillingInterval(instance))
-            instanceIds = [instance.id for instance, nodeInfo in nodes]
+            instanceIds = [instance.id for instance, nodeInfo in nodesToTerminate]
         else:
             # Without load info all we can do is sort instances by time left in billing cycle.
             instances = sorted(instances, key=self._remainingBillingInterval)

--- a/src/toil/provisioners/aws/__init__.py
+++ b/src/toil/provisioners/aws/__init__.py
@@ -194,7 +194,7 @@ iamFullPolicy = dict(Version="2012-10-17", Statement=[
 
 logDir = '--log_dir=/var/lib/mesos'
 leaderArgs = logDir + ' --registry=in_memory --cluster={name}'
-workerArgs = '--work_dir=/var/lib/mesos --master={ip}:5050 --attributes=preemptable:{preemptable} ' + logDir
+workerArgs = '{keyPath} --work_dir=/var/lib/mesos --master={ip}:5050 --attributes=preemptable:{preemptable} ' + logDir
 
 awsUserData = """#cloud-config
 
@@ -283,4 +283,7 @@ coreos:
             --name=toil_{role} \
             {image} \
             {args}
+
+ssh_authorized_keys:
+    - "ssh-rsa {sshKey}"
 """

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -20,6 +20,10 @@ import logging
 import time
 
 import sys
+
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from bd2k.util import memoize
 from boto.ec2.blockdevicemapping import BlockDeviceMapping, BlockDeviceType
 from boto.exception import BotoServerError, EC2ResponseError

--- a/src/toil/provisioners/cgcloud/provisioner.py
+++ b/src/toil/provisioners/cgcloud/provisioner.py
@@ -17,7 +17,10 @@ import os
 import re
 import time
 from collections import Iterable
-from urllib2 import urlopen
+
+# Python 3 compatibility imports
+from six import iterkeys, itervalues
+from six.moves.urllib.request import urlopen
 
 import boto.ec2
 from bd2k.util import memoize, parse_iso_utc, less_strict_bool
@@ -215,12 +218,12 @@ class CGCloudProvisioner(AbstractProvisioner):
                     # Get all nodes to be safe, not just the ones whose preemptability matches,
                     # in case there's a problem with a node determining its own preemptability.
                     nodes = self.batchSystem.getNodes()
-                    for nodeAddress in nodes.iterkeys():
+                    for nodeAddress in iterkeys(nodes):
                         instancesByAddress.pop(nodeAddress, None)
             if instancesByAddress:
                 log.warn('%i instance(s) out of %i did not join the cluster as worker nodes. They '
                          'will be terminated.', len(instancesByAddress), numInstancesAdded)
-                instanceIds = [i.id for i in instancesByAddress.itervalues()]
+                instanceIds = [i.id for i in itervalues(instancesByAddress)]
                 self._logAndTerminate(instanceIds)
                 numInstancesAdded -= len(instanceIds)
             else:

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -259,7 +259,7 @@ class ClusterScaler(object):
         self.stop = True
         for scaler in self.preemptableScaler, self.scaler:
             if scaler is not None:
-                self.scaler.join()
+                scaler.join()
 
     def addCompletedJob(self, job, wallTime):
         """

--- a/src/toil/realtimeLogger.py
+++ b/src/toil/realtimeLogger.py
@@ -22,9 +22,11 @@ import os.path
 import json
 import logging
 import logging.handlers
-import SocketServer
 import socket
 import threading
+
+# Python 3 compatibility imports
+from six.moves import socketserver as SocketServer
 
 import toil.lib.bioio
 

--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -27,8 +27,10 @@ from contextlib import closing
 from io import BytesIO
 from pydoc import locate
 from tempfile import mkdtemp
-from urllib2 import urlopen
 from zipfile import ZipFile, PyZipFile
+
+# Python 3 compatibility imports
+from six.moves.urllib.request import urlopen
 
 from bd2k.util import strict_bool
 from bd2k.util.iterables import concat

--- a/src/toil/serviceManager.py
+++ b/src/toil/serviceManager.py
@@ -16,8 +16,10 @@ from __future__ import absolute_import
 
 import logging
 import time
-from Queue import Queue, Empty
 from threading import Thread, Event
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
 
 logger = logging.getLogger( __name__ )
 

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -31,7 +31,10 @@ from inspect import getsource
 from subprocess import PIPE, Popen, CalledProcessError, check_output
 from textwrap import dedent
 from unittest.util import strclass
-from urllib2 import urlopen
+
+# Python 3 compatibility imports
+from six import iteritems, itervalues
+from six.moves.urllib.request import urlopen
 
 from bd2k.util import less_strict_bool, memoize
 from bd2k.util.files import mkdir_p
@@ -573,7 +576,7 @@ def make_tests(generalMethod, targetClass=None, **kwargs):
 
         :return: the popped key, value tuple
         """
-        k, v = next(iter(kwargs.iteritems()))
+        k, v = next(iter(iteritems(kwargs)))
         d.pop(k)
         return k, v
 
@@ -717,7 +720,7 @@ class ApplianceTestSupport(ToilTest):
             """
             :param ApplianceTestSupport outer:
             """
-            assert all(' ' not in v for v in mounts.itervalues()), 'No spaces allowed in mounts'
+            assert all(' ' not in v for v in itervalues(mounts)), 'No spaces allowed in mounts'
             super(ApplianceTestSupport.Appliance, self).__init__()
             self.outer = outer
             self.mounts = mounts
@@ -734,7 +737,7 @@ class ApplianceTestSupport(ToilTest):
                                    '--net=host',
                                    '-i',
                                    '--name=' + self.containerName,
-                                   ['--volume=%s:%s' % mount for mount in self.mounts.iteritems()],
+                                   ['--volume=%s:%s' % mount for mount in iteritems(self.mounts)],
                                    image,
                                    self._containerCommand()))
                 log.info('Running %r', args)
@@ -781,7 +784,7 @@ class ApplianceTestSupport(ToilTest):
             """
             # Delete all files within each mounted directory, but not the directory itself.
             cmd = 'shopt -s dotglob && rm -rf ' + ' '.join(v + '/*'
-                                                           for k, v in self.mounts.iteritems()
+                                                           for k, v in iteritems(self.mounts)
                                                            if os.path.isdir(k))
             self.outer._run('docker', 'run',
                             '--rm',

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -123,9 +123,9 @@ class hidden:
         def testRunJobs(self):
             testPath = os.path.join(self.tempDir, "test.txt")
             jobNode1 = JobNode(command='sleep 1000', jobName='test1', unitName=None,
-                               jobStoreID=None, requirements=defaultRequirements)
+                               jobStoreID='1', requirements=defaultRequirements)
             jobNode2 = JobNode(command='sleep 1000', jobName='test2', unitName=None,
-                               jobStoreID=None, requirements=defaultRequirements)
+                               jobStoreID='2', requirements=defaultRequirements)
             job1 = self.batchSystem.issueBatchJob(jobNode1)
             job2 = self.batchSystem.issueBatchJob(jobNode2)
 
@@ -144,7 +144,7 @@ class hidden:
             # updated jobs queue.
             self.assertFalse(os.path.exists(testPath))
             jobNode3 = JobNode(command="touch %s" % testPath, jobName='test3', unitName=None,
-                               jobStoreID=None, requirements=defaultRequirements)
+                               jobStoreID='3', requirements=defaultRequirements)
             job3 = self.batchSystem.issueBatchJob(jobNode3)
 
             jobID, exitStatus, wallTime = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
@@ -179,7 +179,7 @@ class hidden:
                 # First, ensure that the test fails if the variable is *not* set
                 command = sys.executable + ' ' + script_path
                 jobNode4 = JobNode(command=command, jobName='test4', unitName=None,
-                                   jobStoreID=None, requirements=defaultRequirements)
+                                   jobStoreID='4', requirements=defaultRequirements)
                 job4 = self.batchSystem.issueBatchJob(jobNode4)
                 jobID, exitStatus, wallTime = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
                 self.assertEqual(exitStatus, 42)
@@ -187,7 +187,7 @@ class hidden:
                 # Now set the variable and ensure that it is present
                 self.batchSystem.setEnv('FOO', 'bar')
                 jobNode5 = JobNode(command=command, jobName='test5', unitName=None,
-                                   jobStoreID=None, requirements=defaultRequirements)
+                                   jobStoreID='5', requirements=defaultRequirements)
                 job5 = self.batchSystem.issueBatchJob(jobNode5)
                 jobID, exitStatus, wallTime = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
                 self.assertEqual(exitStatus, 0)
@@ -544,14 +544,14 @@ class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport)
                            requirements=dict(memory=1 << 30, cores=1,
                                              disk=1000, preemptable=preemptable),
                            jobName='testResourceLimits', unitName=None,
-                           jobStoreID=None)
+                           jobStoreID='1')
         job1 = self.batchSystem.issueBatchJob(jobNode1)
         self.assertIsNotNone(job1)
         jobNode2 = JobNode(command="sleep 1000",
                            requirements=dict(memory=2 << 30, cores=1,
                                              disk=1000, preemptable=preemptable),
                            jobName='testResourceLimits', unitName=None,
-                           jobStoreID=None)
+                           jobStoreID='2')
         job2 = self.batchSystem.issueBatchJob(jobNode2)
         self.assertIsNotNone(job2)
         batches = self._getBatchList()

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -16,7 +16,10 @@ import json
 import os
 import subprocess
 import re
-import StringIO
+
+# Python 3 compatibility imports
+from six.moves import StringIO
+from six import u as unicode
 
 from toil.test import ToilTest, needs_cwl
 
@@ -26,7 +29,7 @@ class CWLTest(ToilTest):
     def _tester(self, cwlfile, jobfile, outDir, expect):
         from toil.cwl import cwltoil
         rootDir = self._projectRootPath()
-        st = StringIO.StringIO()
+        st = StringIO()
         cwltoil.main(['--outdir', outDir,
                             os.path.join(rootDir, cwlfile),
                             os.path.join(rootDir, jobfile)],

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -88,7 +88,7 @@ class CWLTest(ToilTest):
             subprocess.call(["git", "fetch"], cwd=cwlSpec)
         else:
             subprocess.check_call(["git", "clone", "https://github.com/common-workflow-language/common-workflow-language.git", cwlSpec])
-        subprocess.check_call(["git", "checkout", "1d5714dc434ffd6ac45ec64f1535475fa163be09"], cwd=cwlSpec)
+        subprocess.check_call(["git", "checkout", "87d982f7793fe08d4f4af5555d551c272eaa809c"], cwd=cwlSpec)
         subprocess.check_call(["git", "clean", "-f", "-x", "."], cwd=cwlSpec)
         try:
             subprocess.check_output(["./run_test.sh", "RUNNER=cwltoil", "DRAFT=v1.0"], cwd=cwlSpec,

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -14,24 +14,26 @@
 
 from __future__ import absolute_import
 
-import SocketServer
 import hashlib
 import logging
 import threading
-import SimpleHTTPServer
 import os
 import shutil
 import tempfile
 import time
-import urllib2
-import urlparse
 import uuid
 from stubserver import FTPStubServer
-from Queue import Queue
 from abc import abstractmethod, ABCMeta
 from itertools import chain, islice, count
 from threading import Thread
 from unittest import skip
+
+# Python 3 compatibility imports
+from six.moves.queue import Queue
+from six.moves import xrange, socketserver as SocketServer, SimpleHTTPServer
+from six import iteritems
+import six.moves.urllib.parse as urlparse
+from six.moves.urllib.request import urlopen, Request
 
 from bd2k.util import memoize
 from bd2k.util.exceptions import panic
@@ -404,7 +406,7 @@ class AbstractJobStoreTest:
 
         @classmethod
         def cleanUpExternalStores(cls):
-            for test, store in cls.externalStoreCache.iteritems():
+            for test, store in iteritems(cls.externalStoreCache):
                 logger.info('Cleaning up external store for %s.', test)
                 test._cleanUpExternalStore(store)
 
@@ -645,7 +647,7 @@ class AbstractJobStoreTest:
                 self.assertTrue(os.path.exists(path))
             else:
                 try:
-                    urllib2.urlopen(urllib2.Request(url))
+                    urlopen(Request(url))
                 except:
                     self.fail()
 

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -1,0 +1,129 @@
+import logging
+import signal
+import time
+import uuid
+from threading import Thread
+
+import os
+from bd2k.util.files import mkdir_p
+from toil.job import Job
+from toil.leader import FailedJobsException
+from toil.lib.docker import dockerCall, _containerIsRunning, _dockerKill, STOP, FORGO, RM
+from toil.test import ToilTest
+
+_log = logging.getLogger(__name__)
+
+
+class DockerTest(ToilTest):
+    """
+    Tests dockerCall and ensures no containers are left around.
+
+
+    When running tests you may optionally set the TOIL_TEST_TEMP environment variable to the path
+    of a directory where you want temporary test files be placed. The directory will be created
+    if it doesn't exist. The path may be relative in which case it will be assumed to be relative
+    to the project root. If TOIL_TEST_TEMP is not defined, temporary files and directories will
+    be created in the system's default location for such files and any temporary files or
+    directories left over from tests will be removed automatically removed during tear down.
+    Otherwise, left-over files will not be removed.
+    """
+    def setUp(self):
+        self.tempDir = self._createTempDir(purpose='tempDir')
+
+    def testDockerClean(self):
+        """
+        Run the test container that creates a file in the work dir, and sleeps for 5 minutes.  Ensure
+        that the calling job gets SIGKILLed after a minute, leaving behind the spooky/ghost/zombie
+        container. Ensure that the container is killed on batch system shutdown (through the defer
+        mechanism).
+        This inherently also tests _docker
+        :returns: None
+        """
+        # We need to test the behaviour of `defer` with `rm` and `detached`. We do not look at the case
+        # where `rm` and `detached` are both True.  This is the truth table for the different
+        # combinations at the end of the test. R = Running, X = Does not exist, E = Exists but not
+        # running.
+        #              None     FORGO     STOP    RM
+        #    rm        X         R         X      X
+        # detached     R         R         E      X
+        #  Neither     R         R         E      X
+        assert os.getuid() != 0, "Cannot test this if the user is root."
+        data_dir = os.path.join(self.tempDir, 'data')
+        work_dir = os.path.join(self.tempDir, 'working')
+        test_file = os.path.join(data_dir, 'test.txt')
+        mkdir_p(data_dir)
+        mkdir_p(work_dir)
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
+        options.logLevel = 'INFO'
+        options.workDir = work_dir
+        options.clean = 'always'
+        for rm in (True, False):
+            for detached in (True, False):
+                if detached and rm:
+                    continue
+                for defer in (FORGO, STOP, RM, None):
+                    # Not using base64 logic here since it might create a name starting with a `-`.
+                    container_name = uuid.uuid4().hex
+                    print rm, detached, defer
+                    A = Job.wrapJobFn(_testDockerCleanFn, data_dir, detached, rm, defer,
+                                      container_name)
+                    try:
+                        Job.Runner.startToil(A, options)
+                    except FailedJobsException:
+                        # The file created by spooky_container would remain in the directory, and since
+                        # it was created inside the container, it would have had uid and gid == 0 (root)
+                        # upon creation. If the defer mechanism worked, it should now be non-zero and we
+                        # check for that.
+                        file_stats = os.stat(test_file)
+                        assert file_stats.st_gid != 0
+                        assert file_stats.st_uid != 0
+                        if (rm and defer != FORGO) or defer == RM:
+                            # These containers should not exist
+                            assert _containerIsRunning(container_name) is None, \
+                                'Container was not removed.'
+                        elif defer == STOP:
+                            # These containers should exist but be non-running
+                            assert _containerIsRunning(container_name) == False, \
+                                'Container was not stopped.'
+                        else:
+                            # These containers will be running
+                            assert _containerIsRunning(container_name) == True, \
+                                'Container was not running.'
+                    finally:
+                        # Prepare for the next test.
+                        _dockerKill(container_name, RM)
+                        os.remove(test_file)
+
+
+def _testDockerCleanFn(job, workDir, detached=None, rm=None, defer=None, containerName=None):
+    """
+    Test function for test docker_clean.  Runs a container with given flags and then dies leaving
+    behind a zombie container
+    :param toil.job.Job job: job
+    :param workDir: See `work_dir=` in :func:`dockerCall`
+    :param bool rm: See `rm=` in :func:`dockerCall`
+    :param bool detached: See `detached=` in :func:`dockerCall`
+    :param int defer: See `defer=` in :func:`dockerCall`
+    :param str containerName: See `container_name=` in :func:`dockerCall`
+    :return:
+    """
+    dockerParameters = ['--log-driver=none', '-v', os.path.abspath(workDir) + ':/data',
+                        '--name', containerName]
+    if detached:
+        dockerParameters.append('-d')
+    if rm:
+        dockerParameters.append('--rm')
+
+    def killSelf():
+        test_file = os.path.join(workDir, 'test.txt')
+        # This will kill the worker once we are sure the docker container started
+        while not os.path.exists(test_file):
+            _log.debug('Waiting on the file created by spooky_container.')
+            time.sleep(1)
+        # By the time we reach here, we are sure the container is running.
+        os.kill(os.getpid(), signal.SIGKILL)  # signal.SIGINT)
+    t = Thread(target=killSelf)
+    # Make it a daemon thread so that thread failure doesn't hang tests.
+    t.daemon = True
+    t.start()
+    dockerCall(job, tool='quay.io/ucsc_cgl/spooky_test', workDir=workDir, defer=defer, dockerParameters=dockerParameters)

--- a/src/toil/test/provisioners/cgcloud/provisionerTest.py
+++ b/src/toil/test/provisioners/cgcloud/provisionerTest.py
@@ -20,8 +20,10 @@ import subprocess
 from abc import abstractmethod, ABCMeta
 from inspect import getsource
 from textwrap import dedent
-from urlparse import urlparse
 from uuid import uuid4
+
+# Python 3 compatibility imports
+import six.moves.urllib.parse as urlparse
 
 from bd2k.util.iterables import concat
 from cgcloud.lib.test import CgcloudTestCase
@@ -254,7 +256,7 @@ class CGCloudRNASeqTest(AbstractCGCloudProvisionerTest):
         self.numSamples = 2
 
     def _getScript(self):
-        toilScripts = urlparse(self.toilScripts)
+        toilScripts = urlparse.urlparse(self.toilScripts)
         if toilScripts.netloc:
             self._leader('mkdir toil-scripts'
                          '; curl -L ' + toilScripts.geturl() +

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -15,9 +15,13 @@
 from __future__ import absolute_import
 import time
 from threading import Thread, Event
-from Queue import Queue, Empty
 import logging
 import random
+
+# Python 3 compatibility imports
+from six.moves.queue import Empty, Queue
+from six.moves import xrange
+from six import iteritems
 
 from bd2k.util.objects import InnerClass
 
@@ -219,7 +223,7 @@ class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisi
 
     # Stub out all AbstractBatchSystem methods since they are never called
 
-    for name, value in AbstractBatchSystem.__dict__.iteritems():
+    for name, value in iteritems(AbstractBatchSystem.__dict__):
         if getattr(value, '__isabstractmethod__', False):
             exec 'def %s(): pass' % name
         # Without this, the class would end up with .name and .value attributes

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import unittest
 import os
 import random
 from uuid import uuid4
 import logging
 import subprocess
+
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from toil import resolveEntryPoint
 
 from toil.batchSystems.parasolTestSupport import ParasolTestSupport
@@ -297,7 +301,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
             l = open(tempFile, 'r').read()
             fileSize = os.path.getsize(tempFile)
             midPoint = getMidPoint(tempFile, 0, fileSize)
-            print "the mid point is %i of a file of %i bytes" % (midPoint, fileSize)
+            print("the mid point is %i of a file of %i bytes" % (midPoint, fileSize))
             assert midPoint < fileSize
             assert l[midPoint] == '\n'
             assert midPoint >= 0

--- a/src/toil/test/src/fileStoreTest.py
+++ b/src/toil/test/src/fileStoreTest.py
@@ -33,6 +33,8 @@ import signal
 import time
 import unittest
 
+# Python 3 compatibility imports
+from six.moves import xrange
 
 # Some tests take too long on the AWS and Azure Job stores and are unquitable for CI.  They can be
 # be run during manual tests by setting this to False.

--- a/src/toil/test/src/jobFileStoreTest.py
+++ b/src/toil/test/src/jobFileStoreTest.py
@@ -16,6 +16,9 @@ import random
 import os
 import errno
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from toil.common import Toil
 from toil.job import Job
 from toil.test import ToilTest

--- a/src/toil/test/src/jobServiceTest.py
+++ b/src/toil/test/src/jobServiceTest.py
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import random
 import unittest
+
+# Python 3 compatibility imports
+from six.moves import xrange
 
 from toil.lib.bioio import getTempFile
 from toil.job import Job
@@ -85,7 +88,7 @@ class JobServiceTest(ToilTest):
             try:
                 self.runToil(makeWorkflow(), badWorker=0.0, maxServiceJobs=2, deadlockWait=5)
             except DeadlockException:
-                print "Got expected deadlock exception"
+                print("Got expected deadlock exception")
             else:
                 assert 0
                 

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import unittest
 import os
 import random
+
+# Python 3 compatibility imports
+from six.moves import xrange
 
 from toil.common import Toil
 from toil.leader import FailedJobsException
@@ -314,10 +317,10 @@ class JobTest(ToilTest):
                         adjacencyList[int(j)].add(i)
             # Check the ordering retains an acyclic graph
             if not self.isAcyclic(adjacencyList):
-                print "ORDERING", ordering
-                print "CHILD EDGES", childEdges
-                print "FOLLOW ON EDGES", followOnEdges
-                print "ADJACENCY LIST", adjacencyList
+                print("ORDERING", ordering)
+                print("CHILD EDGES", childEdges)
+                print("FOLLOW ON EDGES", followOnEdges)
+                print("ADJACENCY LIST", adjacencyList)
             self.assertTrue(self.isAcyclic(adjacencyList))
 
     @staticmethod

--- a/src/toil/test/src/miscTests.py
+++ b/src/toil/test/src/miscTests.py
@@ -21,6 +21,9 @@ import os
 import random
 import tempfile
 
+# Python 3 compatibility imports
+from six.moves import xrange
+
 
 class MiscTests(ToilTest):
     """

--- a/src/toil/test/src/resourceTest.py
+++ b/src/toil/test/src/resourceTest.py
@@ -212,7 +212,7 @@ class ResourceTest(ToilTest):
         shebang = '#! %s\n' % sys.executable
         with tempFileContaining(shebang + scriptBody) as scriptPath:
             self.assertFalse(scriptPath.endswith(('.py', '.pyc')))
-            os.chmod(scriptPath, 0755)
+            os.chmod(scriptPath, 0o755)
             jobStorePath = scriptPath + '.jobStore'
             process = Popen([scriptPath, jobStorePath], stderr=PIPE)
             stdout, stderr = process.communicate()

--- a/src/toil/test/src/resumabilityTest.py
+++ b/src/toil/test/src/resumabilityTest.py
@@ -14,7 +14,10 @@
 
 from __future__ import absolute_import
 import os
-from StringIO import StringIO
+
+# Python 3 compatibility imports
+from six.moves import xrange
+
 from toil.job import Job
 from toil.test import ToilTest
 from toil.jobStores.abstractJobStore import NoSuchFileException

--- a/src/toil/utils/toilMain.py
+++ b/src/toil/utils/toilMain.py
@@ -4,6 +4,8 @@ import pkg_resources
 import os
 import sys
 
+# Python 3 compatibility imports
+from six import iteritems, iterkeys
 
 def main():
     modules = loadModules()
@@ -34,8 +36,8 @@ def main():
 def loadModules():
     # noinspection PyUnresolvedReferences
     from toil.utils import toilKill, toilStats, toilStatus, toilClean, toilLaunchCluster, toilDestroyCluster, toilSSHCluster, toilRsyncCluster
-    commandMapping = {name[4:].lower(): module for name, module in locals().iteritems()}
-    commandMapping = {name[:-7]+'-'+name[-7:] if name.endswith('cluster') else name: module for name, module in commandMapping.iteritems()}
+    commandMapping = {name[4:].lower(): module for name, module in iteritems(locals())}
+    commandMapping = {name[:-7]+'-'+name[-7:] if name.endswith('cluster') else name: module for name, module in iteritems(commandMapping)}
     return commandMapping
 
 def printHelp(modules):
@@ -46,5 +48,5 @@ def printHelp(modules):
              "where COMMAND is one of the following:\n\n{descriptions}\n\n")
     print(usage.format(
         name=os.path.basename(sys.argv[0]),
-        commands='|'.join(modules.iterkeys()),
-        descriptions='\n'.join("%s - %s" % (n, m.__doc__.strip()) for n, m in modules.iteritems())))
+        commands='|'.join(iterkeys(modules)),
+        descriptions='\n'.join("%s - %s" % (n, m.__doc__.strip()) for n, m in iteritems(modules))))

--- a/src/toil/utils/toilStats.py
+++ b/src/toil/utils/toilStats.py
@@ -16,7 +16,7 @@
 Reports statistical data about a given Toil workflow.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 from functools import partial
 import logging
 import json
@@ -55,7 +55,7 @@ class ColumnWidths(object):
     def report(self):
         for c in self.categories:
             for f in self.fields:
-                print '%s %s %d' % (c, f, self.getWidth(c, f))
+                print('%s %s %d' % (c, f, self.getWidth(c, f)))
 
 def initializeOptions(parser):
     parser.add_argument("jobStore", type=str,
@@ -588,7 +588,7 @@ def reportData(tree, options):
         fileHandle.write(out_str)
         fileHandle.close()
     # Now dump onto the screen
-    print out_str
+    print(out_str)
 
 def main():
     """ Reports stats on the workflow, use with --stats option to toil.

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import sys
 import copy
@@ -24,9 +24,12 @@ import traceback
 import time
 import socket
 import logging
-import cPickle
 import shutil
 from threading import Thread
+
+# Python 3 compatibility imports
+from six.moves import cPickle
+
 from bd2k.util.expando import Expando, MagicExpando
 from toil.common import Toil
 from toil.fileStore import FileStore
@@ -149,7 +152,7 @@ def main():
         
     # Dir to put all this worker's temp files in.
     localWorkerTempDir = tempfile.mkdtemp(dir=toilWorkflowDir)
-    os.chmod(localWorkerTempDir, 0755)
+    os.chmod(localWorkerTempDir, 0o755)
 
     ##########################################
     #Setup the logging
@@ -204,7 +207,7 @@ def main():
     try:
 
         #Put a message at the top of the log, just to make sure it's working.
-        print "---TOIL WORKER OUTPUT LOG---"
+        print("---TOIL WORKER OUTPUT LOG---")
         sys.stdout.flush()
         
         #Log the number of open file descriptors so we can tell if we're leaking

--- a/version_template.py
+++ b/version_template.py
@@ -118,7 +118,7 @@ def dirty():
 
 
 def expand_(name=None):
-    variables = {k: v for k, v in globals().iteritems()
+    variables = {k: v for k, v in globals().items()
                  if not k.startswith('_') and not k.endswith('_')}
 
     def resolve(k):
@@ -128,7 +128,7 @@ def expand_(name=None):
         return v
 
     if name is None:
-        return ''.join("%s = %s\n" % (k, repr(resolve(k))) for k, v in variables.iteritems())
+        return ''.join("%s = %s\n" % (k, repr(resolve(k))) for k, v in variables.items())
     else:
         return resolve(name)
 


### PR DESCRIPTION
PEP for imports
Fix adding custom docker_parameters
Remove all arguments for docker command line options from function args
Add parsing for container name in base_docker_call
Remove mock support (as decreed by the council of dev curmudgeons)
Add docstring example
No tests added

Screwed up the branch name, sorry. Make sure to delete branch after merging. 