### PR TITLE
CWL: fix typo in resolve_indirect

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -117,7 +117,7 @@ def resolve_indirect(d):
             if isinstance(v, StepValueFrom):
                 ev[k] = v.do_eval(res, res[k])
             else:
-                ev[k] = v
+                ev[k] = res[k]
         return ev
     else:
         return res


### PR DESCRIPTION
`resolve_indirect` translates tuples (keyword, dictionary) into context
specific dictionaries for CWL jobs. When a set of values had both values
that needed evaluation and indirect tuples, the evaluation logic would
get non-eval objects from the original dictionary (`d`) instead of the
resolved one (`res`). This fixes the typo to pass along resolved references
when not running `do_eval`.