### PR TITLE
Clean up Mesos logging 

### DIFF
--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -134,7 +134,7 @@ class MesosBatchSystem(BatchSystemSupport,
         # currently able to run on the offers given. This can happen if the cluster is busy
         # or if the nodes in the cluster simply don't have enough resources to run the jobs
         self.lastTimeOfferLogged = 0
-        self.logPeriod = 30  # seconds
+        self.logPeriod = 60  # seconds
 
         self._startDriver()
 
@@ -400,16 +400,6 @@ class MesosBatchSystem(BatchSystemSupport,
                     remainingMemory -= toMiB(jobType.memory)
                     remainingDisk -= toMiB(jobType.disk)
                     nextToLaunchIndex += 1
-                if self.jobQueues[jobType] and not runnableTasksOfType:
-                    log.debug('Offer %(offer)s not suitable to run the tasks with requirements '
-                              '%(requirements)r. Mesos offered %(memory)s memory, %(cores)s cores '
-                              'and %(disk)s of disk on a %(non)spreemptable slave.',
-                              dict(offer=offer.id.value,
-                                   requirements=jobType,
-                                   non='' if offerPreemptable else 'non-',
-                                   memory=fromMiB(offerMemory),
-                                   cores=offerCores,
-                                   disk=fromMiB(offerDisk)))
                 runnableTasks.extend(runnableTasksOfType)
             # Launch all runnable tasks together so we only call launchTasks once per offer
             if runnableTasks:
@@ -425,7 +415,7 @@ class MesosBatchSystem(BatchSystemSupport,
 
         if unableToRun and time.time() > (self.lastTimeOfferLogged + self.logPeriod):
             self.lastTimeOfferLogged = time.time()
-            log.debug('Although there are queued jobs, none of them were able to run in '
+            log.info('Although there are queued jobs, none of them were able to run in '
                      'any of the offers extended to the framework. There are currently '
                      '%i jobs running. Enable debug level logging to see more details about '
                      'job types and offers received.', len(self.runningJobMap))


### PR DESCRIPTION
Resolves #1422. Removes a log message that was repeated len(queued jobs) * len(offers) - when we have thousands of jobs and dozens of simultaneous offers this gets insane. Especially since we get a fresh batch of offers a multiple times a minute.