### PR TITLE
Explain how to terminate (remove) a cgcloud cluster

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,7 +80,7 @@ Here's what each extra provides:
    ``easy_install -a <path_to_egg>``. Note that on Ubuntu Trusty you may need
    to upgrade ``protobuf`` via ``pip install --upgrade protobuf`` **before**
    running the above ``easy_install`` command.
-   
+
    If you intend to install Toil with the ``mesos`` extra into a virtualenv, be
    sure to create that virtualenv with
 
@@ -317,6 +317,11 @@ which contains Troubleshooting sections.
       cgcloud ssh toil-leader
 
 At this point, any Toil script can be run on the distributed AWS cluster following instructions in :ref:`runningAWS`.
+
+Finally, if you wish to tear down the cluster and remove all its data
+permanently, cgcloud allows you to do so without logging into the AWS web interface::
+
+      cgcloud terminate-cluster toil
 
 .. _installationAzure:
 


### PR DESCRIPTION
Needed since I had to dig into the source and test to figure out what `TYPE` meant in CGCLOUD context:

```
vagrant@vagrant-ubuntu-trusty-64:~$ cgcloud terminate-cluster ec2
INFO: Using zone 'ap-southeast-2a' and namespace '/vccc/'
ERROR: Unknown cluster type 'ec2'
vagrant@vagrant-ubuntu-trusty-64:~$ cgcloud terminate-cluster mesos
INFO: Using zone 'ap-southeast-2a' and namespace '/vccc/'
ERROR: Unknown cluster type 'mesos'
vagrant@vagrant-ubuntu-trusty-64:~$ cgcloud terminate-cluster toil
INFO: Using zone 'ap-southeast-2a' and namespace '/vccc/'
INFO: Binding to instance ...
INFO: ... bound to i-063c2580243a0f5d7.
INFO: === Performing terminate() on workers ===
Thread-1 INFO: Terminating instance ...
Thread-2 INFO: Terminating instance ...
Thread-1 INFO: ... instance terminated.
Thread-2 INFO: ... instance terminated.
INFO: === Performing terminate() on leader ===
INFO: Terminating instance ...
INFO: ... instance terminated.
```