### PR TITLE
Avoid import error if ‘AWS’ extra not installed 

### DIFF
--- a/src/toil/utils/__init__.py
+++ b/src/toil/utils/__init__.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import
 from toil import version
 import logging
 
-from toil.provisioners.aws import getCurrentAWSZone
-
 logger = logging.getLogger(__name__)
 
 
@@ -13,7 +11,11 @@ def addBasicProvisionerOptions(parser):
     parser.add_argument('-p', "--provisioner", dest='provisioner', choices=['aws'], required=False, default="aws",
                         help="The provisioner for cluster auto-scaling. Only aws is currently "
                              "supported")
-    currentZone = getCurrentAWSZone()
+    try:
+        from toil.provisioners.aws import getCurrentAWSZone
+        currentZone = getCurrentAWSZone()
+    except ImportError:
+        currentZone = None
     zoneString = currentZone if currentZone else 'No zone could be determined'
     parser.add_argument('-z', '--zone', dest='zone', required=False, default=currentZone,
                         help="The AWS availability zone of the master. This parameter can also be "


### PR DESCRIPTION
Resolves #1436