### PR TITLE
Remove toil containers before start in systemd service files (resolves #1464)

### DIFF
--- a/src/toil/provisioners/aws/__init__.py
+++ b/src/toil/provisioners/aws/__init__.py
@@ -275,6 +275,8 @@ coreos:
 
         [Service]
         Restart=on-failure
+        RestartSec=2
+        ExecPre=-/usr/bin/docker rm toil_{role}
         ExecStart=/usr/bin/docker run \
             --entrypoint={entrypoint} \
             --net=host \


### PR DESCRIPTION
Resolves #1464.

The very first restart after a container failure / docker daemon failure will still fail with a message like:
```
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.597786     1 main.cpp:243] Build: 2016-07-27 20:23:20 by ubuntu
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.597882     1 main.cpp:244] Version: 1.0.0
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.597893     1 main.cpp:247] Git tag: 1.0.0
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.597899     1 main.cpp:251] Git SHA: c9b70582e9fccab8f6863b0bd3a812b5969a8c24
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.600864     1 logging.cpp:194] INFO level logging started!
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: Mount failed for selinuxfs on /sys/fs/selinux:  No such file or directory
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.604971     1 containerizer.cpp:196] Using isolation: posix/cpu,posix/mem,filesystem/posix,network/cni
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.607852     1 main.cpp:434] Starting Mesos agent
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.608415    11 slave.cpp:198] Agent started on 1)@172.31.25.156:5051
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.608448    11 slave.cpp:199] Flags at startup: --appc_simple_discovery_uri_prefix="http://" --appc_store_dir="/tmp/mesos/store/appc" --attributes="preemptable:False" --authenticate_http_readonl
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.609876    11 slave.cpp:519] Agent resources: cpus(*):4; mem(*):14018; disk(*):70267; ports(*):[31000-32000]
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.609952    11 slave.cpp:527] Agent attributes: [ preemptable=False ]
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.609982    11 slave.cpp:532] Agent hostname: ip-172-31-25-156.us-west-2.compute.internal
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.613293     9 state.cpp:57] Recovering state from '/var/lib/mesos/meta'
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.613358     9 state.cpp:697] No checkpointed resources found at '/var/lib/mesos/meta/resources/resources.info'
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.614212     9 status_update_manager.cpp:200] Recovering status update manager
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.614363    11 containerizer.cpp:522] Recovering containerizer
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.614819    11 provisioner.cpp:253] Provisioner recovery complete
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.615066     8 slave.cpp:4782] Finished recovery
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.615720     8 status_update_manager.cpp:174] Pausing sending status updates
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.615731     9 slave.cpp:895] New master detected at master@172.31.6.228:5050
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.615851     9 slave.cpp:916] No credentials provided. Attempting to register without authentication
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.615900     9 slave.cpp:927] Detecting new master
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.915330    10 slave.cpp:809] Agent asked to shut down by master@172.31.6.228:5050 because 'Agent attempted to re-register after removal'
Jan 31 02:54:00 ip-172-31-25-156.us-west-2.compute.internal docker[21686]: I0131 02:54:00.915448    10 slave.cpp:767] Agent terminating
```

but the second restart (triggered automatically when the first restart failed) will work fine.