### PR TITLE
Optionally tag auto-scaled EC2 instances with user-specified tags (resolves #1341)

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -22,6 +22,7 @@ import time
 import sys
 
 # Python 3 compatibility imports
+from six import iteritems
 from six.moves import xrange
 
 from bd2k.util import memoize
@@ -242,7 +243,7 @@ class AWSProvisioner(AbstractProvisioner):
     @classmethod
     def _addTags(cls, instances, tags):
         for instance in instances:
-            for key, value in tags.iteritems():
+            for key, value in iteritems(tags):
                 instance.add_tag(key, value)
 
     @classmethod

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -248,8 +248,7 @@ class AWSProvisioner(AbstractProvisioner):
     @classmethod
     def _addTags(cls, instances, tags):
         for instance in instances:
-            for tag in tags:
-                key, value = tag
+            for key, value in tags.iteritems():
                 instance.add_tag(key, value)
 
     @classmethod

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -60,6 +60,7 @@ class AWSProvisioner(AbstractProvisioner):
         self.leaderIP = self.instanceMetaData['local-ipv4']
         self.keyName = self.instanceMetaData['public-keys'].keys()[0]
         self.masterPublicKey = self.setSSH()
+        self.tags = self.ctx.ec2.get_all_tags()
 
     def setSSH(self):
         if not os.path.exists('/root/.sshSuccess'):
@@ -233,7 +234,7 @@ class AWSProvisioner(AbstractProvisioner):
         leader = instances[0]  # assume leader was launched first
         if wait:
             logger.info("Waiting for toil_leader to enter 'running' state...")
-            cls._tagWhenRunning(ctx.ec2, [leader], clusterName)
+            wait_instances_running(ctx.ec2, [leader])
             logger.info('... toil_leader is running')
             cls._waitForNode(leader, 'toil_leader')
         return leader
@@ -243,6 +244,13 @@ class AWSProvisioner(AbstractProvisioner):
         wait_instances_running(ec2, instances)
         for instance in instances:
             instance.add_tag("Name", tag)
+
+    @classmethod
+    def _addTags(cls, instances, tags):
+        for instance in instances:
+            for tag in tags:
+                key, value = tag
+                instance.add_tag(key, value)
 
     @classmethod
     def _waitForNode(cls, instance, role):
@@ -335,7 +343,7 @@ class AWSProvisioner(AbstractProvisioner):
                 s.close()
 
     @classmethod
-    def launchCluster(cls, instanceType, keyName, clusterName, spotBid=None, zone=None):
+    def launchCluster(cls, instanceType, keyName, clusterName, spotBid=None, userTags={}, zone=None):
         ctx = cls._buildContext(clusterName=clusterName, zone=zone)
         profileARN = cls._getProfileARN(ctx)
         # the security group name is used as the cluster identifier
@@ -364,7 +372,12 @@ class AWSProvisioner(AbstractProvisioner):
                                        tags={'clusterName': clusterName},
                                        spec=kwargs,
                                        num_instances=1))
-        return cls._getLeader(clusterName=clusterName, wait=True, zone=zone)
+        leader = cls._getLeader(clusterName=clusterName, wait=True, zone=zone)
+
+        defaultTags = {'Name': clusterName, 'Owner': keyName}
+        defaultTags.update(userTags)
+        cls._addTags([leader], defaultTags)
+        return leader
 
     @classmethod
     def destroyCluster(cls, clusterName, zone=None):
@@ -507,7 +520,8 @@ class AWSProvisioner(AbstractProvisioner):
                                      )
             # flatten the list 
             instancesLaunched = [item for sublist in instancesLaunched for item in sublist]
-        self._tagWhenRunning(self.ctx.ec2, instancesLaunched, self.clusterName)
+        wait_instances_running(self.ctx.ec2, instancesLaunched)
+        AWSProvisioner._addTags(instancesLaunched, self.tags)
         self._propagateKey(instancesLaunched)
         logger.info('Launched %s new instance(s)', numNodes)
         return len(instancesLaunched)

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -60,7 +60,7 @@ class AWSProvisioner(AbstractProvisioner):
         self.leaderIP = self.instanceMetaData['local-ipv4']
         self.keyName = self.instanceMetaData['public-keys'].keys()[0]
         self.masterPublicKey = self.setSSH()
-        self.tags = self.ctx.ec2.get_all_tags()
+        self.tags = self._getLeader(self.clusterName).tags
 
     def setSSH(self):
         if not os.path.exists('/root/.sshSuccess'):
@@ -238,12 +238,6 @@ class AWSProvisioner(AbstractProvisioner):
             logger.info('... toil_leader is running')
             cls._waitForNode(leader, 'toil_leader')
         return leader
-
-    @classmethod
-    def _tagWhenRunning(cls, ec2, instances, tag):
-        wait_instances_running(ec2, instances)
-        for instance in instances:
-            instance.add_tag("Name", tag)
 
     @classmethod
     def _addTags(cls, instances, tags):

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -343,7 +343,9 @@ class AWSProvisioner(AbstractProvisioner):
                 s.close()
 
     @classmethod
-    def launchCluster(cls, instanceType, keyName, clusterName, spotBid=None, userTags={}, zone=None):
+    def launchCluster(cls, instanceType, keyName, clusterName, spotBid=None, userTags=None, zone=None):
+        if userTags is None:
+            userTags = {}
         ctx = cls._buildContext(clusterName=clusterName, zone=zone)
         profileARN = cls._getProfileARN(ctx)
         # the security group name is used as the cluster identifier

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -100,7 +100,7 @@ class UtilsTest(ToilTest):
             tags.update(userTags)
 
             # launch preemptable master with same name
-            system([self.toilMain, 'launch-cluster', '-T', 'key1=value1', '-T', 'key2=value2', '--tag', 'key3=value3',
+            system([self.toilMain, 'launch-cluster', '-t', 'key1=value1', '-t', 'key2=value2', '--tag', 'key3=value3',
                     '--nodeType=m3.medium:0.2', '--keyPairName=' + keyName, clusterName,
                     '--provisioner=aws', '--logLevel=DEBUG'])
             system([self.toilMain, 'ssh-cluster', '--provisioner=aws', clusterName])

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -84,6 +84,7 @@ class UtilsTest(ToilTest):
     @integrative
     def testAWSProvisionerUtils(self):
         clusterName = 'cluster-utils-test' + str(uuid.uuid4())
+        keyName = 'jenkins@jenkins-master'
         try:
             # --provisioner flag should default to aws, so we're not explicitly
             # specifying that here
@@ -93,10 +94,20 @@ class UtilsTest(ToilTest):
             system([self.toilMain, 'destroy-cluster', '--provisioner=aws', clusterName])
         try:
             from toil.provisioners.aws.awsProvisioner import AWSProvisioner
+            
+            userTags = {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}
+            tags = {'Name': clusterName, 'Owner': keyName}
+            tags.update(userTags)
+
             # launch preemptable master with same name
-            system([self.toilMain, 'launch-cluster', '--nodeType=m3.medium:0.2', '--keyPairName=jenkins@jenkins-master',
-                    clusterName, '--provisioner=aws', '--logLevel=DEBUG'])
+            system([self.toilMain, 'launch-cluster', '-T', 'key1=value1', '-T', 'key2=value2', '--tag', 'key3=value3',
+                    '--nodeType=m3.medium:0.2', '--keyPairName=' + keyName, clusterName,
+                    '--provisioner=aws', '--logLevel=DEBUG'])
             system([self.toilMain, 'ssh-cluster', '--provisioner=aws', clusterName])
+
+            # test leader tags
+            leaderTags = AWSProvisioner._getLeader(clusterName).tags
+            self.assertEqual(tags, leaderTags)
 
             testStrings = ["'foo'",
                            '"foo"',

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -71,4 +71,4 @@ def main():
         assert False
 
     provisioner.launchCluster(instanceType=config.nodeType, clusterName=config.clusterName,
-                              keyName=config.keyPairName, spotBid=spotBid, tags=tagsDict, zone=config.zone)
+                              keyName=config.keyPairName, spotBid=spotBid, userTags=tagsDict, zone=config.zone)

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -52,7 +52,7 @@ def main():
                              "but these can be overridden.")
     config = parseBasicOptions(parser)
     setLoggingFromOptions(config)
-    tagsDict = createTagsDict(config.tags)
+    tagsDict = None if config.tags is None else createTagsDict(config.tags)
 
     spotBid = None
     if config.provisioner == 'aws':

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -39,17 +39,16 @@ def main():
                              "bid for a spot instance, for example 'c3.8xlarge:0.42'.")
     parser.add_argument("--keyPairName", dest='keyPairName', required=True,
                         help="The name of the AWS key pair to include on the instance")
-    parser.add_argument("-T, --tag", dest='tags', action='append',
+    parser.add_argument("-t", "--tag", metavar='NAME=VALUE', dest='tags', default=[], action='append',
                         help="Tags are added to the AWS cluster for this node and all of its"
-                             "children. Tags are of the form:"
-                             "  --T key1=value1 --tag key2=value2"
-                             "Multiple tags are allowed and each tag needs its own flag. By"
-                             "default the cluster is tagged with"
-                             "  {"
+                             "children. Tags are of the form: "
+                             " --T key1=value1 --tag key2=value2 "
+                             "Multiple tags are allowed and each tag needs its own flag. By "
+                             "default the cluster is tagged with "
+                             " {"
                              "      \"Name\": clusterName,"
                              "      \"Owner\": IAM username"
-                             "  }"
-                             "but these can be overridden.")
+                             " }. ")
     config = parseBasicOptions(parser)
     setLoggingFromOptions(config)
     tagsDict = None if config.tags is None else createTagsDict(config.tags)

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -42,7 +42,7 @@ def main():
     parser.add_argument("-t", "--tag", metavar='NAME=VALUE', dest='tags', default=[], action='append',
                         help="Tags are added to the AWS cluster for this node and all of its"
                              "children. Tags are of the form: "
-                             " --T key1=value1 --tag key2=value2 "
+                             " --t key1=value1 --tag key2=value2 "
                              "Multiple tags are allowed and each tag needs its own flag. By "
                              "default the cluster is tagged with "
                              " {"


### PR DESCRIPTION
User can specify tags in the command line when running `toil launch-cluster` which will automatically be added to all node as the cluster auto scales. The form for tags is:

`toil launch-cluster -T key1=value1 --tag key2=value2 ...`

Multiple tags can be specified. 