### PR TITLE
Report 'theoretical' cluster usage in addition to actual usage

### DIFF
--- a/docs/contributing/source.rst
+++ b/docs/contributing/source.rst
@@ -113,3 +113,23 @@ this may come up empty. To fix it, run the following:
 
 .. _Docker: https://www.docker.com/products/docker
 .. _Quay: https://quay.io/
+
+
+Developing with the Toil Appliance
+----------------------------------
+
+To develop on features reliant on the Toil Appliance (i.e. autoscaling), you
+should consider setting up a personal registry on `Quay`_ or `Docker Hub`_. Because
+the Toil Appliance images are tagged with the Git commit they are based on and
+because only commits on our master branch trigger an appliance build on Quay,
+as soon as a developer makes a commit or dirties the working copy they will no
+longer be able to rely on Toil to automatically detect the proper Toil Appliance
+image. Instead, developers wishing to test any appliance changes in autoscaling
+should build and push their own appliance image to a personal Docker registry.
+See :ref:`Autoscaling` and :func:`toil.applianceSelf` for information on how to
+configure Toil to pull the Toil Appliance image from your personal repo instead
+of the our official Quay account.
+
+.. _Quay: https://quay.io/
+
+.. _Docker Hub: https://hub.docker.com/

--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -278,22 +278,3 @@ properly resolving overlapping dependencies and detecting conflicts.
 
 .. _appliance_dev:
 
-Developing with the Toil Appliance
-----------------------------------
-
-To develop on features reliant on the Toil Appliance (i.e. autoscaling), you
-should consider setting up a personal registry on `Quay`_ or `Docker Hub`_. Because
-the Toil Appliance images are tagged with the Git commit they are based on and
-because only commits on our master branch trigger an appliance build on Quay,
-as soon as a developer makes a commit or dirties the working copy they will no
-longer be able to rely on Toil to automatically detect the proper Toil Appliance
-image. Instead, developers wishing to test any appliance changes in autoscaling
-should build and push their own appliance image to a personal Docker registry.
-See :ref:`Autoscaling` and :func:`toil.applianceSelf` for information on how to
-configure Toil to pull the Toil Appliance image from your personal repo instead
-of the our official Quay account.
-
-.. _Quay: https://quay.io/
-
-.. _Docker Hub: https://hub.docker.com/
-

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -613,8 +613,8 @@ workers of the cluster. Instructions for installing Docker can be found on the
 
 When using CGCloud or Toil-based autoscaling, Docker will be automatically set up
 on the cluster's worker nodes, so no additional installation steps are necessary.
-Further information on using Toil-based autoscaling can be found in the `Toil
-autoscaling documentation <Autoscaling>`.
+Further information on using Toil-based autoscaling can be found in the :ref:`Autoscaling`
+documentation.
 
 In order to use docker containers in a Toil workflow, the container can be built
 locally or downloaded in real time from an online docker repository like Quay_. If

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -331,7 +331,7 @@ class NodeInfo(object):
     """
     def __init__(self, coresUsed, memoryUsed, coresTotal, memoryTotal,
                  requestedCores, requestedMemory, workers):
-        self.coresUse = coresUsed
+        self.coresUsed = coresUsed
         self.totalCores = coresTotal
         self.memoryUsed = memoryUsed
         self.memoryTotal = memoryTotal

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -318,7 +318,7 @@ class BatchSystemSupport(AbstractBatchSystem):
             and workflowDirContents in ([], [cacheDirName(info.workflowID)])):
             shutil.rmtree(workflowDir)
 
-class NodeInfo(namedtuple("_NodeInfo", "cores memory workers")):
+class NodeInfo(object):
     """
     The cores attribute  is a floating point value between 0 (all cores idle) and 1 (all cores
     busy), reflecting the CPU load of the node.
@@ -329,6 +329,15 @@ class NodeInfo(namedtuple("_NodeInfo", "cores memory workers")):
     The workers attribute is an integer reflecting the number of workers currently active workers
     on the node.
     """
+    def __init__(self, coresUsed, memoryUsed, coresTotal, memoryTotal,
+                 requestedCores, requestedMemory, workers):
+        self.coresUse = coresUsed
+        self.totalCores = coresTotal
+        self.memoryUsed = memoryUsed
+        self.memoryTotal = memoryTotal
+        self.requestedCores = requestedCores
+        self.requestedMemory = requestedMemory
+        self.workers = workers
 
 
 class AbstractScalableBatchSystem(AbstractBatchSystem):

--- a/src/toil/batchSystems/mesos/__init__.py
+++ b/src/toil/batchSystems/mesos/__init__.py
@@ -20,7 +20,11 @@ TaskData = namedtuple('TaskData', (
     # Mesos' ID of the slave where task is being run
     'slaveID',
     # Mesos' ID of the executor running the task
-    'executorID'))
+    'executorID',
+    # Memory requirement of the task
+    'memory',
+    # CPU requirement of the task
+    'cores'))
 
 
 class ResourceRequirement( namedtuple('_ResourceRequirement', (

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -346,7 +346,7 @@ class MesosBatchSystem(BatchSystemSupport,
                     jobType.remove(job)
 
     def _updateStateToRunning(self, offer, task):
-        resources = self.taskResources[task.task_id]
+        resources = self.taskResources[int(task.task_id.value)]
         self.runningJobMap[int(task.task_id.value)] = TaskData(startTime=time.time(),
                                                                slaveID=offer.slave_id,
                                                                executorID=task.executor.executor_id,

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -349,8 +349,8 @@ class MesosBatchSystem(BatchSystemSupport,
         resourceKey = int(task.task_id.value)
         resources = self.taskResources[resourceKey]
         self.runningJobMap[int(task.task_id.value)] = TaskData(startTime=time.time(),
-                                                               slaveID=offer.slave_id,
-                                                               executorID=task.executor.executor_id,
+                                                               slaveID=offer.slave_id.value,
+                                                               executorID=task.executor.executor_id.value,
                                                                cores=resources.cores,
                                                                memory=resources.memory)
         del self.taskResources[resourceKey]
@@ -549,8 +549,10 @@ class MesosBatchSystem(BatchSystemSupport,
         for k, v in iteritems(message):
             if k == 'nodeInfo':
                 assert isinstance(v, dict)
-                requestedCores = sum([taskData.cores for taskData in itervalues(self.runningJobMap)])
-                requestedMemory = sum([taskData.memory for taskData in itervalues(self.runningJobMap)])
+                resources = [taskData for taskData in itervalues(self.runningJobMap)
+                             if taskData.executorID == executorId.value]
+                requestedCores = sum(taskData.cores for taskData in resources)
+                requestedMemory = sum(taskData.memory for taskData in resources)
                 executor.nodeInfo = NodeInfo(requestedCores=requestedCores, requestedMemory=requestedMemory, **v)
                 self.executors[nodeAddress] = executor
             else:

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -29,7 +29,7 @@ import itertools
 
 # Python 3 compatibility imports
 from six.moves.queue import Empty, Queue
-from six import iteritems
+from six import iteritems, itervalues
 
 import mesos.interface
 import mesos.native
@@ -547,8 +547,8 @@ class MesosBatchSystem(BatchSystemSupport,
         for k, v in iteritems(message):
             if k == 'nodeInfo':
                 assert isinstance(v, dict)
-                requestedCores = sum([taskData.cores for taskData in self.runningJobMap.itervalues()])
-                requestedMemory = sum([taskData.memory for taskData in self.runningJobMap.itervalues()])
+                requestedCores = sum([taskData.cores for taskData in itervalues(self.runningJobMap)])
+                requestedMemory = sum([taskData.memory for taskData in itervalues(self.runningJobMap)])
                 executor.nodeInfo = NodeInfo(requestedCores=requestedCores, requestedMemory=requestedMemory, **v)
                 self.executors[nodeAddress] = executor
             else:

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -346,12 +346,14 @@ class MesosBatchSystem(BatchSystemSupport,
                     jobType.remove(job)
 
     def _updateStateToRunning(self, offer, task):
-        resources = self.taskResources[int(task.task_id.value)]
+        resourceKey = int(task.task_id.value)
+        resources = self.taskResources[resourceKey]
         self.runningJobMap[int(task.task_id.value)] = TaskData(startTime=time.time(),
                                                                slaveID=offer.slave_id,
                                                                executorID=task.executor.executor_id,
                                                                cores=resources.cores,
                                                                memory=resources.memory)
+        del self.taskResources[resourceKey]
         self._deleteByJobID(int(task.task_id.value))
 
     def resourceOffers(self, driver, offers):

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -110,8 +110,10 @@ class MesosExecutor(mesos.interface.Executor):
                 message = Expando(address=self.address)
                 psutil.cpu_percent()
             else:
-                message.nodeInfo = dict(cores=float(psutil.cpu_percent()) * .01,
-                                        memory=float(psutil.virtual_memory().percent) * .01,
+                message.nodeInfo = dict(coresUsed=float(psutil.cpu_percent()) * .01,
+                                        memoryUsed=float(psutil.virtual_memory().percent) * .01,
+                                        coresTotal=psutil.cpu_count(),
+                                        memoryTotal=psutil.virtual_memory().total,
                                         workers=len(self.runningTasks))
             driver.sendFrameworkMessage(repr(message))
             # Prevent workers launched together from repeatedly hitting the leader at the same time

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -99,16 +99,15 @@ class AbstractProvisioner(object):
 
     def _gatherStats(self, preemptable):
         def toDict(nodeInfo):
-            # namedtuples don't retain attribute names when dumped to JSON.
-            # convert them to dicts instead to improve stats output. Also add
-            # time.
+            # convert NodeInfo object to dict to improve JSON output
             return dict(memory=nodeInfo.memoryUsage,
                         cores=nodeInfo.coresUsage,
                         memoryTotal=nodeInfo.memoryTotal,
                         coresTotal=nodeInfo.coresTotal,
-                        theoreticalCores=nodeInfo,
+                        requestedCores=nodeInfo.requestedCores,
+                        requestedMemory=nodeInfo.requestedMemory,
                         workers=nodeInfo.workers,
-                        time=time.time()
+                        time=time.time()  # add time stamp
                         )
         if self.scaleable:
             stats = {}

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -102,8 +102,11 @@ class AbstractProvisioner(object):
             # namedtuples don't retain attribute names when dumped to JSON.
             # convert them to dicts instead to improve stats output. Also add
             # time.
-            return dict(memory=nodeInfo.memory,
-                        cores=nodeInfo.cores,
+            return dict(memory=nodeInfo.memoryUsage,
+                        cores=nodeInfo.coresUsage,
+                        memoryTotal=nodeInfo.memoryTotal,
+                        coresTotal=nodeInfo.coresTotal,
+                        theoreticalCores=nodeInfo,
                         workers=nodeInfo.workers,
                         time=time.time()
                         )

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -411,15 +411,16 @@ class AWSProvisioner(AbstractProvisioner):
     @classmethod
     def _terminateInstances(cls, instances, ctx):
         instanceIDs = [x.id for x in instances]
+        logger.info('Terminating instance(s): %s', instanceIDs)
         cls._terminateIDs(instanceIDs, ctx)
+        logger.info('... Waiting for instance(s) to shut down...')
         for instance in instances:
             wait_transition(instance, {'running', 'shutting-down'}, 'terminated')
+        logger.info('Instance(s) terminated.')
 
     @classmethod
     def _terminateIDs(cls, instanceIDs, ctx):
-        logger.info('Terminating instance(s): %s', instanceIDs)
         ctx.ec2.terminate_instances(instance_ids=instanceIDs)
-        logger.info('Instance(s) terminated.')
 
     def _logAndTerminate(self, instances):
         self._terminateInstances(instances, self.ctx)

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -289,8 +289,8 @@ class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisi
         # AbstractScalableBatchSystem functionality
 
         def getNodes(self):
-            return {address: NodeInfo(cores=0,
-                                      memory=0,
+            return {address: NodeInfo(coresTotal=0, coresUsed=0,
+                                      memoryTotal=0, memoryUsed=0,
                                       workers=1 if w.busyEvent.is_set() else 0)
                     for address, w in enumerate(self.workers)}
 


### PR DESCRIPTION
Resolves #1416 

The cluster statistics currently report the cluster's actual resource usage. This is helpful to users but for Toil development, especially in relation to the autoscaler, we only care about how efficiently Toil is managing the resources that a user requests regardless of whether the user is using them. This lets us distinguish between efficiency losses due to Toil scheduling/autoscaling and losses due to a user requesting more resources than needed. 

