### PR TITLE
Issues/1465 1466 Fix verification that new checkpoint jobs are leaf vertices

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -646,7 +646,7 @@ class Job(JobLikeObject):
         # Check for each job for which checkpoint is true that it is a cut vertex or leaf
         for y in filter(lambda x : x.checkpoint, jobs):
             if y not in roots: # The roots are the prexisting jobs
-                if len(y._children) != 0 and len(y._followOns) != 0 and len(y._services) != 0:
+                if not (len(y._children) == 0 and len(y._followOns) == 0 and len(y._services) == 0):
                     raise JobGraphDeadlockException("New checkpoint job %s is not a leaf in the job graph" % y)
 
     def defer(self, function, *args, **kwargs):

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -646,7 +646,7 @@ class Job(JobLikeObject):
         # Check for each job for which checkpoint is true that it is a cut vertex or leaf
         for y in filter(lambda x : x.checkpoint, jobs):
             if y not in roots: # The roots are the prexisting jobs
-                if not (len(y._children) == 0 and len(y._followOns) == 0 and len(y._services) == 0):
+                if not Job._isLeafVertex(y):
                     raise JobGraphDeadlockException("New checkpoint job %s is not a leaf in the job graph" % y)
 
     def defer(self, function, *args, **kwargs):
@@ -824,6 +824,12 @@ class Job(JobLikeObject):
         if predecessorJob in self._directPredecessors:
             raise RuntimeError("The given job is already a predecessor of this job")
         self._directPredecessors.add(predecessorJob)
+
+    @staticmethod
+    def _isLeafVertex(job):
+        return len(job._children) == 0 \
+               and len(job._followOns) == 0 \
+               and len(job._services) == 0
 
     @classmethod
     def _loadUserModule(cls, userModule):
@@ -1180,6 +1186,13 @@ class Job(JobLikeObject):
 
         :param toil.jobStores.abstractJobStore.AbstractJobStore jobStore:
         """
+
+        # Check if the workflow root is a checkpoint but not a leaf vertex.
+        # All other job vertices in the graph are checked by checkNewCheckpointsAreLeafVertices
+        if self.checkpoint and not Job._isLeafVertex(self):
+            raise JobGraphDeadlockException(
+                'New checkpoint job %s is not a leaf in the job graph' % self)
+
         # Create first jobGraph
         jobGraph = self._createEmptyJobGraphForJob(jobStore=jobStore, predecessorNumber=0)
         # Write the graph of jobs to disk

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -275,7 +275,6 @@ class JobTest(ToilTest):
 
         self.runNewCheckpointIsLeafVertexTest(createWorkflow)
 
-    @unittest.skip("Enable this test when issue #1466 has been fixed.")
     def testNewCheckpointIsLeafVertexRootCase(self):
         """
         Test for issue #1466: Detection of checkpoint jobs that are not leaf vertices

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -254,6 +254,113 @@ class JobTest(ToilTest):
                 and (fNode, tNode) not in childEdges and (fNode, tNode) not in followOnEdges):
                 checkFollowOnEdgeCycleDetection(fNode, tNode)
 
+    def testNewCheckpointIsLeafVertexNonRootCase(self):
+        """
+        Test for issue #1465: Detection of checkpoint jobs that are not leaf vertices
+        identifies leaf vertices incorrectly
+
+        Test verification of new checkpoint jobs being leaf verticies,
+        starting with the following baseline workflow:
+
+            Parent
+              |
+            Child # Checkpoint=True
+
+        """
+
+        def createWorkflow():
+            rootJob = Job.wrapJobFn(simpleJobFn, "Parent")
+            childCheckpointJob = rootJob.addChildJobFn(simpleJobFn, "Child", checkpoint=True)
+            return rootJob, childCheckpointJob
+
+        self.runNewCheckpointIsLeafVertexTest(createWorkflow)
+
+    @unittest.skip("Enable this test when issue #1466 has been fixed.")
+    def testNewCheckpointIsLeafVertexRootCase(self):
+        """
+        Test for issue #1466: Detection of checkpoint jobs that are not leaf vertices
+                              omits the workflow root job
+
+        Test verification of a new checkpoint job being leaf vertex,
+        starting with a baseline workflow of a single, root job:
+
+            Root # Checkpoint=True
+
+        """
+
+        def createWorkflow():
+            rootJob = Job.wrapJobFn(simpleJobFn, "Root", checkpoint=True)
+            return rootJob, rootJob
+
+        self.runNewCheckpointIsLeafVertexTest(createWorkflow)
+
+    def runNewCheckpointIsLeafVertexTest(self, createWorkflowFn):
+        """
+        Test verification that a checkpoint job is a leaf vertex using both
+        valid and invalid cases.
+
+        :param createWorkflowFn: function to create and new workflow and return a tuple of:
+
+                                 0) the workflow root job
+                                 1) a checkpoint job to test within the workflow
+
+        """
+
+        print('Test checkpoint job that is a leaf vertex')
+        self.runCheckpointVertexTest(*createWorkflowFn(),
+                                     expectedException=None)
+
+        print('Test checkpoint job that is not a leaf vertex due to the presence of a service')
+        self.runCheckpointVertexTest(*createWorkflowFn(),
+                                     checkpointJobService=TrivialService("LeafTestService"),
+                                     expectedException=JobGraphDeadlockException)
+
+        print('Test checkpoint job that is not a leaf vertex due to the presence of a child job')
+        self.runCheckpointVertexTest(*createWorkflowFn(),
+                                     checkpointJobChild=Job.wrapJobFn(
+                                         simpleJobFn, "LeafTestChild"),
+                                     expectedException=JobGraphDeadlockException)
+
+        print('Test checkpoint job that is not a leaf vertex due to the presence of a follow-on job')
+        self.runCheckpointVertexTest(*createWorkflowFn(),
+                                     checkpointJobFollowOn=Job.wrapJobFn(
+                                         simpleJobFn,
+                                         "LeafTestFollowOn"),
+                                     expectedException=JobGraphDeadlockException)
+
+    def runCheckpointVertexTest(self,
+                                workflowRootJob,
+                                checkpointJob,
+                                checkpointJobService=None,
+                                checkpointJobChild=None,
+                                checkpointJobFollowOn=None,
+                                expectedException=None):
+        """
+        Modifies the checkpoint job according to the given parameters
+        then runs the workflow, checking for the expected exception, if any.
+        """
+
+        self.assertTrue(checkpointJob.checkpoint)
+
+        if checkpointJobService is not None:
+            checkpointJob.addService(checkpointJobService)
+        if checkpointJobChild is not None:
+            checkpointJob.addChild(checkpointJobChild)
+        if checkpointJobFollowOn is not None:
+            checkpointJob.addFollowOn(checkpointJobFollowOn)
+
+        # Run the workflow and check for the expected behavior
+        options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
+        options.logLevel = "INFO"
+        if expectedException is None:
+            Job.Runner.startToil(workflowRootJob, options)
+        else:
+            try:
+                Job.Runner.startToil(workflowRootJob, options)
+                self.fail("The expected exception was not thrown")
+            except expectedException as ex:
+                print("The expected exception was thrown: ", repr(ex))
+
     def testEvaluatingRandomDAG(self):
         """
         Randomly generate test input then check that the job graph can be 
@@ -495,6 +602,9 @@ class JobTest(ToilTest):
             if cyclic(i, visited, []):
                 return False
         return True
+
+def simpleJobFn(job, value):
+    job.fileStore.logToMaster(value)
 
 def fn1Test(string, outputFile):
     """

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import absolute_import, print_function
 import unittest
+import logging
 import os
 import random
 
@@ -25,11 +26,17 @@ from toil.lib.bioio import getTempFile
 from toil.job import Job, JobGraphDeadlockException, JobFunctionWrappingJob
 from toil.test import ToilTest
 
+logger = logging.getLogger(__name__)
 
 class JobTest(ToilTest):
     """
     Tests testing the job class
     """
+
+    @classmethod
+    def setUpClass(cls):
+        super(JobTest, cls).setUpClass()
+        logging.basicConfig(level=logging.DEBUG)
 
     def testStatic(self):
         """
@@ -305,22 +312,22 @@ class JobTest(ToilTest):
 
         """
 
-        print('Test checkpoint job that is a leaf vertex')
+        logger.info('Test checkpoint job that is a leaf vertex')
         self.runCheckpointVertexTest(*createWorkflowFn(),
                                      expectedException=None)
 
-        print('Test checkpoint job that is not a leaf vertex due to the presence of a service')
+        logger.info('Test checkpoint job that is not a leaf vertex due to the presence of a service')
         self.runCheckpointVertexTest(*createWorkflowFn(),
                                      checkpointJobService=TrivialService("LeafTestService"),
                                      expectedException=JobGraphDeadlockException)
 
-        print('Test checkpoint job that is not a leaf vertex due to the presence of a child job')
+        logger.info('Test checkpoint job that is not a leaf vertex due to the presence of a child job')
         self.runCheckpointVertexTest(*createWorkflowFn(),
                                      checkpointJobChild=Job.wrapJobFn(
                                          simpleJobFn, "LeafTestChild"),
                                      expectedException=JobGraphDeadlockException)
 
-        print('Test checkpoint job that is not a leaf vertex due to the presence of a follow-on job')
+        logger.info('Test checkpoint job that is not a leaf vertex due to the presence of a follow-on job')
         self.runCheckpointVertexTest(*createWorkflowFn(),
                                      checkpointJobFollowOn=Job.wrapJobFn(
                                          simpleJobFn,
@@ -358,7 +365,7 @@ class JobTest(ToilTest):
                 Job.Runner.startToil(workflowRootJob, options)
                 self.fail("The expected exception was not thrown")
             except expectedException as ex:
-                print("The expected exception was thrown: ", repr(ex))
+                logger.info("The expected exception was thrown: %s", repr(ex))
 
     def testEvaluatingRandomDAG(self):
         """


### PR DESCRIPTION
Fix verification that new checkpoint jobs are leaf vertices (resolves #1465, resolves #1466)

Changed to 1) correctly identify a leaf vertex and 2) to include checking of the workflow root job.

Note: This pull request is also listing a merge-related commit from updating my fork.
However, this merge-related commit did not contribute any of the changes displayed for this pull request. I reviewed the changes shown for this pull request, and they are a correct and complete set for the two fix-related commits that are intended for this pull request.
I think I know why that happened and I will avoid including extraneous commits in future pull requests.