### PR TITLE
Fix image url (resolves #1488)

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
         <section>
             <div class="row">
                 <div class="half-box">
-                    <img src="/static/gi-logo.png" alt="UCSC Genomics Institute logo">
+                    <img src="static/gi-logo.png" alt="UCSC Genomics Institute logo">
                 </div>
                 <div class="half-box">
                     <p>


### PR DESCRIPTION
Fixes the static url for the genomics institute link.