### PR TITLE
Remove disallowed character from role name (resolves #1458)

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -608,7 +608,7 @@ class AWSProvisioner(AbstractProvisioner):
     def _getProfileARN(cls, ctx):
         def addRoleErrors(e):
             return e.status == 404
-        roleName = '-toil'
+        roleName = 'toil'
         policy = dict(iam_full=iamFullPolicy, ec2_full=ec2FullPolicy,
                       s3_full=s3FullPolicy, sbd_full=sdbFullPolicy)
         iamRoleName = ctx.setup_iam_ec2_role(role_name=roleName, policies=policy)


### PR DESCRIPTION
Changes role name in AWS Provisioner to 'toil' instead of '-toil'.