### PR TITLE
Strict hostkey checking by default in cluster utils (fixes #1373)

### DIFF
--- a/src/toil/provisioners/__init__.py
+++ b/src/toil/provisioners/__init__.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def awsRemainingBillingInterval(instance):
     """
     Takes a node object and determines how far into it's billing cycle it is.
-    
+
     :param instance:
     :return:
     """
@@ -70,21 +70,22 @@ class Cluster(object):
         else:
             assert False, "Invalid provisioner '%s'" % provisioner
 
-    def sshCluster(self, args):
-        self.provisioner.sshLeader(self.clusterName, args, self.zone)
+    def sshCluster(self, args, **kwargs):
+        self.provisioner.sshLeader(self.clusterName, args, self.zone, **kwargs)
 
-    def rsyncCluster(self, args):
-        self.provisioner.rsyncLeader(self.clusterName, args, self.zone)
+    def rsyncCluster(self, args, **kwargs):
+        self.provisioner.rsyncLeader(self.clusterName, args, self.zone, **kwargs)
         ctx = self.provisioner._buildContext(self.clusterName, zone=self.zone)
         instances = self.provisioner._getNodesInCluster(ctx, self.clusterName, both=True)
         leader = self.provisioner._getLeader(self.clusterName, zone=self.zone)
         workers = [i for i in instances if i.public_dns_name != leader.public_dns_name]
         for instance in workers:
             self.provisioner._waitForNode(instance, 'toil_worker')
-            self.provisioner._rsyncNode(instance.public_dns_name, args, applianceName='toil_worker')
+            self.provisioner._rsyncNode(instance.public_dns_name, args, applianceName='toil_worker', **kwargs)
 
     def destroyCluster(self):
         self.provisioner.destroyCluster(self.clusterName, self.zone)
+
 
 class Node(object):
 

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -146,7 +146,7 @@ class AbstractProvisioner(object):
 
     @classmethod
     @abstractmethod
-    def rsyncLeader(cls, clusterName, args):
+    def rsyncLeader(cls, clusterName, args, **kwargs):
         """
         Rsyncs to the leader of the cluster with the specified name. The arguments are passed directly to
         Rsync.
@@ -154,6 +154,7 @@ class AbstractProvisioner(object):
         :param clusterName: name of the cluster to target
         :param args: list of string arguments to rsync. Identical to the normal arguments to rsync, but the
            host name of the remote host can be omitted. ex) ['/localfile', ':/remotedest']
+        :param strict: If False, strict host key checking is disabled. (Enabled by default.)
         """
         raise NotImplementedError
 
@@ -173,11 +174,12 @@ class AbstractProvisioner(object):
 
     @classmethod
     @abstractmethod
-    def sshLeader(cls, clusterName, args):
+    def sshLeader(cls, clusterName, args, **kwargs):
         """
-        SSH into the leader instnace of the specified cluster with the specified arguments to SSH.
+        SSH into the leader instance of the specified cluster with the specified arguments to SSH.
         :param clusterName: name of the cluster to target
         :param args: list of string arguments to ssh.
+        :param strict: If False, strict host key checking is disabled. (Enabled by default.)
         """
         raise NotImplementedError
 

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -154,7 +154,11 @@ class AbstractProvisioner(object):
         :param clusterName: name of the cluster to target
         :param args: list of string arguments to rsync. Identical to the normal arguments to rsync, but the
            host name of the remote host can be omitted. ex) ['/localfile', ':/remotedest']
-        :param strict: If False, strict host key checking is disabled. (Enabled by default.)
+        :param \**kwargs:
+           See below
+
+        :Keyword Arguments:
+            * *strict*: if False, strict host key checking is disabled. (Enabled by default.)
         """
         raise NotImplementedError
 

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -38,12 +38,12 @@ log = logging.getLogger(__name__)
 class AbstractAWSAutoscaleTest(ToilTest):
 
     def sshUtil(self, command):
-        baseCommand = ['toil', 'ssh-cluster', '-p=aws', self.clusterName]
+        baseCommand = ['toil', 'ssh-cluster', '--insecure', '-p=aws', self.clusterName]
         callCommand = baseCommand + command
         subprocess.check_call(callCommand)
 
     def rsyncUtil(self, src, dest):
-        baseCommand = ['toil', 'rsync-cluster', '-p=aws', self.clusterName]
+        baseCommand = ['toil', 'rsync-cluster', '--insecure', '-p=aws', self.clusterName]
         callCommand = baseCommand + [src, dest]
         subprocess.check_call(callCommand)
 

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -94,7 +94,7 @@ class UtilsTest(ToilTest):
             system([self.toilMain, 'destroy-cluster', '--provisioner=aws', clusterName])
         try:
             from toil.provisioners.aws.awsProvisioner import AWSProvisioner
-            
+
             userTags = {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}
             tags = {'Name': clusterName, 'Owner': keyName}
             tags.update(userTags)
@@ -103,11 +103,24 @@ class UtilsTest(ToilTest):
             system([self.toilMain, 'launch-cluster', '-t', 'key1=value1', '-t', 'key2=value2', '--tag', 'key3=value3',
                     '--nodeType=m3.medium:0.2', '--keyPairName=' + keyName, clusterName,
                     '--provisioner=aws', '--logLevel=DEBUG'])
-            system([self.toilMain, 'ssh-cluster', '--provisioner=aws', clusterName])
 
             # test leader tags
             leaderTags = AWSProvisioner._getLeader(clusterName).tags
             self.assertEqual(tags, leaderTags)
+
+            # Test strict host key checking
+            try:
+                AWSProvisioner.sshLeader(clusterName=clusterName, strict=True)
+            except RuntimeError:
+                pass
+            else:
+                self.fail("Host key verification passed where it should have failed")
+
+            # Add the host key to known_hosts so that the rest of the tests can
+            # pass without choking on the verification prompt.
+            AWSProvisioner.sshLeader(clusterName=clusterName, strict=True, sshOptions=['-oStrictHostKeyChecking=no'])
+
+            system([self.toilMain, 'ssh-cluster', '--provisioner=aws', clusterName])
 
             testStrings = ["'foo'",
                            '"foo"',
@@ -142,7 +155,7 @@ class UtilsTest(ToilTest):
             # `toil rsync-cluster`
             # Testing special characters - string.punctuation
             fname = '!"#$%&\'()*+,-.;<=>:\ ?@[\\\\]^_`{|}~'
-            testData = os.urandom(3*(10**6))
+            testData = os.urandom(3 * (10**6))
             with tempfile.NamedTemporaryFile(suffix=fname) as tmpFile:
                 relpath = os.path.basename(tmpFile.name)
                 tmpFile.write(testData)

--- a/src/toil/utils/toilRsyncCluster.py
+++ b/src/toil/utils/toilRsyncCluster.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 def main():
     parser = getBasicOptionParser()
     parser = addBasicProvisionerOptions(parser)
+    parser.add_argument("--insecure", dest='insecure', action='store_true', required=False,
+                        help="Temporarily disable strict host key checking.")
     parser.add_argument("args", nargs=argparse.REMAINDER, help="Arguments to pass to"
                         "`rsync`. Takes any arguments that rsync accepts. Specify the"
                         " remote with a colon. For example, to upload `example.py`,"
@@ -37,4 +39,4 @@ def main():
     config = parseBasicOptions(parser)
     setLoggingFromOptions(config)
     cluster = Cluster(provisioner=config.provisioner, clusterName=config.clusterName, zone=config.zone)
-    cluster.rsyncCluster(args=config.args)
+    cluster.rsyncCluster(args=config.args, strict=not config.insecure)

--- a/src/toil/utils/toilSSHCluster.py
+++ b/src/toil/utils/toilSSHCluster.py
@@ -20,15 +20,17 @@ from toil.provisioners import Cluster
 from toil.lib.bioio import parseBasicOptions, setLoggingFromOptions, getBasicOptionParser
 from toil.utils import addBasicProvisionerOptions
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
 
 
 def main():
     parser = getBasicOptionParser()
     parser = addBasicProvisionerOptions(parser)
+    parser.add_argument("--insecure", dest='insecure', action='store_true', required=False,
+                        help="Temporarily disable strict host key checking.")
     parser.add_argument('args', nargs=argparse.REMAINDER)
     config = parseBasicOptions(parser)
     setLoggingFromOptions(config)
     cluster = Cluster(provisioner=config.provisioner,
                       clusterName=config.clusterName, zone=config.zone)
-    cluster.sshCluster(args=config.args)
+    cluster.sshCluster(args=config.args, strict=not config.insecure)


### PR DESCRIPTION
* Automated functions (i.e. spinning up a cluster) will skip host key checking
* `ssh-cluster` and `rsync-cluster` will not skip host key checking by default and will prompt the user when encountering a new host. This can by temporarily overridden by the user by passing the `--insecure` flag. (See also: #1505)