### PR TITLE
Prevent hanging due to cPickle serialization 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ check_docker_registry:
 check_cpickle:
 	# fail if cPickle.dump(s) called without HIGHEST_PROTOCOL
 	# https://github.com/BD2KGenomics/toil/issues/1503
-	! grep -R 'cPickle.dump' * | grep --invert-match HIGHEST_PROTOCOL
+	! grep -R 'cPickle.dump' *.py | grep --invert-match HIGHEST_PROTOCOL
 
 .PHONY: help \
 		prepare \

--- a/Makefile
+++ b/Makefile
@@ -246,9 +246,14 @@ check_docker_registry:
 	$(default_docker_registry) and ensure that you have permissions to push \
 	to that registry. Only CI builds should push to $(default_docker_registry).$(normal)\n' ; false )
 
+check_cpickle:
+	# fail if cPickle.dump(s) called without HIGHEST_PROTOCOL
+	# https://github.com/BD2KGenomics/toil/issues/1503
+	! grep -R 'cPickle.dump' * | grep --invert-match HIGHEST_PROTOCOL
 
 .PHONY: help \
 		prepare \
+		check_cpickle \
 		develop clean_develop \
 		sdist clean_sdist \
 		test \

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -666,7 +666,7 @@ class Toil(object):
             with self._jobStore.writeSharedFileStream('rootJobReturnValue') as fH:
                 rootJob.prepareForPromiseRegistration(self._jobStore)
                 promise = rootJob.rv()
-                cPickle.dump(promise, fH)
+                cPickle.dump(promise, fH, protocol=cPickle.HIGHEST_PROTOCOL)
 
             # Setup the first wrapper and cache it
             rootJobGraph = rootJob._serialiseFirstJob(self._jobStore)

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -1115,7 +1115,7 @@ class Job(JobLikeObject):
             #service = serviceJob.service
 
             # Pickle the job
-            serviceJob.pickledService = cPickle.dumps(serviceJob.service)
+            serviceJob.pickledService = cPickle.dumps(serviceJob.service, protocol=cPickle.HIGHEST_PROTOCOL)
             serviceJob.service = None
 
             # Serialise the service job and job wrapper

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -1353,7 +1353,7 @@ class AWSJob(JobGraph, SDBHelper):
         :rtype: (str,dict)
         :return: a str for the item's name and a dictionary for the item's attributes
         """
-        return self.jobStoreID, self.binaryToAttributes(cPickle.dumps(self))
+        return self.jobStoreID, self.binaryToAttributes(cPickle.dumps(self, protocol=cPickle.HIGHEST_PROTOCOL))
 
 
 class BucketLocationConflictException(Exception):

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -783,7 +783,7 @@ class AzureJob(JobGraph):
         """
         assert chunkSize <= maxAzureTablePropertySize
         item = {}
-        serializedAndEncodedJob = bz2.compress(cPickle.dumps(self))
+        serializedAndEncodedJob = bz2.compress(cPickle.dumps(self, protocol=cPickle.HIGHEST_PROTOCOL))
         jobChunks = [serializedAndEncodedJob[i:i + chunkSize]
                      for i in range(0, len(serializedAndEncodedJob), chunkSize)]
         for attributeOrder, chunk in enumerate(jobChunks):

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -118,7 +118,7 @@ class GoogleJobStore(AbstractJobStore):
                        command=jobNode.command, remainingRetryCount=self._defaultTryCount(),
                        logJobStoreFileID=None, predecessorNumber=jobNode.predecessorNumber,
                        **jobNode._requirements)
-        self._writeString(jobStoreID, cPickle.dumps(job))
+        self._writeString(jobStoreID, cPickle.dumps(job, protocol=cPickle.HIGHEST_PROTOCOL))
         return job
 
     def exists(self, jobStoreID):
@@ -148,7 +148,7 @@ class GoogleJobStore(AbstractJobStore):
         return cPickle.loads(jobString)
 
     def update(self, job):
-        self._writeString(job.jobStoreID, cPickle.dumps(job), update=True)
+        self._writeString(job.jobStoreID, cPickle.dumps(job, protocol=cPickle.HIGHEST_PROTOCOL), update=True)
 
     def delete(self, jobStoreID):
         # jobs will always be encrypted when avaliable


### PR DESCRIPTION
Resolves #1503

Skipping the automatically triggered CI test since this PR will add a new CI target. The first build with this target should fail after detecting the current usages of cPickle without HIGHEST_PROTOCOL, and the second commit I add will fix those usages.
