### PR TITLE
AWS autoscaling: arbitrary VPCs

### DIFF
--- a/src/toil/provisioners/aws/__init__.py
+++ b/src/toil/provisioners/aws/__init__.py
@@ -42,7 +42,12 @@ def _getCurrentAWSZone(spotBid=None, nodeType=None, ctx=None):
         pass
     else:
         zone = os.environ.get('TOIL_AWS_ZONE', None)
-        if spotBid:
+        if not zone and runningOnEC2():
+            try:
+                zone = get_instance_metadata()['placement']['availability-zone']
+            except KeyError:
+                pass
+        if not zone and spotBid:
             # if spot bid is present, all the other parameters must be as well
             assert bool(spotBid) == bool(nodeType) == bool(ctx)
             # if the zone is unset and we are using the spot market, optimize our
@@ -52,11 +57,6 @@ def _getCurrentAWSZone(spotBid=None, nodeType=None, ctx=None):
             zone = boto.config.get('Boto', 'ec2_region_name')
             if zone is not None:
                 zone += 'a'  # derive an availability zone in the region
-        if not zone and runningOnEC2():
-            try:
-                zone = get_instance_metadata()['placement']['availability-zone']
-            except KeyError:
-                pass
     return zone
 
 
@@ -113,10 +113,13 @@ def choose_spot_zone(zones, bid, spot_history):
     for zone in zones:
         zone_histories = filter(lambda zone_history:
                                 zone_history.availability_zone == zone.name, spot_history)
-        price_deviation = std_dev([history.price for history in zone_histories])
-        recent_price = zone_histories[0]
+        if zone_histories:
+            price_deviation = std_dev([history.price for history in zone_histories])
+            recent_price = zone_histories[0].price
+        else:
+            price_deviation, recent_price = 0.0, bid
         zone_tuple = ZoneTuple(name=zone.name, price_deviation=price_deviation)
-        (markets_over_bid, markets_under_bid)[recent_price.price < bid].append(zone_tuple)
+        (markets_over_bid, markets_under_bid)[recent_price < bid].append(zone_tuple)
 
     return min(markets_under_bid or markets_over_bid,
                key=attrgetter('price_deviation')).name
@@ -127,7 +130,8 @@ def optimize_spot_bid(ctx, instance_type, spot_bid):
     Check whether the bid is sane and makes an effort to place the instance in a sensible zone.
     """
     spot_history = _get_spot_history(ctx, instance_type)
-    _check_spot_bid(spot_bid, spot_history)
+    if spot_history:
+        _check_spot_bid(spot_bid, spot_history)
     zones = ctx.ec2.get_all_zones()
     most_stable_zone = choose_spot_zone(zones, spot_bid, spot_history)
     logger.info("Placing spot instances in zone %s.", most_stable_zone)

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -49,6 +49,9 @@ def main():
                              "      \"Name\": clusterName,"
                              "      \"Owner\": IAM username"
                              " }. ")
+    parser.add_argument("--vpcSubnet",
+                        help="VPC subnet ID to launch cluster in. Uses default subnet if not specified."
+                        "This subnet needs to have auto assign IPs turned on.")
     config = parseBasicOptions(parser)
     setLoggingFromOptions(config)
     tagsDict = None if config.tags is None else createTagsDict(config.tags)
@@ -70,4 +73,5 @@ def main():
         assert False
 
     provisioner.launchCluster(instanceType=config.nodeType, clusterName=config.clusterName,
-                              keyName=config.keyPairName, spotBid=spotBid, userTags=tagsDict, zone=config.zone)
+                              keyName=config.keyPairName, spotBid=spotBid, userTags=tagsDict, zone=config.zone,
+                              vpcSubnet=config.vpcSubnet)


### PR DESCRIPTION
CJ -- this follows up on our discussion in #1470 around using accounts with non-default VPCs. It's back compatible with the previous approach but provides a new option so a user can specify a VPC to launch in, then all other steps happen within that VPC. With this in place I can spin up and start running autoscaling CWL jobs, then get blocked by a bug in cwltool which is also fixed here. Thanks much for the help getting this in.

- Allow specifying a VPC subnet when launching a cluster. The previous
  code assumed use of a default VPC which is not true for all AWS
  accounts.
- VPC subnet passed to all node creation scripts so everything occurs
  in same configured VPC.
- Using specific VPCs in boto requires sending security groups by ID
  instead of name (https://github.com/boto/boto/issues/350).
- Retrieve cluster name from instance tags instead of security groups
  (fixes #1508)
- Place spot instances in current VPC availability zone.
- Handle spot instances where we can't find pricing history for
  an instance type.
- Use public_dns_name instead of ip_address for ssh. This allows
  tweaking AWS ssh options in `~/.ssh/config` via `Host *.amazonaws.com`
- Update cwltool to latest stable tested version, fixing issue
  with schema-salad in current Toil Docker images.