### PR TITLE
CWL: update to latest cwltool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ def runSetup():
                 'gcs_oauth2_boto_plugin==1.9',
                 botoRequirement],
             'cwl': [
-                'cwltool==1.0.20161221171240']},
+                'cwltool==1.0.20170217172322',
+                'cwltest>=1.0.20170214185319']},
         package_dir={'': 'src'},
         packages=find_packages(where='src',
                                # Note that we intentionally include the top-level `test` package for

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -21,6 +21,7 @@ from toil.version import baseVersion
 from toil.lib.bioio import setLoggingFromOptions
 
 from argparse import ArgumentParser
+import cwltool.errors
 import cwltool.load_tool
 import cwltool.main
 import cwltool.workflow
@@ -278,16 +279,18 @@ class CWLJob(Job):
         opts = copy.deepcopy(self.executor_options)
         # Exports temporary directory for batch systems that reset TMPDIR
         os.environ["TMPDIR"] = os.path.realpath(opts.pop("tmpdir", None) or tmpdir)
-        output = cwltool.main.single_job_executor(self.cwltool, cwljob,
-                                                  basedir=os.getcwd(),
-                                                  outdir=outdir,
-                                                  tmpdir=tmpdir,
-                                                  tmpdir_prefix="tmp",
-                                                  **opts)
-        cwltool.builder.adjustDirObjs(output, locToPath)
-        cwltool.builder.adjustFileObjs(output, locToPath)
-        cwltool.builder.adjustFileObjs(output, functools.partial(computeFileChecksums,
-                                                                 cwltool.stdfsaccess.StdFsAccess(outdir)))
+        (output, status) = cwltool.main.single_job_executor(self.cwltool, cwljob,
+                                                            basedir=os.getcwd(),
+                                                            outdir=outdir,
+                                                            tmpdir=tmpdir,
+                                                            tmpdir_prefix="tmp",
+                                                            **opts)
+        if status != "success":
+            raise cwltool.errors.WorkflowException(status)
+        cwltool.pathmapper.adjustDirObjs(output, locToPath)
+        cwltool.pathmapper.adjustFileObjs(output, locToPath)
+        cwltool.pathmapper.adjustFileObjs(output, functools.partial(computeFileChecksums,
+                                                                    cwltool.stdfsaccess.StdFsAccess(outdir)))
         # Copy output files into the global file store.
         adjustFiles(output, functools.partial(writeFile, fileStore.writeGlobalFile, {}))
 
@@ -666,14 +669,14 @@ def main(args=None, stdout=sys.stdout):
         job = {}
 
     try:
-        cwltool.builder.adjustDirObjs(job, unsupportedInputCheck)
-        cwltool.builder.adjustFileObjs(job, unsupportedInputCheck)
+        cwltool.pathmapper.adjustDirObjs(job, unsupportedInputCheck)
+        cwltool.pathmapper.adjustFileObjs(job, unsupportedInputCheck)
     except cwltool.process.UnsupportedRequirement as e:
         logging.error(e)
         return 33
 
-    cwltool.builder.adjustDirObjs(job, pathToLoc)
-    cwltool.builder.adjustFileObjs(job, pathToLoc)
+    cwltool.pathmapper.adjustDirObjs(job, pathToLoc)
+    cwltool.pathmapper.adjustFileObjs(job, pathToLoc)
 
     if type(t) == int:
         return t
@@ -696,8 +699,8 @@ def main(args=None, stdout=sys.stdout):
 
     with Toil(options) as toil:
         def importDefault(tool):
-            cwltool.builder.adjustDirObjs(tool, locToPath)
-            cwltool.builder.adjustFileObjs(tool, locToPath)
+            cwltool.pathmapper.adjustDirObjs(tool, locToPath)
+            cwltool.pathmapper.adjustFileObjs(tool, locToPath)
             adjustFiles(tool, lambda x: "file://%s" % x if not urlparse.urlparse(x).scheme else x)
             adjustFiles(tool, functools.partial(writeFile, toil.importFile, {}))
         t.visit(importDefault)
@@ -715,13 +718,13 @@ def main(args=None, stdout=sys.stdout):
                 logging.error(e)
                 return 33
 
-            cwltool.builder.adjustDirObjs(builder.job, locToPath)
-            cwltool.builder.adjustFileObjs(builder.job, locToPath)
+            cwltool.pathmapper.adjustDirObjs(builder.job, locToPath)
+            cwltool.pathmapper.adjustFileObjs(builder.job, locToPath)
             adjustFiles(builder.job, lambda x: "file://%s" % os.path.abspath(os.path.join(basedir, x))
                         if not urlparse.urlparse(x).scheme else x)
-            cwltool.builder.adjustDirObjs(builder.job, pathToLoc)
-            cwltool.builder.adjustFileObjs(builder.job, pathToLoc)
-            cwltool.builder.adjustFileObjs(builder.job, addFilePartRefs)
+            cwltool.pathmapper.adjustDirObjs(builder.job, pathToLoc)
+            cwltool.pathmapper.adjustFileObjs(builder.job, pathToLoc)
+            cwltool.pathmapper.adjustFileObjs(builder.job, addFilePartRefs)
             adjustFiles(builder.job, functools.partial(writeFile, toil.importFile, {}))
             wf1.cwljob = builder.job
             outobj = toil.start(wf1)


### PR DESCRIPTION
Updates cwltool and schema-salad to help with debugging fixes for CWL
runs on AWS.

- Handles new status return tuple from single_job_executor
- Updates `adjust*Objs` import path from builder to pathmapper