### PR TITLE
AWS: increase default size of root volume

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ def runSetup():
                 botoRequirement],
             'cwl': [
                 'cwltool==1.0.20170217172322',
+                'schema-salad==2.2.20170216125639',
                 'cwltest>=1.0.20170214185319']},
         package_dir={'': 'src'},
         packages=find_packages(where='src',

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -594,6 +594,10 @@ class AWSProvisioner(AbstractProvisioner):
         # determine number of ephemeral drives via cgcloud-lib
         bdtKeys = ['', '/dev/xvdb', '/dev/xvdc', '/dev/xvdd']
         bdm = BlockDeviceMapping()
+        # Change root volume size to allow for bigger Docker instances
+        root_vol = BlockDeviceType()
+        root_vol.size = 50
+        bdm["/dev/xvda"] = root_vol
         # the first disk is already attached for us so start with 2nd.
         for disk in xrange(1, instanceType.disks + 1):
             bdm[bdtKeys[disk]] = BlockDeviceType(


### PR DESCRIPTION
CJ and all;
While testing bcbio CWL runs on AWS I'm running into the issue that bcbio Docker image is too big for the root volume size on CoreOS instances (8Gb). The failure log for this is below. This PR bumps it to 50Gb to allow for the Docker image + associated running data for a wider variety of pipelines.

Longer term it would be good if the launched nodes set this based on requested disk usage in the set of Job, which does get passed from CWL's ResourceRequirements. However I don't have enough expertise to implement that so this unblocks current attempts to test bcbio CWL runs on AWS.

```
---TOIL WORKER OUTPUT LOG---
c4382872-faad-41f4-b1ef-6045391331e0    INFO:toil:Running Toil version 3.7.0a1.dev353-00c18d033666227f86d798c6ce2f30d95f173a1e.
c4382872-faad-41f4-b1ef-6045391331e0    INFO:toil.fileStore:Starting job ('file:///home/run/test_bcbio_cwl-master/run_info-cwl-workflow/steps/prep_align_inputs.cwl' bcbio_nextgen.py runfn prep_align_inputs cwl c4382872-faad-41f4-b1ef-6045391331e0) with ID (e5ca5cd58580845cf6046cd0091b8adafdc348b8).
c4382872-faad-41f4-b1ef-6045391331e0    ['docker', 'pull', 'bcbio/bcbio']
c4382872-faad-41f4-b1ef-6045391331e0    INFO:cwltool:['docker', 'pull', 'bcbio/bcbio']
c4382872-faad-41f4-b1ef-6045391331e0    Using default tag: latest
c4382872-faad-41f4-b1ef-6045391331e0    latest: Pulling from bcbio/bcbio
c4382872-faad-41f4-b1ef-6045391331e0    8387d9ff0016: Pulling fs layer
c4382872-faad-41f4-b1ef-6045391331e0    3b52deaaf0ed: Pulling fs layer
c4382872-faad-41f4-b1ef-6045391331e0    4bd501fad6de: Pulling fs layer
c4382872-faad-41f4-b1ef-6045391331e0    a3ed95caeb02: Pulling fs layer
c4382872-faad-41f4-b1ef-6045391331e0    9537779ccc69: Pulling fs layer
c4382872-faad-41f4-b1ef-6045391331e0    a3ed95caeb02: Waiting
c4382872-faad-41f4-b1ef-6045391331e0    9537779ccc69: Waiting
c4382872-faad-41f4-b1ef-6045391331e0    4bd501fad6de: Verifying Checksum
c4382872-faad-41f4-b1ef-6045391331e0    4bd501fad6de: Download complete
c4382872-faad-41f4-b1ef-6045391331e0    3b52deaaf0ed: Verifying Checksum
c4382872-faad-41f4-b1ef-6045391331e0    3b52deaaf0ed: Download complete
c4382872-faad-41f4-b1ef-6045391331e0    a3ed95caeb02: Verifying Checksum
c4382872-faad-41f4-b1ef-6045391331e0    a3ed95caeb02: Download complete
c4382872-faad-41f4-b1ef-6045391331e0    8387d9ff0016: Verifying Checksum
c4382872-faad-41f4-b1ef-6045391331e0    8387d9ff0016: Download complete
c4382872-faad-41f4-b1ef-6045391331e0    8387d9ff0016: Pull complete
c4382872-faad-41f4-b1ef-6045391331e0    3b52deaaf0ed: Pull complete
c4382872-faad-41f4-b1ef-6045391331e0    4bd501fad6de: Pull complete
c4382872-faad-41f4-b1ef-6045391331e0    a3ed95caeb02: Pull complete
c4382872-faad-41f4-b1ef-6045391331e0    write /var/lib/docker/tmp/GetImageBlob751033652: no space left on device
```