### PR TITLE
ImportFile should return a FileID object

### DIFF
--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -344,6 +344,13 @@ class AbstractJobStore(object):
             otherCls._writeToUrl(readable, url)
 
     @abstractclassmethod
+    def getSize(cls, url):
+        """
+        returns the size of the file at the given URL
+        """
+        raise NotImplementedError
+
+    @abstractclassmethod
     def _readFromUrl(cls, url, writable):
         """
         Reads the contents of the object at the specified location and writes it to the given

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -968,6 +968,14 @@ class JobStoreSupport(AbstractJobStore):
         return url.scheme.lower() in ('http', 'https', 'ftp') and not export
 
     @classmethod
+    def getSize(cls, url):
+        for attempt in retry_http():
+            with attempt:
+                with closing(urlopen(url.geturl())) as readable:
+                    # just read the header for content length
+                    return readable.info().get('content-length')
+
+    @classmethod
     def _readFromUrl(cls, url, writable):
         for attempt in retry_http():
             with attempt:

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -303,7 +303,7 @@ class AbstractJobStore(object):
         if sharedFileName is None:
             with self.writeFileStream() as (writable, jobStoreFileID):
                 otherCls._readFromUrl(url, writable)
-                return FileID(uuid4(), otherCls.getSize(url))
+                return FileID(jobStoreFileID, otherCls.getSize(url))
         else:
             self._requireValidSharedFileName(sharedFileName)
             with self.writeSharedFileStream(sharedFileName) as writable:

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -28,7 +28,6 @@ import itertools
 # Python 3 compatibility imports
 from six.moves import xrange, cPickle, StringIO, reprlib
 from six import iteritems
-import six.moves.urllib.parse as urlparse
 
 from bd2k.util import strict_bool
 from bd2k.util.exceptions import panic
@@ -429,7 +428,6 @@ class AWSJobStore(AbstractJobStore):
 
     @classmethod
     def getSize(cls, url):
-        url = urlparse.urlparse(url)
         key = cls._getKeyForUrl(url, existing=True)
         try:
             return key.size

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -28,6 +28,7 @@ import itertools
 # Python 3 compatibility imports
 from six.moves import xrange, cPickle, StringIO, reprlib
 from six import iteritems
+import six.moves.urllib.parse as urlparse
 
 from bd2k.util import strict_bool
 from bd2k.util.exceptions import panic
@@ -425,6 +426,15 @@ class AWSJobStore(AbstractJobStore):
                 dstKey.bucket.connection.close()
         else:
             super(AWSJobStore, self)._exportFile(otherCls, jobStoreFileID, url)
+
+    @classmethod
+    def getSize(cls, url):
+        url = urlparse.urlparse(url)
+        key = cls._getKeyForUrl(url, existing=True)
+        try:
+            return key.size
+        finally:
+            key.bucket.connection.close()
 
     @classmethod
     def _readFromUrl(cls, url, writable):

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -29,6 +29,7 @@ from datetime import datetime, timedelta
 from six.moves import cPickle
 from six.moves.http_client import HTTPException
 from six.moves.configparser import RawConfigParser, NoOptionError
+import six.moves.urllib.parse as urlparse
 
 from azure.common import AzureMissingResourceHttpError, AzureException
 from azure.storage import SharedAccessPolicy, AccessPolicy
@@ -268,6 +269,13 @@ class AzureJobStore(AbstractJobStore):
         def service(self):
             return BlobService(account_name=self.account,
                                account_key=_fetchAzureAccountKey(self.account))
+
+    @classmethod
+    def getSize(cls, url):
+        url = urlparse.urlparse(url)
+        blob = cls._parseWasbUrl(url)
+        blobProps = blob.container.get_blob_properties()
+        return int(blobProps['Content-Length'])
 
     @classmethod
     def _readFromUrl(cls, url, writable):

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -29,7 +29,6 @@ from datetime import datetime, timedelta
 from six.moves import cPickle
 from six.moves.http_client import HTTPException
 from six.moves.configparser import RawConfigParser, NoOptionError
-import six.moves.urllib.parse as urlparse
 
 from azure.common import AzureMissingResourceHttpError, AzureException
 from azure.storage import SharedAccessPolicy, AccessPolicy
@@ -272,7 +271,6 @@ class AzureJobStore(AbstractJobStore):
 
     @classmethod
     def getSize(cls, url):
-        url = urlparse.urlparse(url)
         blob = cls._parseWasbUrl(url)
         blobProps = blob.container.get_blob_properties()
         return int(blobProps['Content-Length'])

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -272,8 +272,8 @@ class AzureJobStore(AbstractJobStore):
     @classmethod
     def getSize(cls, url):
         blob = cls._parseWasbUrl(url)
-        blobProps = blob.container.get_blob_properties()
-        return int(blobProps['Content-Length'])
+        blobProps = blob.service.get_blob_properties(blob.container, blob.name)
+        return int(blobProps['content-length'])
 
     @classmethod
     def _readFromUrl(cls, url, writable):

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -26,7 +26,6 @@ import errno
 
 # Python 3 compatibility imports
 from six.moves import xrange
-import six.moves.urllib.parse as urlparse
 
 from bd2k.util.exceptions import require
 
@@ -187,7 +186,6 @@ class FileJobStore(AbstractJobStore):
 
     @classmethod
     def getSize(cls, url):
-        url = urlparse.urlparse(url)
         return os.stat(cls._extractPathFromUrl(url)).st_size
 
     @classmethod

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -29,6 +29,7 @@ from six.moves import xrange
 
 from bd2k.util.exceptions import require
 
+from toil.fileStore import FileID
 from toil.lib.bioio import absSymPath
 from toil.jobStores.abstractJobStore import (AbstractJobStore,
                                              NoSuchJobException,
@@ -167,7 +168,7 @@ class FileJobStore(AbstractJobStore):
                 fd, absPath = self._getTempFile()
                 shutil.copyfile(self._extractPathFromUrl(url), absPath)
                 os.close(fd)
-                return self._getRelativePath(absPath)
+                return FileID(self._getRelativePath(absPath), os.stat(absPath).st_size)
             else:
                 self._requireValidSharedFileName(sharedFileName)
                 with self.writeSharedFileStream(sharedFileName) as writable:

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -26,6 +26,7 @@ import errno
 
 # Python 3 compatibility imports
 from six.moves import xrange
+import six.moves.urllib.parse as urlparse
 
 from bd2k.util.exceptions import require
 
@@ -183,6 +184,11 @@ class FileJobStore(AbstractJobStore):
             shutil.copyfile(self._getAbsPath(jobStoreFileID), self._extractPathFromUrl(url))
         else:
             super(FileJobStore, self)._exportFile(otherCls, jobStoreFileID, url)
+
+    @classmethod
+    def getSize(cls, url):
+        url = urlparse.urlparse(url)
+        return os.stat(cls._extractPathFromUrl(url)).st_size
 
     @classmethod
     def _readFromUrl(cls, url, writable):

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -10,6 +10,7 @@ import time
 
 # Python 3 compatibility imports
 from six.moves import cPickle, StringIO
+import six.moves.urllib.parse as urlparse
 
 from toil.jobStores.abstractJobStore import (AbstractJobStore, NoSuchJobException,
                                              NoSuchFileException,
@@ -247,6 +248,13 @@ class GoogleJobStore(AbstractJobStore):
         projectID = url.host
         bucketAndKey = url.path
         return projectID, 'gs://'+bucketAndKey
+
+    @classmethod
+    def getSize(cls, url):
+        url = urlparse.urlparse(url)
+        projectID, uri = GoogleJobStore._getResources(url)
+        uri = boto.storage_uri(uri, GOOGLE_STORAGE)
+        return uri.get_key().size
 
     @classmethod
     def _readFromUrl(cls, url, writable):

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -10,7 +10,6 @@ import time
 
 # Python 3 compatibility imports
 from six.moves import cPickle, StringIO
-import six.moves.urllib.parse as urlparse
 
 from toil.jobStores.abstractJobStore import (AbstractJobStore, NoSuchJobException,
                                              NoSuchFileException,
@@ -251,7 +250,6 @@ class GoogleJobStore(AbstractJobStore):
 
     @classmethod
     def getSize(cls, url):
-        url = urlparse.urlparse(url)
         projectID, uri = GoogleJobStore._getResources(url)
         uri = boto.storage_uri(uri, GOOGLE_STORAGE)
         return uri.get_key().size

--- a/src/toil/test/src/importExportFileTest.py
+++ b/src/toil/test/src/importExportFileTest.py
@@ -21,6 +21,7 @@ from toil.common import Toil
 from toil.job import Job
 from toil.leader import FailedJobsException
 from toil.test import ToilTest
+from toil.fileStore import FileID
 
 
 class ImportExportFileTest(ToilTest):
@@ -38,7 +39,7 @@ class ImportExportFileTest(ToilTest):
                     f.write('Hello')
                 inputFileID = toil.importFile('file://' + srcFile)
                 # Make sure that importFile returns the fileID wrapper
-                self.assertIsInstance(inputFileID, toil.fileStore.FileID)
+                self.assertIsInstance(inputFileID, FileID)
                 self.assertEqual(os.stat(srcFile).st_size, inputFileID.size)
 
                 # Write a boolean that determines whether the job fails.

--- a/src/toil/test/src/importExportFileTest.py
+++ b/src/toil/test/src/importExportFileTest.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 import uuid
+import os
 
 from toil.common import Toil
 from toil.job import Job
@@ -36,6 +37,9 @@ class ImportExportFileTest(ToilTest):
                 with open(srcFile, 'w') as f:
                     f.write('Hello')
                 inputFileID = toil.importFile('file://' + srcFile)
+                # Make sure that importFile returns the fileID wrapper
+                self.assertIsInstance(inputFileID, toil.fileStore.FileID)
+                self.assertEqual(os.stat(srcFile).st_size, inputFileID.size)
 
                 # Write a boolean that determines whether the job fails.
                 with toil._jobStore.writeFileStream() as (f, failFileID):


### PR DESCRIPTION
Currently jobStore.importFile returns a string which is inconsistent with other methods for uploading a file to the jobStore. This PR instead makes importFile return a FileID object.

This involved adding a getSize attribute to abstractJobStore which returns the file size (in bytes) from the specified URL. This is necessary because FileID has a size attribute.