### PR TITLE
Fix service deadlock detection (resolves #1509)

### DIFF
--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -141,7 +141,7 @@ class Leader:
         self.statsAndLogging = StatsAndLogging(self.jobStore, self.config)
 
         # Set used to monitor deadlocked jobs
-        self.potentialDeadlockedJobs = None
+        self.potentialDeadlockedJobs = set()
         self.potentialDeadlockTime = 0
 
         # internal jobs we should not expose at top level debugging
@@ -495,6 +495,7 @@ class Leader:
         if totalServicesIssued >= totalRunningJobs and len(self.toilState.updatedJobs) == 0 and totalRunningJobs > 0:
             serviceJobs = filter(lambda x : isinstance(x, ServiceJobNode), self.jobBatchSystemIDToIssuedJob.values())
             runningServiceJobs = set(filter(lambda x : self.serviceManager.isRunning(x), serviceJobs))
+            assert len(runningServiceJobs) <= totalRunningJobs
 
             # If all the running jobs are active services then we have a potential deadlock
             if len(runningServiceJobs) == totalRunningJobs:
@@ -506,11 +507,11 @@ class Leader:
                     raise DeadlockException("The system is service deadlocked - all %d running jobs are active services" % totalRunningJobs)
             else:
                 # We have observed non-service jobs running, so reset the potential deadlock
-                self.potentialDeadlockedJobs = []
+                self.potentialDeadlockedJobs = set()
                 self.potentialDeadlockTime = 0
         else:
             # We have observed non-service jobs running, so reset the potential deadlock
-            self.potentialDeadlockedJobs = []
+            self.potentialDeadlockedJobs = set()
             self.potentialDeadlockTime = 0
 
 

--- a/src/toil/serviceManager.py
+++ b/src/toil/serviceManager.py
@@ -125,10 +125,17 @@ class ServiceManager( object ):
             
     def isActive(self, serviceJobNode):
         """
-        Returns true is the service job has not been told to terminate.
+        Returns true if the service job has not been told to terminate.
         :rtype: boolean
         """
         return self.jobStore.fileExists(serviceJobNode.terminateJobStoreID)
+
+    def isRunning(self, serviceJobNode):
+        """
+        Returns true if the service job has started and is active
+        :rtype: boolean
+        """
+        return (not self.jobStore.fileExists(serviceJobNode.startJobStoreID)) and self.isActive(serviceJobNode)
 
     def check(self):
         """


### PR DESCRIPTION
The current service deadlock detection doesn't actually detect most (any?) deadlocks, because it works on the basis of issued jobs. Instead it just occasionally crashes the workflow when there aren't any deadlocks, because it doesn't reset when "potential deadlock" situations are gone. It also calls deadlocks when services are still starting up.

This patch:
- Works on the basis of *running*, not issued or starting, jobs
- Resets when deadlock situations are no longer detected

Stylistically, I'm not totally happy with the deep level of if conditions, and the duplicated code on the elses, but it does speed things up since it skips some expensive checks the majority of the time.

Unfortunately it's difficult to create a proper test for this. As a stopgap, here is a script that shows the wrong behavior on the old version and the correct behavior on the new version:

```
python deadlockExample.py jobStore --deadlockWait 60 --maxCores 1
```
This has a deadlock because there is one service job, and one core available. The new version detects the deadlock, and the old version doesn't.

```
python deadlockExample.py jobStore --deadlockWait 10 --maxCores 4
```
The old version incorrectly detects a deadlock, because the service takes longer than 10 seconds to start up. The new version finishes the workflow.

```python
#!/usr/bin/env python2.7
import time
from argparse import ArgumentParser

from toil.job import Job
from toil.common import Toil

class WaiterService(Job.Service):
    def __init__(self, startupTime, shutdownTime):
        super(WaiterService, self).__init__()
        self.startupTime = startupTime
        self.shutdownTime = shutdownTime

    def start(self, job):
        time.sleep(self.startupTime)

    def stop(self, job):
        time.sleep(self.shutdownTime)

    def check(self):
        return True

def start(job):
    job.addService(WaiterService(30, 35))
    job.addChildJobFn(next)

def next(job):
    time.sleep(10)
    job.addChildJobFn(next2)

def next2(job):
    time.sleep(10)

def main():
    parser = ArgumentParser()
    Job.Runner.addToilOptions(parser)
    opts = parser.parse_args()
    with Toil(opts) as toil:
        if opts.restart:
            toil.restart()
        else:
            toil.start(Job.wrapJobFn(start))

if __name__ == '__main__':
    main()
```