### PR TITLE
Terminate the job chain if preemptability status changes (resolves #1537)

### DIFF
--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -383,6 +383,9 @@ def main():
             if successorJobNode.disk > jobGraph.disk:
                 logger.debug("We need more disk for the next job, so finishing")
                 break
+            if successorJobNode.preemptable != jobGraph.preemptable:
+                logger.debug("Preemptability is different for the next job, returning to the leader")
+                break
             if successorJobNode.predecessorNumber > 1:
                 logger.debug("The jobGraph has multiple predecessors, we must return to the leader.")
                 break


### PR DESCRIPTION
Previously, a non-preemptable job could be run on a preemptable node if it was run in a chain from a preemptable predecessor.