### PR TITLE
Support shared temp directory in distributed system (resolves #1462)

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1150,12 +1150,17 @@ def getNodeID(nodeIDFile, nodeIDCommand):
 
     Assumes that at least one of its inputs is None
 
-    :param config: the config file used to start toil
-    :return: a unique string
+    :param str nodeIDFile: absolute path to a file with nodeID
+    :param str nodeIDCommand: a command to be run which returns the nodeID
+    :return: a unique strin
     :rtype: str
     """
     if nodeIDCommand is not None:
-        return subprocess.check_output(nodeIDCommand)
+        try:
+            output = subprocess.check_output(nodeIDCommand.split())
+        except subprocess.CalledProcessError as e:
+            logger.debug("NodeID command %s failed with output %s", e.cmd, e.output)
+            raise
     elif nodeIDFile is not None:
         with open(nodeIDFile) as f:
             return f.read()

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1152,7 +1152,7 @@ def getNodeID(nodeIDFile, nodeIDCommand):
 
     :param str nodeIDFile: absolute path to a file with nodeID
     :param str nodeIDCommand: a command to be run which returns the nodeID
-    :return: a unique strin
+    :return: a unique string
     :rtype: str
     """
     if nodeIDCommand is not None:

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -1282,7 +1282,7 @@ class CachingFileStore(FileStore):
         for jobID, state in nodeInfo.jobState.items():
             # Because this is a classmethod, the easiest way to get the nodeID it to keep the info
             # needed to generate it in the jobState and then generate the ID dynamically.
-            nodeID = getNodeID(**state['findID'])
+            nodeID = getNodeID(*state['findID'])
             # Only delete job if its PID is dead and if it's nodeID matches ours.
             if not cls._pidExists(state['pid']) and state['nodeID'] == nodeID:
                 jobState = CachingFileStore._JobState(nodeInfo.jobState[jobID])
@@ -1739,7 +1739,7 @@ class NonCachingFileStore(FileStore):
         for jobState in cls._getAllJobStates(nodeInfo):
             # Because this is a classmethod, the easiest way to get the nodeID it to keep the info
             # needed to generate it in the jobState and then generate the ID dynamically.
-            nodeID = getNodeID(**jobState['findID'])
+            nodeID = getNodeID(*jobState['findID'])
             # Only delete job if it PID doesn't exist and if it's nodeID matches ours.
             if not cls._pidExists(jobState['jobPID']) and jobState['nodeID'] == nodeID:
                 # using same logic to prevent races as CachingFileStore._setupCache


### PR DESCRIPTION
This PR adds two mutually exclusive command line options:
- `--nodeIDFile <file>`  and
- `--nodeIDCommand <command>`.

`--nodeIDFile` indicates a file that contains a unique nodeID while `--nodeIDCommand` indicates a commands that can be run on a node to consistently get a nodeID.

Giving a node an ID will force the node to check that any jobs it may delete are jobs that it had originally created. This becomes necessary when the temp/work directory is shared among nodes. If neither of these two options are specified, then Toil assumes that the temp directory is not shared and will delete any job that it is not currently running.