### PR TITLE
Fix incorrect memory usage and "wait" stats reporting (resolves #1541)

### DIFF
--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -171,12 +171,14 @@ def system(command):
     subprocess.check_call(command, shell=isinstance(command, string_types), bufsize=-1)
 
 def getTotalCpuTimeAndMemoryUsage():
-    """Gives the total cpu time and memory usage of itself and its children.
+    """
+    Gives the total cpu time of itself and all its children, and the maximum RSS memory usage of
+    itself and its single largest child.
     """
     me = resource.getrusage(resource.RUSAGE_SELF)
     childs = resource.getrusage(resource.RUSAGE_CHILDREN)
-    totalCPUTime = me.ru_utime+me.ru_stime+childs.ru_utime+childs.ru_stime
-    totalMemoryUsage = me.ru_maxrss+ me.ru_maxrss
+    totalCPUTime = me.ru_utime + me.ru_stime + childs.ru_utime + childs.ru_stime
+    totalMemoryUsage = me.ru_maxrss + childs.ru_maxrss
     return totalCPUTime, totalMemoryUsage
 
 def getTotalCpuTime():
@@ -185,7 +187,7 @@ def getTotalCpuTime():
     return getTotalCpuTimeAndMemoryUsage()[0]
 
 def getTotalMemoryUsage():
-    """Gets the amount of memory used by the process and its children.
+    """Gets the amount of memory used by the process and its largest child.
     """
     return getTotalCpuTimeAndMemoryUsage()[1]
 

--- a/src/toil/utils/toilStats.py
+++ b/src/toil/utils/toilStats.py
@@ -387,11 +387,10 @@ def reportPrettyData(root, worker, job, job_types, options):
     """
     out_str = "Batch System: %s\n" % root.batch_system
     out_str += ("Default Cores: %s  Default Memory: %s\n"
-                "Max Cores: %s  Max Threads: %s\n" % (
+                "Max Cores: %s\n" % (
         reportNumber(get(root, "default_cores"), options),
         reportMemory(get(root, "default_memory"), options, isBytes=True),
         reportNumber(get(root, "max_cores"), options),
-        reportNumber(get(root, "max_threads"), options),
         ))
     out_str += ("Total Clock: %s  Total Runtime: %s\n" % (
         reportTime(get(root, "total_clock"), options),
@@ -460,7 +459,7 @@ def buildElement(element, items, itemName):
 
     itemWaits=[]
     for index in range(0,len(itemTimes)):
-        itemWaits.append(itemClocks[index]-itemTimes[index])
+        itemWaits.append(itemTimes[index] - itemClocks[index])
 
     itemWaits.sort()
     itemTimes.sort()


### PR DESCRIPTION
The reported "wait" time (wall-clock time - CPU time) was also almost always negative, because it was calculating CPU time - wall-clock time instead.

NB: the memory usage is still not perfect, because the only data available for the children is the maximum size of the single largest child, not (as previously implied by the docstring) the entire process tree:
>    ru_maxrss (since Linux 2.6.32)
>          This is the maximum resident set size used (in kilobytes).  For RUSAGE_CHILDREN, this is the resident set size of the largest child, not the maximum resident set size of the process tree.

Unfortunately, it's significantly more difficult to portably get the maximum RSS for the entire process tree. We would probably need to spawn a monitoring thread if we wanted to be fully accurate. But this should be correct in the vast majority of cases (it will only be wrong if people spawn two or more children at the same time), and it's certainly an improvement over the old behavior.