### PR TITLE
Torque and workDir fixes (resolves #1462, #1628)

### DIFF
--- a/docs/batchSystem.rst
+++ b/docs/batchSystem.rst
@@ -16,9 +16,11 @@ For SLURM::
 
     export TOIL_SLURM_ARGS="-t 1:00:00 -q fatq"
 
-For TORQUE::
+For TORQUE there are two environment variables - one for everything but the resource
+requirements, and another - for resources requirements (without the `-l` prefix)::
 
-    export TOIL_TORQUE_ARGS="-l walltime=1:00:00 -q fatq"
+    export TOIL_TORQUE_ARGS="-q fatq"
+    export TOIL_TORQUE_REQS="walltime=1:00:00"
 
 For GridEngine (SGE, UGE), there is an additional environmental variable to define the
 `parallel environment <https://blogs.oracle.com/templedf/entry/configuring_a_new_parallel_environment>`_

--- a/docs/running/running.rst
+++ b/docs/running/running.rst
@@ -193,11 +193,6 @@ There are several environment variables that affect the way Toil runs.
 |                        | Instead, define resource requirements for the job. |
 |                        | There is no default value for this variable.       |
 +------------------------+----------------------------------------------------+
-| TOIL_TORQUE_ARGS       | Arguments for qsub for the torque batch system.    |
-|                        | Do not pass CPU or memory specifications here.     |
-|                        | Instead, define resource requirements for the job. |
-|                        | There is no default value for this variable.       |
-+------------------------+----------------------------------------------------+
 | TOIL_GRIDENGINE_ARGS   | Arguments for qsub for the gridengine batch        |
 |                        | system. Do not pass CPU or memory specifications   |
 |                        | here. Instead, define resource requirements for    |

--- a/docs/running/running.rst
+++ b/docs/running/running.rst
@@ -208,6 +208,22 @@ There are several environment variables that affect the way Toil runs.
 |                        | the gridengine batch system. There is no default   |
 |                        | value for this variable.                           |
 +------------------------+----------------------------------------------------+
+| TOIL_TORQUE_ARGS       | Arguments for qsub for the Torque batch system.    |
+|                        | Do not pass CPU or memory specifications here.     |
+|                        | Instead, define extra parameters for the job such  |
+|                        | as queue. Example: -q medium                       |
+|                        | Use TOIL_TORQUE_REQS to pass extra values for the  |
+|                        | -l resource requirements parameter.                |
+|                        | There is no default value for this variable.       |
++------------------------+----------------------------------------------------+
+| TOIL_TORQUE_REQS       | Arguments for the resource requirements for Torque |
+|                        | batch system. Do not pass CPU or memory            |
+|                        | specifications here. Instead, define extra resource| 
+|                        | requirements as a string that goes after the -l    |
+|                        | argument to qsub. Example:                         |
+|                        | walltime=2:00:00,file=50gb                         |
+|                        | There is no default value for this variable.       |
++------------------------+----------------------------------------------------+
 
 .. _standard temporary directory: https://docs.python.org/2/library/tempfile.html#tempfile.gettempdir
 

--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -20,6 +20,7 @@ import subprocess
 import time
 import math
 import sys
+import shlex
 import xml.etree.ElementTree as ET
 import tempfile
 
@@ -138,6 +139,15 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
             
             if reqline:
                 qsubline += ['-l',','.join(reqline)]
+            
+            # All other qsub parameters can be passed through the environment (see man qsub).
+            # No attempt is made to parse them out here and check that they do not conflict
+            # with those that we already constructed above
+            arglineEnv = os.getenv('TOIL_TORQUE_ARGS')
+            if arglineEnv is not None:
+                logger.debug("Additional Torque arguments appended to qsub from "\
+                        "TOIL_TORQUE_ARGS env. variable: {}".format(arglineEnv))
+                qsubline += shlex.split(arglineEnv)
 
             # "Native extensions" for TORQUE (see DRMAA or SAGA)
             nativeConfig = os.getenv('TOIL_TORQUE_ARGS')

--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -134,6 +134,8 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
             if reqlineEnv is not None:
                 logger.debug("Additional Torque resource requirements appended to qsub from "\
                         "TOIL_TORQUE_REQS env. variable: {}".format(reqlineEnv))
+                if ("mem=" in reqlineEnv) or ("nodes=" in reqlineEnv) or ("ppn=" in reqlineEnv):
+                    raise ValueError("Incompatible resource arguments ('mem=', 'nodes=', 'ppn='): {}".format(reqlineEnv))
 
                 reqline.append(reqlineEnv)
             
@@ -145,18 +147,12 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
             # with those that we already constructed above
             arglineEnv = os.getenv('TOIL_TORQUE_ARGS')
             if arglineEnv is not None:
-                logger.debug("Additional Torque arguments appended to qsub from "\
-                        "TOIL_TORQUE_ARGS env. variable: {}".format(arglineEnv))
+                logger.debug("Native Torque options appended to qsub from TOIL_TORQUE_ARGS env. variable: {}".\
+                        format(arglineEnv))
+                if ("mem=" in arglineEnv) or ("nodes=" in arglineEnv) or ("ppn=" in arglineEnv):
+                    raise ValueError("Incompatible resource arguments ('mem=', 'nodes=', 'ppn='): {}".format(arglineEnv))
                 qsubline += shlex.split(arglineEnv)
 
-            # "Native extensions" for TORQUE (see DRMAA or SAGA)
-            nativeConfig = os.getenv('TOIL_TORQUE_ARGS')
-            if nativeConfig is not None:
-                logger.debug("Native TORQUE options appended to qsub from TOIL_TORQUE_RESOURCES env. variable: {}".format(nativeConfig))
-                if ("mem=" in nativeConfig) or ("nodes=" in nativeConfig) or ("ppn=" in nativeConfig):
-                    raise ValueError("Incompatible resource arguments ('mem=', 'nodes=', 'ppn='): {}".format(nativeConfig))
-            qsubline.extend(nativeConfig.split())
-            
             return qsubline
 
         def generateTorqueWrapper(self, command):

--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -91,6 +91,8 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
                     logger.debug('Exit Status: ' + status)
                     return int(status)
                 if 'unknown job id' in line.lower():
+                    # some clusters configure Torque to forget everything about just
+                    # finished jobs instantly, apparently for performance reasons
                     logger.debug('Batch system no longer remembers about job {}'.format(torqueJobID))
                     # return assumed success; status files should reveal failure
                     return 0

--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -131,7 +131,8 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
             # Other resource requirements can be passed through the environment (see man qsub)
             reqlineEnv = os.getenv('TOIL_TORQUE_REQS')
             if reqlineEnv is not None:
-                logger.debug("Additional Torque resource requirements appended to qsub from TOIL_TORQUE_REQS env. variable: {}".format(reqlineEnv))
+                logger.debug("Additional Torque resource requirements appended to qsub from "\
+                        "TOIL_TORQUE_REQS env. variable: {}".format(reqlineEnv))
 
                 reqline.append(reqlineEnv)
             

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -568,9 +568,9 @@ def addOptions(parser, config=Config()):
         raise RuntimeError("Unanticipated class passed to addOptions(), %s. Expecting "
                            "argparse.ArgumentParser" % parser.__class__)
 
-
-    """Return unique ID of the current node (host).
 def getNodeID(extraIDFiles=None):
+    """
+    Return unique ID of the current node (host).
     Tries several methods until success. The returned ID should be identical across calls from different processes on 
     the same node at least until the next OS reboot.
 
@@ -581,7 +581,6 @@ def getNodeID(extraIDFiles=None):
 
     :param list extraIDFiles: Optional list of additional file names to try reading node ID before trying default 
     methods. ID should be a single word (no spaces) on the first line of the file.
-
     """
     if extraIDFiles is None:
         extraIDFiles = []
@@ -589,7 +588,7 @@ def getNodeID(extraIDFiles=None):
     for idSourceFile in idSourceFiles:
         if os.path.exists(idSourceFile):
             try:
-                with open(idSourceFile,"r") as inp:
+                with open(idSourceFile, "r") as inp:
                     nodeID = inp.readline().strip()
             except EnvironmentError:
                 logger.warning(("Exception when trying to read ID file {}. Will try next method to get node ID").\
@@ -600,18 +599,18 @@ def getNodeID(extraIDFiles=None):
                     break
                 else:
                     logger.warning(("Node ID {} from file {} contains spaces. Will try next method to get node ID").\
-                            format(nodeID,idSourceFile))
+                            format(nodeID, idSourceFile))
     else:
         nodeIDs = []
         for i_call in range(2):
             nodeID = str(uuid.getnode()).strip()
-            if len(nodeID.split())==1: 
+            if len(nodeID.split()) == 1:
                 nodeIDs.append(nodeID)
             else:
                 logger.warning("Node ID {} from uuid.getnode() contains spaces".format(nodeID))
         nodeID = ""
-        if (len(nodeIDs) == 2):
-            if (nodeIDs[0] == nodeIDs[1]):
+        if len(nodeIDs) == 2:
+            if nodeIDs[0] == nodeIDs[1]:
                 nodeID = nodeIDs[0]
             else:
                 logger.warning("Different node IDs {} received from repeated calls to uuid.getnode(). You should use "\

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -569,8 +569,8 @@ def addOptions(parser, config=Config()):
                            "argparse.ArgumentParser" % parser.__class__)
 
 
-def getNodeID(extraIDFiles=[]):
     """Return unique ID of the current node (host).
+def getNodeID(extraIDFiles=None):
     Tries several methods until success. The returned ID should be identical across calls from different processes on 
     the same node at least until the next OS reboot.
 
@@ -583,6 +583,8 @@ def getNodeID(extraIDFiles=[]):
     methods. ID should be a single word (no spaces) on the first line of the file.
 
     """
+    if extraIDFiles is None:
+        extraIDFiles = []
     idSourceFiles = extraIDFiles + ["/var/lib/dbus/machine-id", "/proc/sys/kernel/random/boot_id"]
     for idSourceFile in idSourceFiles:
         if os.path.exists(idSourceFile):

--- a/src/toil/test/src/nodeIDTest.py
+++ b/src/toil/test/src/nodeIDTest.py
@@ -27,7 +27,7 @@ class GetNodeIDTest(ToilTest):
     def testSkipNonExistingFile(self):
         import uuid, os
         no_file = "/etc/totally_non_existing_"+str(uuid.uuid4())
-        assert not os.path.exists(no_file), "Could not make up a missing file name"
+        self.assertFalse(os.path.exists(no_file), "Could not make up a missing file name")
         nodeID1 = getNodeID([no_file])
         nodeID2 = getNodeID()
         self.assertEquals(nodeID1,nodeID2)

--- a/src/toil/test/src/nodeIDTest.py
+++ b/src/toil/test/src/nodeIDTest.py
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from toil.common import getNodeID
+from toil.test import ToilTest
+
+class GetNodeIDTest(ToilTest):
+    def testIDStability(self):
+        prevNodeID = None
+        for i in range(10):
+            nodeID = getNodeID()
+            if i > 0:
+                self.assertEquals(nodeID,prevNodeID)
+            prevNodeID = nodeID
+
+    def testSkipNonExistingFile(self):
+        import uuid, os
+        no_file = "/etc/totally_non_existing_"+str(uuid.uuid4())
+        assert not os.path.exists(no_file), "Could not make up a missing file name"
+        nodeID1 = getNodeID([no_file])
+        nodeID2 = getNodeID()
+        self.assertEquals(nodeID1,nodeID2)
+


### PR DESCRIPTION
Proposing two sets of changes. These were caused by not being able to execute `toil-sort-example.py` from the Toil manual on our cluster.

Our cluster:

- runs Torque. The `qsub` job scripts need to use `/bin/sh` instead of `/bin/bash`, otherwise `-V` variables get zapped by BASH profiles sourced when a job starts. This is the same as [this](https://github.com/roryk/ipython-cluster-helper/commit/33c9eb1fdeb5816c87a5c0b685291673ac685cad)

- has a tiny `/tmp` file system on each node (2GB each), and no other local disks that we can use. This is a very common setup on the clusters. Because of that, we need to use a shared FS for all scratch work, including as a `--workDir` when running Toil. This results in workers on different nodes erasing each other's live job directories in a call to `fileStore.findAndHandleDeadJobs()`.

With the proposed changes, `toil-sort-example.py` runs under Torque with `--workDir` on a shared FS.

More details are in the commit messages.

Thanks,
Andrey
