### PR TITLE
Fix a few cluster scaler bugs (resolves #1583, #1584)

### DIFF
--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -373,17 +373,18 @@ class ScalerThread(ExceptionalThread):
                                 'non-preemptable ones.', compensationNodes, _preemptableNodeDeficit)
                     estimatedNodes += compensationNodes
 
-                fix_my_name = (0 if nodesToRunRecentJobs <= 0
+                jobsPerNode = (0 if nodesToRunRecentJobs <= 0
                                else len(recentJobShapes) / float(nodesToRunRecentJobs))
                 logger.info('Estimating that cluster needs %s %s of shape %s, from current '
                              'size of %s, given a queue size of %s, the number of jobs per node '
                              'estimated to be %s, an alpha parameter of %s and a run-time length correction of %s.',
                              estimatedNodes, self.nodeTypeString, self.nodeShape, 
-                             self.totalNodes, queueSize, fix_my_name,
+                             self.totalNodes, queueSize, jobsPerNode,
                              self.scaler.config.alphaPacking, runtimeCorrection)
 
                 # Use inertia parameter to stop small fluctuations
-                if estimatedNodes <= self.totalNodes * self.scaler.config.betaInertia <= estimatedNodes:
+                delta = self.totalNodes * max(0.0, self.scaler.config.betaInertia - 1.0)
+                if self.totalNodes - delta <= estimatedNodes <= self.totalNodes + delta:
                     logger.debug('Difference in new (%s) and previous estimates in number of '
                                  '%s (%s) required is within beta (%s), making no change.',
                                  estimatedNodes, self.nodeTypeString, self.totalNodes, self.scaler.config.betaInertia)

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -358,7 +358,7 @@ class ScalerThread(ExceptionalThread):
                     logger.warn("Historical avg. runtime (%s) is less than current avg. runtime (%s) and cluster"
                                 " is being well utilised (%s running jobs), increasing cluster requirement by: %s" % 
                                 (historicalAvgRuntime, currentAvgRuntime, numberOfRunningJobs, runtimeCorrection))
-                    estimatedNodes *= runtimeCorrection
+                    estimatedNodes = int(round(estimatedNodes * runtimeCorrection))
 
                 # If we're the non-preemptable scaler, we need to see if we have a deficit of
                 # preemptable nodes that we should compensate for.

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -347,8 +347,8 @@ class ScalerThread(ExceptionalThread):
                 numberOfRunningJobs, currentAvgRuntime  = self.scaler.leader.getNumberAndAvgRuntimeOfCurrentlyRunningJobs()
                 
                 # Average runtime of recently completed jobs
-                historicalAvgRuntime = sum(map(lambda jS : jS.wallTime, recentJobShapes))
-            
+                historicalAvgRuntime = sum(map(lambda jS : jS.wallTime, recentJobShapes))/len(recentJobShapes)
+
                 # Ratio of avg. runtime of currently running and completed jobs
                 runtimeCorrection = float(currentAvgRuntime)/historicalAvgRuntime if currentAvgRuntime > historicalAvgRuntime and numberOfRunningJobs >= estimatedNodes else 1.0
                 


### PR DESCRIPTION
Sorry for the delay in submitting this patch, I wanted to test this on a large run. It doesn't seem to cause any problems.

This also resolves the issue that was causing the faulty code path depending on "historical average runtime" to almost never trigger: the "average runtime" was actually just a sum of the runtime of all previous jobs, unnormalized by the number of previous jobs. So only when your current jobs have been running a truly exceptional amount of time would that path trigger.

The beta parameter is 1.2 by default. I've assumed that that's intended to mean "ignore wobbles in cluster sizes of less than 20% of the current cluster size", rather than 120%. So I subtract 1.0 from the beta parameter every time.