### PR TITLE
AWS autoscaling: limit distracting log messages

### DIFF
--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -321,7 +321,7 @@ class MesosBatchSystem(BatchSystemSupport,
                 assert preemptable is None, "Attribute 'preemptable' occurs more than once."
                 preemptable = strict_bool(attribute.text.value)
         if preemptable is None:
-            log.warn('Slave not marked as either preemptable or not. Assuming non-preemptable.')
+            log.debug('Slave not marked as either preemptable or not. Assuming non-preemptable.')
             preemptable = False
         for resource in offer.resources:
             if resource.name == "cpus":

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -369,18 +369,20 @@ class ScalerThread(ExceptionalThread):
                     # nodes is the product of the deficit (the number of preemptable nodes we did
                     # _not_ allocate) and configuration preference.
                     compensationNodes = int(round(_preemptableNodeDeficit * compensation))
-                    logger.info('Adding %d preemptable nodes to compensate for a deficit of %d '
-                                'non-preemptable ones.', compensationNodes, _preemptableNodeDeficit)
+                    if compensationNodes > 0:
+                        logger.info('Adding %d preemptable nodes to compensate for a deficit of %d '
+                                    'non-preemptable ones.', compensationNodes, _preemptableNodeDeficit)
                     estimatedNodes += compensationNodes
 
                 jobsPerNode = (0 if nodesToRunRecentJobs <= 0
                                else len(recentJobShapes) / float(nodesToRunRecentJobs))
-                logger.info('Estimating that cluster needs %s %s of shape %s, from current '
-                             'size of %s, given a queue size of %s, the number of jobs per node '
-                             'estimated to be %s, an alpha parameter of %s and a run-time length correction of %s.',
-                             estimatedNodes, self.nodeTypeString, self.nodeShape, 
-                             self.totalNodes, queueSize, jobsPerNode,
-                             self.scaler.config.alphaPacking, runtimeCorrection)
+                if estimatedNodes > 0:
+                    logger.info('Estimating that cluster needs %s %s of shape %s, from current '
+                                'size of %s, given a queue size of %s, the number of jobs per node '
+                                'estimated to be %s, an alpha parameter of %s and a run-time length correction of %s.',
+                                estimatedNodes, self.nodeTypeString, self.nodeShape, 
+                                self.totalNodes, queueSize, jobsPerNode,
+                                self.scaler.config.alphaPacking, runtimeCorrection)
 
                 # Use inertia parameter to stop small fluctuations
                 delta = self.totalNodes * max(0.0, self.scaler.config.betaInertia - 1.0)
@@ -392,8 +394,8 @@ class ScalerThread(ExceptionalThread):
 
                 # Bound number using the max and min node parameters
                 if estimatedNodes > self.maxNodes:
-                    logger.info('Limiting the estimated number of necessary %s (%s) to the '
-                                'configured maximum (%s).', self.nodeTypeString, estimatedNodes, self.maxNodes)
+                    logger.debug('Limiting the estimated number of necessary %s (%s) to the '
+                                 'configured maximum (%s).', self.nodeTypeString, estimatedNodes, self.maxNodes)
                     estimatedNodes = self.maxNodes
                 elif estimatedNodes < self.minNodes:
                     logger.info('Raising the estimated number of necessary %s (%s) to the '


### PR DESCRIPTION
Following run status on AWS can be difficult due to the presence of a
regularly generated identical status messages:
```
ip-10-0-0-66.ec2.internal 2017-02-14 17:55:35,221 preemptable-scaler INFO toil.provisioners.clusterScaler: Limiting the estimated number of necessary preemptable nodes (3) to the configured maximum (2).
ip-10-0-0-66.ec2.internal 2017-02-14 17:55:37,504 scaler INFO toil.provisioners.clusterScaler: Adding 0 preemptable nodes to compensate for a deficit of 0 non-preemptable ones.
ip-10-0-0-66.ec2.internal 2017-02-14 17:55:37,505 scaler INFO toil.provisioners.clusterScaler: Estimating that cluster needs 0 non-preemptable nodes of shape _Shape(wallTime=3600, memory=8589934592, cores=2, disk=0), from current size of 0, given a queue size of 0, the number of jobs per node estimated to be 1.0, an alpha parameter of 0.8 and a run-time length correction of 1.0.
WARNING toil.batchSystems.mesos.batchSystem: Slave not marked as either preemptable or not. Assuming non-preemptable.
```
This reduces these to debug messages or limits them to generation when
a status actually changes.