### PR TITLE
Retry Docker errors when possible

### DIFF
--- a/src/toil/lib/__init__.py
+++ b/src/toil/lib/__init__.py
@@ -12,3 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import
+
+import os
+import subprocess
+from pwd import getpwuid
+
+FORGO = 0
+STOP = 1
+RM = 2
+
+
+def ownerName(filename):
+    """
+    Determines a given file's owner
+    :param str filename: path to a file
+    :return: name of filename's owner
+    """
+    return getpwuid(os.stat(filename).st_uid).pw_name
+
+
+def _dockerPredicate(e):
+    """
+    Used to ensure Docker exceptions are retried if appropriate
+
+    :param e: Exception
+    :return: True if e retriable, else False
+    """
+    if not isinstance(e, subprocess.CalledProcessError):
+        return False
+    if e.returncode == 125:
+        return True

--- a/src/toil/lib/__init__.py
+++ b/src/toil/lib/__init__.py
@@ -13,22 +13,11 @@
 # limitations under the License.
 from __future__ import absolute_import
 
-import os
 import subprocess
-from pwd import getpwuid
 
 FORGO = 0
 STOP = 1
 RM = 2
-
-
-def ownerName(filename):
-    """
-    Determines a given file's owner
-    :param str filename: path to a file
-    :return: name of filename's owner
-    """
-    return getpwuid(os.stat(filename).st_uid).pw_name
 
 
 def dockerPredicate(e):

--- a/src/toil/lib/__init__.py
+++ b/src/toil/lib/__init__.py
@@ -31,7 +31,7 @@ def ownerName(filename):
     return getpwuid(os.stat(filename).st_uid).pw_name
 
 
-def _dockerPredicate(e):
+def dockerPredicate(e):
     """
     Used to ensure Docker exceptions are retried if appropriate
 

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -173,7 +173,7 @@ def _docker(job,
     else:
         callMethod = subprocess.check_call
 
-    for attempt in retry(predicate=_dockerPredicate):
+    for attempt in retry(predicate=dockerPredicate):
         with attempt:
             out = callMethod(call, **params)
 
@@ -203,7 +203,7 @@ def _dockerKill(containerName, action):
                          containerName)
             if running and action >= STOP:
                 _logger.info('Stopping container "%s".', containerName)
-                for attempt in retry(predicate=_dockerPredicate):
+                for attempt in retry(predicate=dockerPredicate):
                     with attempt:
                         subprocess.check_call(['docker', 'stop', containerName])
             else:
@@ -214,7 +214,7 @@ def _dockerKill(containerName, action):
                 running = _containerIsRunning(containerName)
                 if running is not None:
                     _logger.info('Removing container "%s".', containerName)
-                    for attempt in retry(predicate=_dockerPredicate):
+                    for attempt in retry(predicate=dockerPredicate):
                         with attempt:
                             subprocess.check_call(['docker', 'rm', '-f', containerName])
                 else:
@@ -244,7 +244,7 @@ def _fixPermissions(tool, workDir):
                       '-v', os.path.abspath(workDir) + ':/data', '--rm', '--entrypoint=chown']
     stat = os.stat(workDir)
     command = baseDockerCall + [tool] + ['-R', '{}:{}'.format(stat.st_uid, stat.st_gid), '/data']
-    for attempt in retry(predicate=_dockerPredicate):
+    for attempt in retry(predicate=dockerPredicate):
         with attempt:
             subprocess.check_call(command)
 
@@ -262,7 +262,7 @@ def _containerIsRunning(container_name):
     :rtype: bool
     """
     try:
-        for attempt in retry(predicate=_dockerPredicate):
+        for attempt in retry(predicate=dockerPredicate):
             with attempt:
                 output = subprocess.check_output(['docker', 'inspect', '--format', '{{.State.Running}}',
                                                   container_name]).strip()

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -14,6 +14,7 @@
 """
 import base64
 import logging
+import os
 import pipes
 import uuid
 
@@ -231,13 +232,8 @@ def _fixPermissions(tool, workDir):
     :param str tool: Name of tool
     :param str workDir: Path of work directory to recursively chown
     """
-    testFileName = str(uuid.uuid4())
-    with open(testFileName):
-        pass
-    owner = ownerName(testFileName)
-    os.unlink(testFileName)
-    if owner == "root":
-        # We are running as root, so this chown is redundant
+    if os.geteuid() == 0:
+        # we're running as root so this chown is redundant
         return
 
     baseDockerCall = ['docker', 'run', '--log-driver=none',

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -5,10 +5,11 @@ import uuid
 from threading import Thread
 
 import os
+from pwd import getpwuid
 from bd2k.util.files import mkdir_p
 from toil.job import Job
 from toil.leader import FailedJobsException
-from toil.lib.docker import dockerCall, dockerCheckOutput, _containerIsRunning, _dockerKill, STOP, FORGO, RM, ownerName
+from toil.lib.docker import dockerCall, dockerCheckOutput, _containerIsRunning, _dockerKill, STOP, FORGO, RM
 from toil.test import ToilTest
 
 _log = logging.getLogger(__name__)
@@ -182,3 +183,10 @@ def _testDockerPermissions(job):
     assert not ownerName(outFile) == "root"
 
 
+def ownerName(filename):
+    """
+    Determines a given file's owner
+    :param str filename: path to a file
+    :return: name of filename's owner
+    """
+    return getpwuid(os.stat(filename).st_uid).pw_name

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -2,14 +2,13 @@ import logging
 import signal
 import time
 import uuid
-from pwd import getpwuid
 from threading import Thread
 
 import os
 from bd2k.util.files import mkdir_p
 from toil.job import Job
 from toil.leader import FailedJobsException
-from toil.lib.docker import dockerCall, dockerCheckOutput, _containerIsRunning, _dockerKill, STOP, FORGO, RM
+from toil.lib.docker import dockerCall, dockerCheckOutput, _containerIsRunning, _dockerKill, STOP, FORGO, RM, ownerName
 from toil.test import ToilTest
 
 _log = logging.getLogger(__name__)
@@ -176,13 +175,10 @@ def _testDockerPipeChainFn(job):
 
 
 def _testDockerPermissions(job):
-    def ownerName(filename):
-        return getpwuid(os.stat(filename).st_uid).pw_name
-
     testDir = job.fileStore.getLocalTempDir()
     dockerCall(job, tool='ubuntu', workDir=testDir, parameters=[['touch', '/data/test.txt']])
     outFile = os.path.join(testDir, 'test.txt')
     assert os.path.exists(outFile)
-    assert not "root" == ownerName(outFile)
+    assert not ownerName(outFile) == "root"
 
 


### PR DESCRIPTION
Resolves #1578 
Some of these retries, like docker kill, may be unnecessary. Also includes a short-circuit for _fixPermissions so it isn't fully executed if running as root. 