### PR TITLE
Fix issues with large stats files (fixes #1594, #1595)

### DIFF
--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -604,7 +604,13 @@ class AbstractJobStore(object):
 
         # Remove any crufty stats/logging files from the previous run
         logger.info("Discarding old statistics and logs...")
-        self.readStatsAndLogging(lambda x: None)
+        # We have to manually discard the stream to avoid getting
+        # stuck on a blocking write from the job store.
+        def discardStream(stream):
+            """Read the stream 4K at a time until EOF, discarding all input."""
+            while len(stream.read(4096)) != 0:
+                pass
+        self.readStatsAndLogging(discardStream)
 
         logger.info("Job store is clean")
         # TODO: reloading of the rootJob may be redundant here

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -724,11 +724,11 @@ class Leader:
                     # more memory efficient than read().striplines() while leaving off the
                     # trailing \n left when using readlines()
                     # http://stackoverflow.com/a/15233739
-                    messages = [line.rstrip('\n') for line in logFileStream]
-                    logFormat = '\n%s    ' % jobStoreID
-                    logger.warn('The job seems to have left a log file, indicating failure: %s\n%s',
-                                jobGraph, logFormat.join(messages))
-                    StatsAndLogging.writeLogFiles(jobGraph.chainedJobs, messages, self.config)
+                    StatsAndLogging.logWithFormatting(jobStoreID, logFileStream, method=logger.warn,
+                                                      message='The job seems to have left a log file, indicating failure: %s' % jobGraph)
+                if self.config.writeLogs or self.config.writeLogsGzip:
+                    with jobGraph.getLogFileHandle(self.jobStore) as logFileStream:
+                        StatsAndLogging.writeLogFiles(jobGraph.chainedJobs, logFileStream, self.config)
             if resultStatus != 0:
                 # If the batch system returned a non-zero exit code then the worker
                 # is assumed not to have captured the failure of the job, so we

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -74,7 +74,9 @@ class AWSProvisioner(AbstractProvisioner):
         zone = getCurrentAWSZone()
         region = Context.availability_zone_re.match(zone).group(1)
         conn = boto.ec2.connect_to_region(region)
-        return conn.get_all_instances(instance_ids=[md["instance-id"]])[0].instances[0]
+        for attempt in retry(predicate=AWSProvisioner.throttlePredicate):
+            with attempt:
+                return conn.get_all_instances(instance_ids=[md["instance-id"]])[0].instances[0]
 
     @staticmethod
     def retryPredicate(e):

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -48,7 +48,7 @@ class StatsAndLogging( object ):
         if message is not None:
             method(message)
         for line in jobLogs:
-            method('%s    %s', jobStoreID, line)
+            method('%s    %s', jobStoreID, line.rstrip('\n'))
 
     @classmethod
     def writeLogFiles(cls, jobNames, jobLogList, config):

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -112,9 +112,10 @@ class StatsAndLogging( object ):
                 pass
             else:
                 def logWithFormatting(jobStoreID, jobLogs):
-                    logFormat = '\n%s    ' % jobStoreID
                     logger.debug('Received Toil worker log. Disable debug level '
-                                 'logging to hide this output\n%s', logFormat.join(jobLogs))
+                                 'logging to hide this output')
+                    for line in jobLogs:
+                        logger.debug('%s    %s', jobStoreID, line)
                 # we may have multiple jobs per worker
                 jobNames = logs.names
                 messages = logs.messages

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -26,6 +26,7 @@ from toil.lib.bioio import getTotalCpuTime
 
 logger = logging.getLogger( __name__ )
 
+
 class StatsAndLogging( object ):
     """
     Class manages a thread that aggregates statistics and logging information on a toil run.
@@ -41,6 +42,13 @@ class StatsAndLogging( object ):
         Start the stats and logging thread.
         """
         self._worker.start()
+
+    @classmethod
+    def logWithFormatting(cls, jobStoreID, jobLogs, method=logger.debug, message=None):
+        if message is not None:
+            method(message)
+        for line in jobLogs:
+            method('%s    %s', jobStoreID, line)
 
     @classmethod
     def writeLogFiles(cls, jobNames, jobLogList, config):
@@ -111,15 +119,11 @@ class StatsAndLogging( object ):
             except AttributeError:
                 pass
             else:
-                def logWithFormatting(jobStoreID, jobLogs):
-                    logger.debug('Received Toil worker log. Disable debug level '
-                                 'logging to hide this output')
-                    for line in jobLogs:
-                        logger.debug('%s    %s', jobStoreID, line)
                 # we may have multiple jobs per worker
                 jobNames = logs.names
                 messages = logs.messages
-                logWithFormatting(jobNames[0], messages)
+                cls.logWithFormatting(jobNames[0], messages,
+                                      message='Received Toil worker log. Disable debug level logging to hide this output')
                 cls.writeLogFiles(jobNames, messages, config=config)
 
         while True:


### PR DESCRIPTION
This seems to work OK: the workflow that previously deadlocked has restarted fine with these changes.

There is one visible change in the logs: the `---TOIL WORKER OUTPUT LOG---` line is prefixed by the job name now. Not sure if that was intentionally left unprefixed or not.