### PR TITLE
Globalize user module in Job.__init__ (fixes #1593)

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -285,7 +285,7 @@ class Job(JobLikeObject):
         # Note that self.__module__ is not necessarily this module, i.e. job.py. It is the module
         # defining the class self is an instance of, which may be a subclass of Job that may be
         # defined in a different module.
-        self.userModule = ModuleDescriptor.forModule(self.__module__)
+        self.userModule = ModuleDescriptor.forModule(self.__module__).globalize()
         # Maps index paths into composite return values to lists of IDs of files containing
         # promised values for those return value items. An index path is a tuple of indices that
         # traverses a nested data structure of lists, dicts, tuples or any other type supporting


### PR DESCRIPTION
This globalizes the module descriptor during Job creation, rather than only during serializing successors. This doesn't crash anything, and seems to fix the problem as far as I can tell.

I've left the globalize() call in while serializing successors: https://github.com/BD2KGenomics/toil/blob/bfb63c9c85ae311945d61be2e1fa6e7717f05522/src/toil/job.py#L1069 because I'm a bit worried that taking it out might break restarting a workflow created previous to this commit. globalize() is idempotent so it won't matter that it's run twice (it's already run twice for function-jobs and services).