### PR TITLE
Return an integer rather than string size for HTTP imports

### DIFF
--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -973,7 +973,7 @@ class JobStoreSupport(AbstractJobStore):
             with attempt:
                 with closing(urlopen(url.geturl())) as readable:
                     # just read the header for content length
-                    return readable.info().get('content-length')
+                    return int(readable.info().get('content-length'))
 
     @classmethod
     def _readFromUrl(cls, url, writable):

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -969,6 +969,8 @@ class JobStoreSupport(AbstractJobStore):
 
     @classmethod
     def getSize(cls, url):
+        if url.scheme.lower() == 'ftp':
+            return None
         for attempt in retry_http():
             with attempt:
                 with closing(urlopen(url.geturl())) as readable:


### PR DESCRIPTION
Didn't create an issue for this. Hopefully that's OK for such a trivial change. Somewhat related to #1453.