### PR TITLE
Fix dead link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@ Contribution Guidelines
 
 Before proposing a pull request, please read our [Contributor's Guide][1].
 
-  [1]: https://toil.readthedocs.io/en/latest/contributing/pull-requests.html "Toil Contributor's Guide"
+  [1]: https://toil.readthedocs.io/en/latest/contributing/contributing.html#contributing "Toil Contributor's Guide"


### PR DESCRIPTION
I think some restructuring of the docs broke this link.