### PR TITLE
Remove "refresh" thread and just set S3 user script ACL to public-read (resolves #1600, #1516)

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -874,33 +874,6 @@ class Toil(object):
             userScriptResource = userScript.saveAsResourceTo(self._jobStore)
             logger.debug('Injecting user script %s into batch system.', userScriptResource)
             self._batchSystem.setUserScript(userScriptResource)
-            thread = Thread(target=self._refreshUserScript,
-                            name='refreshUserScript',
-                            kwargs=dict(userScriptResource=userScriptResource))
-            thread.daemon = True
-            thread.start()
-
-    def _refreshUserScript(self, userScriptResource):
-        """
-        Periodically refresh the user script in the job store to prevent credential
-        expiration from causing the public URL to the user script to expire.
-        """
-        while True:
-            # Boto refreshes IAM credentials if they will be expiring within the next five
-            # minutes, but it will only check the expiry if and when credentials are needed to
-            # sign an actual AWS request. This means that we should be refreshing the user script
-            # at least every 5 minutes. Note that refreshing the user script in the job store
-            # involves an S3 request requiring credentials and therefore also triggers refreshing
-            # the IAM role credentials. In the worst case, refresh() is called 5 minutes plus
-            # epsilon before IAM credential expiration. The resource is refreshed three minutes
-            # after that, leaving two minutes plus epsilon generating a new signed URL, this time
-            # with refreshed IAM role credentials. This consideration only applies to AWS and
-            # Boto2, of course. See https://github.com/BD2KGenomics/toil/issues/1372.
-            time.sleep(3 * 60)
-            logger.debug('Refreshing user script resource %s.', userScriptResource)
-            userScriptResource = userScriptResource.refresh(self._jobStore)
-            logger.debug('Injecting refreshed user script %s into batch system.', userScriptResource)
-            self._batchSystem.setUserScript(userScriptResource)
 
     def importFile(self, srcUrl, sharedFileName=None):
         self._assertContextManagerUsed()

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -24,6 +24,8 @@ import uuid
 import base64
 import hashlib
 import itertools
+import urlparse
+import urllib
 
 # Python 3 compatibility imports
 from six.moves import xrange, cPickle, StringIO, reprlib
@@ -32,15 +34,9 @@ from six import iteritems
 from bd2k.util import strict_bool
 from bd2k.util.exceptions import panic
 from bd2k.util.objects import InnerClass
-from boto.sdb.domain import Domain
-from boto.s3.bucket import Bucket
-from boto.s3.connection import S3Connection
-from boto.sdb.connection import SDBConnection
-from boto.sdb.item import Item
 import boto.s3
 import boto.sdb
 from boto.exception import S3CreateError
-from boto.s3.key import Key
 from boto.exception import SDBResponseError, S3ResponseError
 from concurrent.futures import ThreadPoolExecutor
 
@@ -621,7 +617,20 @@ class AWSJobStore(AbstractJobStore):
         for attempt in retry_s3():
             with attempt:
                 key = self.filesBucket.get_key(key_name=jobStoreFileID, version_id=info.version)
-                return key.generate_url(expires_in=self.publicUrlExpiration.total_seconds())
+                key.set_canned_acl('public-read')
+                url = key.generate_url(query_auth=False,
+                                       expires_in=self.publicUrlExpiration.total_seconds())
+                # boto doesn't properly remove the x-amz-security-token parameter when
+                # query_auth is False when using an IAM role (see issue #2043). Including the
+                # x-amz-security-token parameter without the access key results in a 403,
+                # even if the resource is public, so we need to remove it.
+                scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
+                params = urlparse.parse_qs(query)
+                if 'x-amz-security-token' in params:
+                    del params['x-amz-security-token']
+                query = urllib.urlencode(params, doseq=True)
+                url = urlparse.urlunsplit((scheme, netloc, path, query, fragment))
+                return url
 
     def getSharedPublicUrl(self, sharedFileName):
         assert self._validateSharedFileName(sharedFileName)


### PR DESCRIPTION
Just throwing this out there, not really 100% sure that this is the best solution.

The refresh thread isn't really guaranteed to be scheduled within its 2 minute window, especially given the number of other threads that are running in the leader process. This would remove the refresh thread entirely, and set the ACL of the user script object to `public-read` instead. Unfortunately I can't seem to get a straight answer on the consistency of the PUT object?acl operation. It seems to take effect right away, but I'm not totally sure.