### PR TITLE
Logging: avoid repetitive messages at maxNodes

### DIFF
--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -355,10 +355,11 @@ class ScalerThread(ExceptionalThread):
                 # Make correction, if necessary (only do so if cluster is busy and average runtime is higher than historical
                 # average)
                 if runtimeCorrection != 1.0:
-                    logger.warn("Historical avg. runtime (%s) is less than current avg. runtime (%s) and cluster"
-                                " is being well utilised (%s running jobs), increasing cluster requirement by: %s" % 
-                                (historicalAvgRuntime, currentAvgRuntime, numberOfRunningJobs, runtimeCorrection))
                     estimatedNodes = int(round(estimatedNodes * runtimeCorrection))
+                    if self.totalNodes < self.maxNodes:
+                        logger.warn("Historical avg. runtime (%s) is less than current avg. runtime (%s) and cluster"
+                                    " is being well utilised (%s running jobs), increasing cluster requirement by: %s" % 
+                                    (historicalAvgRuntime, currentAvgRuntime, numberOfRunningJobs, runtimeCorrection))
 
                 # If we're the non-preemptable scaler, we need to see if we have a deficit of
                 # preemptable nodes that we should compensate for.
@@ -376,11 +377,11 @@ class ScalerThread(ExceptionalThread):
 
                 jobsPerNode = (0 if nodesToRunRecentJobs <= 0
                                else len(recentJobShapes) / float(nodesToRunRecentJobs))
-                if estimatedNodes > 0:
+                if estimatedNodes > 0 and self.totalNodes < self.maxNodes:
                     logger.info('Estimating that cluster needs %s %s of shape %s, from current '
                                 'size of %s, given a queue size of %s, the number of jobs per node '
                                 'estimated to be %s, an alpha parameter of %s and a run-time length correction of %s.',
-                                estimatedNodes, self.nodeTypeString, self.nodeShape, 
+                                estimatedNodes, self.nodeTypeString, self.nodeShape,
                                 self.totalNodes, queueSize, jobsPerNode,
                                 self.scaler.config.alphaPacking, runtimeCorrection)
 


### PR DESCRIPTION
Avoids repetitive messages about increasing number of nodes when an
autoscaling cluster hits maximum node usage:
```
ip-10-0-0-38.ec2.internal 2017-04-08 20:18:48,925 preemptable-scaler INFO toil.provisioners.clusterScaler: Estimating that cluster needs 2 preemptable nodes of shape _Shape(wallTime=3600, memory=68719476736, cores=16, disk=0), from curren
t size of 2, given a queue size of 2, the number of jobs per node estimated to be 1.0, an alpha parameter of 0.8 and a run-time length correction of 1.0.
ip-10-0-0-80.ec2.internal 2017-04-09 19:55:12,620 scaler WARNING toil.provisioners.clusterScaler: Historical avg. runtime (3600) is less than current avg. runtime (4518.77800202) and cluster is being well utilised (2 running jobs), increasing cluster requirement by: 1.25521611167
```