### PR TITLE
Launch workers alongside leader with toil launch-cluster (resolves #1383)

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -32,8 +32,10 @@ test_suites = {
         'CachingFileStoreTestWithGoogleJobStore',
         None],
     'integration-test': [
-        'AWSAutoscaleTest',
-        'UtilsTest and testAWSProvisionerUtils'
+        'AWSRestartTest',
+        'PremptableDeficitCompensationTest',
+        'UtilsTest and testAWSProvisionerUtils',
+        'AWSAutoscaleTest'
     ]}
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,8 @@ test_suites = {
         'CachingFileStoreTestWithGoogleJobStore',
         None],
     'integration-test': [
-        'AWSAutoscaleTest'
+        'AWSAutoscaleTest',
+        'UtilsTest and testAWSProvisionerUtils'
     ]}
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,9 +32,6 @@ test_suites = {
         'CachingFileStoreTestWithGoogleJobStore',
         None],
     'integration-test': [
-        'AWSRestartTest',
-        'PremptableDeficitCompensationTest',
-        'UtilsTest and testAWSProvisionerUtils',
         'AWSAutoscaleTest'
     ]}
 

--- a/src/toil/provisioners/__init__.py
+++ b/src/toil/provisioners/__init__.py
@@ -69,6 +69,12 @@ class Cluster(object):
 
     def rsyncCluster(self, args):
         self.provisioner.rsyncLeader(self.clusterName, args, self.zone)
+        ctx = self.provisioner._buildContext(self.clusterName, zone=self.zone)
+        instances = self.provisioner._getNodesInCluster(ctx, self.clusterName, both=True)
+        leader = self.provisioner._getLeader(self.clusterName, zone=self.zone)
+        workers = [i for i in instances if i.public_dns_name != leader.public_dns_name]
+        for instance in workers:
+            self.provisioner._rsyncNode(instance.public_dns_name, args, applianceName='toil_worker')
 
     def destroyCluster(self):
         self.provisioner.destroyCluster(self.clusterName, self.zone)

--- a/src/toil/provisioners/__init__.py
+++ b/src/toil/provisioners/__init__.py
@@ -74,6 +74,7 @@ class Cluster(object):
         leader = self.provisioner._getLeader(self.clusterName, zone=self.zone)
         workers = [i for i in instances if i.public_dns_name != leader.public_dns_name]
         for instance in workers:
+            self.provisioner._waitForNode(instance, 'toil_worker')
             self.provisioner._rsyncNode(instance.public_dns_name, args, applianceName='toil_worker')
 
     def destroyCluster(self):

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -67,6 +67,7 @@ class AbstractProvisioner(object):
         self.statsThreads = []
         self.statsPath = config.clusterStats if config else None
         self.scaleable = isinstance(self.batchSystem, AbstractScalableBatchSystem) if batchSystem else False
+        self.staticNodesDict = {}  # dict with keys of nodes private IPs, val is nodeInfo
 
 
     @staticmethod
@@ -152,6 +153,15 @@ class AbstractProvisioner(object):
                 self.stats[threadName] = stats
         else:
             pass
+
+    def setStaticNodesDict(self, nodes):
+        """
+        this is a very hacky way to ignore the nodes that were spun up before the scalar
+        started. This should probably be reworked in the near future.
+
+        :param nodes:
+        """
+        self.staticNodesDict = nodes
 
     def setNodeCount(self, numNodes, preemptable=False, force=False):
         """

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -169,7 +169,7 @@ class AbstractProvisioner(object):
                of nodes. For example, when downsizing a cluster, a provisioner might leave nodes
                running if they have active jobs running on them.
 
-        :rtype: int :return: the number of nodes in the cluster after making the necessary
+        :rtype: int :return: the number of worker nodes in the cluster after making the necessary
                 adjustments. This value should be, but is not guaranteed to be, close or equal to
                 the `numNodes` argument. It represents the closest possible approximation of the
                 actual cluster size at the time this method returns.

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -86,8 +86,12 @@ class AbstractProvisioner(object):
             self._shutDownStats()
         log.debug('Forcing provisioner to reduce cluster size to zero.')
         totalNodes = self.setNodeCount(numNodes=0, preemptable=preemptable, force=True)
-        if totalNodes != len(self.staticNodesDict):  # ignore static nodes
-            raise RuntimeError('Provisioner was not able to reduce cluster size to zero.')
+        if totalNodes > len(self.staticNodesDict):  # ignore static nodes
+            raise RuntimeError('Provisioner could not terminate all autoscaled nodes. There are '
+                               '%s nodes left in the cluster, %s of which were statically provisioned' % (totalNodes, len(self.staticNodesDict))
+                               )
+        elif totalNodes < len(self.staticNodesDict):  # ignore static nodes
+            raise RuntimeError('Provisioner incorrectly terminated statically provisioned nodes.')
 
     def _shutDownStats(self):
         def getFileName():

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -86,7 +86,7 @@ class AbstractProvisioner(object):
             self._shutDownStats()
         log.debug('Forcing provisioner to reduce cluster size to zero.')
         totalNodes = self.setNodeCount(numNodes=0, preemptable=preemptable, force=True)
-        if totalNodes != 0:
+        if totalNodes != len(self.staticNodesDict):  # ignore static nodes
             raise RuntimeError('Provisioner was not able to reduce cluster size to zero.')
 
     def _shutDownStats(self):
@@ -218,6 +218,10 @@ class AbstractProvisioner(object):
             # nodes for yet. We'll ignore those, too, unless forced.
             nodesToTerminate = []
             for instance, nodeInfo in nodes:
+                if instance.private_ip_address in self.staticNodesDict:
+                    # we don't want to automatically terminate any statically
+                    # provisioned nodes
+                    continue
                 if force:
                     nodesToTerminate.append((instance, nodeInfo))
                 elif nodeInfo is not None and nodeInfo.workers < 1:

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -51,14 +51,23 @@ class AbstractProvisioner(object):
 
     __metaclass__ = ABCMeta
 
-    def __init__(self, config, batchSystem):
+
+    def __init__(self, config=None, batchSystem=None):
+        """
+        Initialize provisioner. If config and batchSystem are not specified, the
+        provisioner is being used to manage nodes without a workflow
+
+        :param config: Config from common.py
+        :param batchSystem: The batchSystem used during run
+        """
         self.config = config
         self.batchSystem = batchSystem
         self.stop = False
         self.stats = {}
         self.statsThreads = []
-        self.statsPath = config.clusterStats
-        self.scaleable = isinstance(self.batchSystem, AbstractScalableBatchSystem)
+        self.statsPath = config.clusterStats if config else None
+        self.scaleable = isinstance(self.batchSystem, AbstractScalableBatchSystem) if batchSystem else False
+
 
     @staticmethod
     def retryPredicate(e):

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -419,6 +419,7 @@ class AWSProvisioner(AbstractProvisioner):
 
         # if we running launch cluster we need to save this data as it won't be generated
         # from the metadata. This data is needed to launch worker nodes.
+        self.ctx = ctx
         self.leaderIP = leader.ip_address
         self._addTags([leader], defaultTags)
         self.clusterName = clusterName

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -674,10 +674,11 @@ class AWSProvisioner(AbstractProvisioner):
 
     def _getWorkersInCluster(self, preemptable):
         entireCluster = self._getNodesInCluster(ctx=self.ctx, clusterName=self.clusterName, both=True)
-        logger.debug('All nodes in cluster %s', entireCluster)
-        workerInstances = [i for i in entireCluster if i.private_ip_address != self.leaderIP and
-                           preemptable != (i.spot_instance_request_id is None)]
-        logger.debug('Workers found in cluster %s', workerInstances)
+        logger.debug('All nodes in cluster: %s', entireCluster)
+        workerInstances = [i for i in entireCluster if i.private_ip_address != self.leaderIP]
+        logger.debug('All workers found in cluster: %s', workerInstances)
+        workerInstances = [i for i in workerInstances if preemptable != (i.spot_instance_request_id is None)]
+        logger.debug('%spreemptable workers found in cluster: %s', 'non-' if not preemptable else '', workerInstances)
         workerInstances = awsFilterImpairedNodes(workerInstances, self.ctx.ec2)
         return workerInstances
 

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -505,7 +505,7 @@ class AWSProvisioner(AbstractProvisioner):
         cls._terminateIDs(instanceIDs, ctx)
         logger.info('... Waiting for instance(s) to shut down...')
         for instance in instances:
-            wait_transition(instance, {'running', 'shutting-down'}, 'terminated')
+            wait_transition(instance, {'pending', 'running', 'shutting-down'}, 'terminated')
         logger.info('Instance(s) terminated.')
 
     @classmethod

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -452,7 +452,7 @@ class AWSProvisioner(AbstractProvisioner):
         if workers:
             # assuming that if the leader was launched without a spotbid then all workers
             # will be non-preemptable
-            workersCreated = self.setNodeCount(workers, preemptable=spotBid)
+            workersCreated = self.setNodeCount(workers, preemptable=bool(spotBid))
             logger.info('Added %d workers with %d workers requested', workersCreated, workers)
 
         return leader

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -432,8 +432,8 @@ class AWSProvisioner(AbstractProvisioner):
         if workers:
             # assuming that if the leader was launched without a spotbid then all workers
             # will be non-preemptable
-            # adding 1 to workers because setNodeCount is including leader (is this intended?)
-            workersCreated = self.setNodeCount(workers + 1, preemptable=spotBid)
+            # adding (and subtracting) 1 because setNodeCount is including leader (is this intended?)
+            workersCreated = self.setNodeCount(workers + 1, preemptable=spotBid) - 1
             logger.info('Added %d workers with %d workers requested', workersCreated, workers)
 
         return leader

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -675,8 +675,10 @@ class AWSProvisioner(AbstractProvisioner):
     def _getWorkersInCluster(self, preemptable):
         entireCluster = self._getNodesInCluster(ctx=self.ctx, clusterName=self.clusterName, both=True)
         logger.debug('All nodes in cluster %s', entireCluster)
-        workerInstances = [i for i in entireCluster if i.private_ip_address != self.leaderIP and
-                           preemptable != (i.spot_instance_request_id is None)]
+        workerInstances = [i for i in entireCluster
+                           if i.private_ip_address != self.leaderIP
+                           and preemptable != (i.spot_instance_request_id is None)
+                           and not self.staticNodesDict.get(i.private_ip_address)]  # filter static nodes
         logger.debug('Workers found in cluster %s', workerInstances)
         workerInstances = awsFilterImpairedNodes(workerInstances, self.ctx.ec2)
         return workerInstances

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -675,10 +675,8 @@ class AWSProvisioner(AbstractProvisioner):
     def _getWorkersInCluster(self, preemptable):
         entireCluster = self._getNodesInCluster(ctx=self.ctx, clusterName=self.clusterName, both=True)
         logger.debug('All nodes in cluster %s', entireCluster)
-        workerInstances = [i for i in entireCluster
-                           if i.private_ip_address != self.leaderIP
-                           and preemptable != (i.spot_instance_request_id is None)
-                           and not self.staticNodesDict.get(i.private_ip_address)]  # filter static nodes
+        workerInstances = [i for i in entireCluster if i.private_ip_address != self.leaderIP and
+                           preemptable != (i.spot_instance_request_id is None)]
         logger.debug('Workers found in cluster %s', workerInstances)
         workerInstances = awsFilterImpairedNodes(workerInstances, self.ctx.ec2)
         return workerInstances

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -74,7 +74,7 @@ class AWSProvisioner(AbstractProvisioner):
             self.instanceMetaData = get_instance_metadata()
             self.clusterName = self._getClusterNameFromTags(self.instanceMetaData)
             self.ctx = self._buildContext(clusterName=self.clusterName)
-            self.leaderIP = self.instanceMetaData['local-ipv4']
+            self.leaderIP = self.instanceMetaData['local-ipv4']  # this is PRIVATE IP
             self.keyName = self.instanceMetaData['public-keys'].keys()[0]
             self.tags = self._getLeader(self.clusterName).tags
             self.masterPublicKey = self.setSSH()
@@ -440,7 +440,7 @@ class AWSProvisioner(AbstractProvisioner):
 
         # if we running launch cluster we need to save this data as it won't be generated
         # from the metadata. This data is needed to launch worker nodes.
-        self.leaderIP = leader.ip_address
+        self.leaderIP = leader.private_ip_address
         self._addTags([leader], defaultTags)
         self.ctx = ctx
         self.spotBid = spotBid
@@ -452,8 +452,7 @@ class AWSProvisioner(AbstractProvisioner):
         if workers:
             # assuming that if the leader was launched without a spotbid then all workers
             # will be non-preemptable
-            # adding (and subtracting) 1 because setNodeCount is including leader (is this intended?)
-            workersCreated = self.setNodeCount(workers + 1, preemptable=spotBid) - 1
+            workersCreated = self.setNodeCount(workers, preemptable=spotBid)
             logger.info('Added %d workers with %d workers requested', workersCreated, workers)
 
         return leader

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -307,6 +307,7 @@ class ScalerThread(ExceptionalThread):
         self.maxNodes = scaler.config.maxPreemptableNodes if preemptable else scaler.config.maxNodes
         if isinstance(self.scaler.leader.batchSystem, AbstractScalableBatchSystem):
             self.totalNodes = len(self.scaler.leader.batchSystem.getNodes(self.preemptable))
+            self.scaler.provisioner.setStaticNodesDict(self.scaler.leader.batchSystem.getNodes(self.preemptable))
         else:
             self.totalNodes = 0
         logger.info('Starting with %s %s(s) in the cluster.', self.totalNodes, self.nodeTypeString)

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -307,7 +307,7 @@ class ScalerThread(ExceptionalThread):
         self.maxNodes = scaler.config.maxPreemptableNodes if preemptable else scaler.config.maxNodes
         if isinstance(self.scaler.leader.batchSystem, AbstractScalableBatchSystem):
             self.totalNodes = len(self.scaler.leader.batchSystem.getNodes(self.preemptable))
-            self.scaler.provisioner.setStaticNodesDict(self.scaler.leader.batchSystem.getNodes(self.preemptable))
+            self.scaler.provisioner.setStaticNodesDict(self.scaler.leader.batchSystem.getNodes(self.preemptable), self.preemptable)
         else:
             self.totalNodes = 0
         logger.info('Starting with %s %s(s) in the cluster.', self.totalNodes, self.nodeTypeString)

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -113,7 +113,7 @@ class AbstractAWSAutoscaleTest(ToilTest):
         ctx = AWSProvisioner._buildContext(self.clusterName)
 
         # test that two worker nodes were created + 1 for leader
-        self.assertEqual(2 + 1, len(AWSProvisioner.__getNodesInCluster(ctx, both=True)))
+        self.assertEqual(2 + 1, len(AWSProvisioner._getNodesInCluster(ctx, both=True)))
 
         assert len(self.getMatchingRoles(self.clusterName)) == 1
         # --never-download prevents silent upgrades to pip, wheel and setuptools

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -136,7 +136,8 @@ class AbstractAWSAutoscaleTest(ToilTest):
                        '--clean=always',
                        '--retryCount=2',
                        '--clusterStats=/home/',
-                       '--logDebug']
+                       '--logDebug',
+                       '--provisioner=aws']
 
         if spotInstances:
             toilOptions.extend([

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -113,7 +113,7 @@ class AbstractAWSAutoscaleTest(ToilTest):
         ctx = AWSProvisioner._buildContext(self.clusterName)
 
         # test that two worker nodes were created + 1 for leader
-        self.assertEqual(2 + 1, len(AWSProvisioner._getNodesInCluster(ctx, both=True)))
+        self.assertEqual(2 + 1, len(AWSProvisioner._getNodesInCluster(ctx, self.clusterName, both=True)))
 
         assert len(self.getMatchingRoles(self.clusterName)) == 1
         # --never-download prevents silent upgrades to pip, wheel and setuptools

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -277,6 +277,10 @@ class AWSRestartTest(AbstractAWSAutoscaleTest):
             command.extend(toilOptions)
             self.sshUtil(command)
 
+    @integrative
+    def testAutoScaledCluster(self):
+        self._test()
+
 
 class PremptableDeficitCompensationTest(AbstractAWSAutoscaleTest):
 
@@ -289,6 +293,8 @@ class PremptableDeficitCompensationTest(AbstractAWSAutoscaleTest):
         self.instanceType = 'm3.large' # instance needs to be available on the spot market
         self.jobStore = 'aws:%s:deficit-%s' % (self.awsRegion(), uuid4())
 
+    def test(self):
+        self._test(spotInstances=True, fulfillableBid=False)
 
     def _getScript(self):
         def userScript():

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -136,8 +136,7 @@ class AbstractAWSAutoscaleTest(ToilTest):
                        '--clean=always',
                        '--retryCount=2',
                        '--clusterStats=/home/',
-                       '--logDebug',
-                       '--provisioner=aws']
+                       '--logDebug']
 
         if spotInstances:
             toilOptions.extend([

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -110,9 +110,10 @@ class AbstractAWSAutoscaleTest(ToilTest):
         # get the leader so we know the IP address - we don't need to wait since create cluster
         # already insures the leader is running
         self.leader = AWSProvisioner._getLeader(wait=False, clusterName=self.clusterName)
+        ctx = AWSProvisioner._buildContext(self.clusterName)
 
         # test that two worker nodes were created + 1 for leader
-        self.assertEqual(2 + 1, len(AWSProvisioner._getNodesInCluster(both=True)))
+        self.assertEqual(2 + 1, len(AWSProvisioner.__getNodesInCluster(ctx, both=True)))
 
         assert len(self.getMatchingRoles(self.clusterName)) == 1
         # --never-download prevents silent upgrades to pip, wheel and setuptools
@@ -161,7 +162,6 @@ class AbstractAWSAutoscaleTest(ToilTest):
 
         self.sshUtil(checkStatsCommand)
 
-        ctx = AWSProvisioner._buildContext(self.clusterName)
         assert isinstance(self.leader.block_device_mapping["/dev/xvda"], BlockDeviceType)
         volumeID = self.leader.block_device_mapping["/dev/xvda"].volume_id
         ctx.ec2.get_all_volumes(volume_ids=[volumeID])

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -222,6 +222,11 @@ class AWSAutoscaleTest(AbstractAWSAutoscaleTest):
     def testAutoScale(self):
         self._test(spotInstances=False)
 
+    @integrative
+    @needs_aws
+    def testSpotAutoScale(self):
+        self._test(spotInstances=True)
+
 
 class AWSRestartTest(AbstractAWSAutoscaleTest):
     """

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -199,7 +199,7 @@ class AWSAutoscaleTest(AbstractAWSAutoscaleTest):
     def _getScript(self):
         fileToSort = os.path.join(os.getcwd(), 'sortFile')
         with open(fileToSort, 'w') as f:
-            f.write('01234567890123456789012345678901' * 1000)
+            f.write('01234567890123456789012345678901')
         self.rsyncUtil(os.path.join(self._projectRootPath(), 'src/toil/test/sort/sort.py'), ':/home/sort.py')
         self.rsyncUtil(fileToSort, ':/home/sortFile')
         os.unlink(fileToSort)

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -205,9 +205,8 @@ class AWSAutoscaleTest(AbstractAWSAutoscaleTest):
     def _runScript(self, toilOptions):
         # the file to sort is included in the Toil appliance so we know it will be on every node in the cluster
         # hacky, but it works.
-        runCommand = ['/home/venv/bin/python', '/home/sort.py', '--fileToSort=/home/s3am/bin/asadmin']
+        runCommand = ['/home/venv/bin/python', '/home/sort.py', '--fileToSort=/home/sortFile']
         runCommand.extend(toilOptions)
-        runCommand.append('--sseKey=/home/keyFile')
         self.sshUtil(runCommand)
 
     @integrative

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -195,12 +195,12 @@ class AWSAutoscaleTest(AbstractAWSAutoscaleTest):
         self.jobStore = 'aws:%s:autoscale-%s' % (self.awsRegion(), uuid4())
 
     def _getScript(self):
-        sseKeyFile = os.path.join(os.getcwd(), 'keyFile')
-        with open(sseKeyFile, 'w') as f:
-            f.write('01234567890123456789012345678901')
+        fileToSort = os.path.join(os.getcwd(), 'sortFile')
+        with open(fileToSort, 'w') as f:
+            f.write('01234567890123456789012345678901' * 1000)
         self.rsyncUtil(os.path.join(self._projectRootPath(), 'src/toil/test/sort/sort.py'), ':/home/sort.py')
-        self.rsyncUtil(sseKeyFile, ':/home/keyFile')
-        os.unlink(sseKeyFile)
+        self.rsyncUtil(fileToSort, ':/home/sortFile')
+        os.unlink(fileToSort)
 
     def _runScript(self, toilOptions):
         # the file to sort is included in the Toil appliance so we know it will be on every node in the cluster

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -137,6 +137,7 @@ class AbstractAWSAutoscaleTest(ToilTest):
                        '--mesosMaster=%s:5050' % self.leader.private_ip_address,
                        '--clean=always',
                        '--retryCount=2',
+                       '--clusterStats=/home/',
                        '--logDebug',
                        '--provisioner=aws']
 
@@ -276,10 +277,6 @@ class AWSRestartTest(AbstractAWSAutoscaleTest):
             command.extend(toilOptions)
             self.sshUtil(command)
 
-    @integrative
-    def testAutoScaledCluster(self):
-        self._test()
-
 
 class PremptableDeficitCompensationTest(AbstractAWSAutoscaleTest):
 
@@ -292,8 +289,6 @@ class PremptableDeficitCompensationTest(AbstractAWSAutoscaleTest):
         self.instanceType = 'm3.large' # instance needs to be available on the spot market
         self.jobStore = 'aws:%s:deficit-%s' % (self.awsRegion(), uuid4())
 
-    def test(self):
-        self._test(spotInstances=True, fulfillableBid=False)
 
     def _getScript(self):
         def userScript():

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -137,7 +137,6 @@ class AbstractAWSAutoscaleTest(ToilTest):
                        '--mesosMaster=%s:5050' % self.leader.private_ip_address,
                        '--clean=always',
                        '--retryCount=2',
-                       '--clusterStats=/home/',
                        '--logDebug',
                        '--provisioner=aws']
 
@@ -221,11 +220,6 @@ class AWSAutoscaleTest(AbstractAWSAutoscaleTest):
     @needs_aws
     def testAutoScale(self):
         self._test(spotInstances=False)
-
-    @integrative
-    @needs_aws
-    def testSpotAutoScale(self):
-        self._test(spotInstances=True)
 
 
 class AWSRestartTest(AbstractAWSAutoscaleTest):

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -52,7 +52,7 @@ def main():
     parser.add_argument("--vpcSubnet",
                         help="VPC subnet ID to launch cluster in. Uses default subnet if not specified."
                         "This subnet needs to have auto assign IPs turned on.")
-    parser.add_argument("-w", "--workers", dest='workers', default=0,
+    parser.add_argument("-w", "--workers", dest='workers', default=0, type=int,
                         help="Specify a number of workers to launch alongside the leader when the "
                              "cluster is created. This can be useful if running toil without "
                              "auto-scaling but with need of more hardware support")

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -42,7 +42,7 @@ def main():
     parser.add_argument("-t", "--tag", metavar='NAME=VALUE', dest='tags', default=[], action='append',
                         help="Tags are added to the AWS cluster for this node and all of its"
                              "children. Tags are of the form: "
-                             " --t key1=value1 --tag key2=value2 "
+                             " -t key1=value1 --tag key2=value2 "
                              "Multiple tags are allowed and each tag needs its own flag. By "
                              "default the cluster is tagged with "
                              " {"

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -53,7 +53,7 @@ def main():
                         help="VPC subnet ID to launch cluster in. Uses default subnet if not specified."
                         "This subnet needs to have auto assign IPs turned on.")
     parser.add_argument("-w", "--workers", dest='workers', default=0,
-                        help="Specify a number of workers to launch alongside the leader when the"
+                        help="Specify a number of workers to launch alongside the leader when the "
                              "cluster is created. This can be useful if running toil without "
                              "auto-scaling but with need of more hardware support")
     config = parseBasicOptions(parser)

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -52,6 +52,10 @@ def main():
     parser.add_argument("--vpcSubnet",
                         help="VPC subnet ID to launch cluster in. Uses default subnet if not specified."
                         "This subnet needs to have auto assign IPs turned on.")
+    parser.add_argument("-w", "--workers", dest='workers', default=0,
+                        help="Specify a number of workers to launch alongside the leader when the"
+                             "cluster is created. This can be useful if running toil without "
+                             "auto-scaling but with need of more hardware support")
     config = parseBasicOptions(parser)
     setLoggingFromOptions(config)
     tagsDict = None if config.tags is None else createTagsDict(config.tags)
@@ -63,7 +67,7 @@ def main():
             from toil.provisioners.aws.awsProvisioner import AWSProvisioner
         except ImportError:
             raise RuntimeError('The aws extra must be installed to use this provisioner')
-        provisioner = AWSProvisioner
+        provisioner = AWSProvisioner()
         parsedBid = config.nodeType.split(':', 1)
         if len(config.nodeType) != len(parsedBid[0]):
             # there is a bid
@@ -72,6 +76,11 @@ def main():
     else:
         assert False
 
-    provisioner.launchCluster(instanceType=config.nodeType, clusterName=config.clusterName,
-                              keyName=config.keyPairName, spotBid=spotBid, userTags=tagsDict, zone=config.zone,
+    provisioner.launchCluster(instanceType=config.nodeType,
+                              keyName=config.keyPairName,
+                              clusterName=config.clusterName,
+                              workers=config.workers,
+                              spotBid=spotBid,
+                              userTags=tagsDict,
+                              zone=config.zone,
                               vpcSubnet=config.vpcSubnet)


### PR DESCRIPTION
This allows worker nodes to be launched along side leader by adding `-w` option to `toil launch-cluster`. To spin up a cluster with 4 workers (not including the leader) run:
     `toil launch-cluster CLUSTER_NAME --nodeType=t2.micro --keyPairName foo@example.com  -w 4`