### PR TITLE
Upgrade to Mesos 1.0.1

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -28,7 +28,7 @@ dependencies = ' '.join(['libffi-dev',  # For client side encryption for 'azure'
                          'wget',
                          'curl',
                          'openssh-server',
-                         'mesos=1.0.0-2.0.89.ubuntu1404',
+                         'mesos=1.0.1-2.0.93.ubuntu1404',
                          'rsync',
                          'screen'])
 


### PR DESCRIPTION
1.0.1 fixes a [pretty critical bug in Mesos](https://issues.apache.org/jira/browse/MESOS-5943) which causes the scheduler to occasionally crash when it receives enough task status updates at once that a read chunk ends in the middle of a request.

This is somewhat relevant to #1629, where I ran into this crash, and #1553, where the "partitions" (really just disconnections) *may* have the same root cause, though I'm not totally sure. It does have a very similar pattern (an random RST from the server after a bunch of large packets get POSTed at once). It doesn't really fix either of those issues in principle, but it might in practice.

This PR doesn't upgrade past the 1.0 series, because beyond that the meaning of the task updates changes slightly. I'm working on proper reconciliation, because right now I see lost tasks popping up constantly. As part of that I will probably upgrade to 1.2 while trying to keep backward compatibility with 1.0.