### PR TITLE
Add `import os`

### DIFF
--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -23,6 +23,7 @@ import subprocess
 import time
 from threading import Thread
 from datetime import date
+import os
 
 # Python 3 compatibility imports
 from six.moves.queue import Empty, Queue


### PR DESCRIPTION
I'm getting an error `NameError: global name 'os' is not defined` when using cwltoil. This PR should fix this error.