### PR TITLE
Set mesosMasterAddress default to private IP (resolves #1664)

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -37,32 +37,13 @@ from toil import logProcessContext
 from toil.lib.bioio import addLoggingOptions, getLogLevelString, setLoggingFromOptions
 from toil.realtimeLogger import RealtimeLogger
 
+from socket import gethostbyname, gethostname
+
 logger = logging.getLogger(__name__)
 
 # This constant is set to the default value used on unix for block size (in bytes) when
 # os.stat(<file>).st_blocks is called.
 unixBlockSize = 512
-
-
-def getLocalIP():
-    """
-    Gets the local IP address of the machine that calls this function.
-    This works on CoreOS but is not guaranteed to work on any other
-    systems.
-
-    taken from http://stackoverflow.com/a/24196955
-
-    :return: IP address as a string
-    """
-    def get_ip_address(ifname):
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        return socket.inet_ntoa(fcntl.ioctl(
-            s.fileno(),
-            0x8915,  # SIOCGIFADDR
-            struct.pack('256s', ifname[:15])
-        )[20:24])
-
-    return get_ip_address('eth0')
 
 
 class Config(object):
@@ -95,7 +76,8 @@ class Config(object):
         self.batchSystem = "singleMachine"
         self.disableHotDeployment = False
         self.scale = 1
-        self.mesosMasterAddress = '%s:5050' % getLocalIP()
+        # may return localhost on some systems (not osx and coreos) https://stackoverflow.com/a/166520
+        self.mesosMasterAddress = '%s:5050' % gethostbyname(gethostname())
         self.parasolCommand = "parasol"
         self.parasolMaxBatches = 10000
         self.environment = {}

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -44,6 +44,27 @@ logger = logging.getLogger(__name__)
 unixBlockSize = 512
 
 
+def getLocalIP():
+    """
+    Gets the local IP address of the machine that calls this function.
+    This works on CoreOS but is not guaranteed to work on any other
+    systems.
+
+    taken from http://stackoverflow.com/a/24196955
+
+    :return: IP address as a string
+    """
+    def get_ip_address(ifname):
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        return socket.inet_ntoa(fcntl.ioctl(
+            s.fileno(),
+            0x8915,  # SIOCGIFADDR
+            struct.pack('256s', ifname[:15])
+        )[20:24])
+
+    return get_ip_address('eth0')
+
+
 class Config(object):
     """
     Class to represent configuration operations for a toil workflow run.
@@ -1119,22 +1140,3 @@ def getFileSystemSize(dirPath):
     return freeSpace, diskSize
 
 
-def getLocalIP():
-    """
-    Gets the local IP address of the machine that calls this function.
-    This works on CoreOS but is not guaranteed to work on any other
-    systems.
-
-    taken from http://stackoverflow.com/a/24196955
-
-    :return: IP address as a string
-    """
-    def get_ip_address(ifname):
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        return socket.inet_ntoa(fcntl.ioctl(
-            s.fileno(),
-            0x8915,  # SIOCGIFADDR
-            struct.pack('256s', ifname[:15])
-        )[20:24])
-
-    return get_ip_address('eth0')

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -21,8 +21,6 @@ import sys
 import tempfile
 import time
 import socket
-import fcntl
-import struct
 from argparse import ArgumentParser
 from threading import Thread
 
@@ -37,7 +35,6 @@ from toil import logProcessContext
 from toil.lib.bioio import addLoggingOptions, getLogLevelString, setLoggingFromOptions
 from toil.realtimeLogger import RealtimeLogger
 
-from socket import gethostbyname, gethostname
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +74,7 @@ class Config(object):
         self.disableHotDeployment = False
         self.scale = 1
         # may return localhost on some systems (not osx and coreos) https://stackoverflow.com/a/166520
-        self.mesosMasterAddress = '%s:5050' % gethostbyname(gethostname())
+        self.mesosMasterAddress = '%s:5050' % socket.gethostbyname(socket.gethostname())
         self.parasolCommand = "parasol"
         self.parasolMaxBatches = 10000
         self.environment = {}

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -74,7 +74,7 @@ class Config(object):
         self.disableHotDeployment = False
         self.scale = 1
         # may return localhost on some systems (not osx and coreos) https://stackoverflow.com/a/166520
-        self.mesosMasterAddress = '%s:5050' % socket.gethostbyname(socket.gethostname())
+        self.mesosMasterAddress = '%s:5050' % 'localhost' # socket.gethostbyname(socket.gethostname())
         self.parasolCommand = "parasol"
         self.parasolMaxBatches = 10000
         self.environment = {}


### PR DESCRIPTION
This sets the default address for the Mesos master to the private IP of the node where the workflow is launched. 

Because workflows are always launched from the leader node, the private IP is precisely what we need in 99% of circumstances and thus makes a sensible default.

First commit is the actual change. A second commit will follow that will adjust the tests to make use of the new feature.