### PR TITLE
CWL: Add support for InitalWorkDirRequirement

### DIFF
--- a/docs/running/running.rst
+++ b/docs/running/running.rst
@@ -63,9 +63,6 @@ support for the stable v1.0 specification, only lacking the following features:
 
 - `Directory`_ inputs and outputs in pipelines. Currently, directory inputs must
   be enumerated as Files.
-- `InitialWorkDirRequirement`_ to create files together within a specific work
-  directory. Collecting associated files using `secondaryFiles`_ is a good
-  workaround.
 - `File literals`_ that specify only ``contents`` to a File without an explicit
   file name.
 - Complex file inputs – from ExpressionTool or a default value, both of which do
@@ -80,7 +77,6 @@ command line parameters to select and configure the batch system to use.
 
 .. _File literals: http://www.commonwl.org/v1.0/CommandLineTool.html#File
 .. _Directory: http://www.commonwl.org/v1.0/CommandLineTool.html#Directory
-.. _InitialWorkDirRequirement: http://www.commonwl.org/v1.0/CommandLineTool.html#InitialWorkDirRequirement
 .. _secondaryFiles: http://www.commonwl.org/v1.0/CommandLineTool.html#CommandInputParameter
 .. _CWL User Guide: http://www.commonwl.org/v1.0/UserGuide.html
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -584,6 +584,7 @@ class CWLWorkflow(Job):
 cwltool.process.supportedProcessRequirements = ("DockerRequirement",
                                                 "ExpressionEngineRequirement",
                                                 "InlineJavascriptRequirement",
+                                                "InitialWorkDirRequirement",
                                                 "SchemaDefRequirement",
                                                 "EnvVarRequirement",
                                                 "CreateFileRequirement",


### PR DESCRIPTION
The current toil integration with cwltool allows specification of
inputs into the initial working directory, so this enables this feature.
This is not generalized directory support (#1656 #1459), but does
allow writing inputs to the work directory making cross platform
CWL support for records easier.