### PR TITLE
When killing tasks, make sure to reap child processes in the process groups

### DIFF
--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -1628,7 +1628,7 @@ class NonCachingFileStore(FileStore):
                                            requestedDisk=jobReqs))
             self.logToMaster(logString, level=logging.DEBUG)
             if diskUsed > jobReqs:
-                self.logToMaster("Job used more disk than requested. Cconsider modifying the user "
+                self.logToMaster("Job used more disk than requested. Consider modifying the user "
                                  "script to avoid the chance of failure due to incorrectly "
                                  "requested resources. " + logString, level=logging.WARNING)
             os.chdir(startingDir)

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -138,6 +138,7 @@ def _docker(job,
                 containerName = baseDockerCall[baseDockerCall.index('--name') + 1]
         else:
             containerName = _getContainerName(job)
+            baseDockerCall.extend(['--name', containerName])
     except ValueError:
         containerName = _getContainerName(job)
         baseDockerCall.extend(['--name', containerName])

--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -372,7 +372,6 @@ class ModuleDescriptor(namedtuple('ModuleDescriptor', ('dirPath', 'name', 'fromV
         filePath[-1], extension = os.path.splitext(filePath[-1])
         require(extension in ('.py', '.pyc'),
                 'The name of a user script/module must end in .py or .pyc.')
-        log.debug("Module name is %s", name)
         if name == '__main__':
             log.debug("Discovering real name of module")
             # User script/module was invoked as the main program
@@ -393,6 +392,10 @@ class ModuleDescriptor(namedtuple('ModuleDescriptor', ('dirPath', 'name', 'fromV
                 cls._check_conflict(dirPath, name)
         else:
             # User module was imported. Determine the directory containing the top-level package
+            if filePath[-1] == '__init__':
+                # module is a subpackage
+                filePath.pop()
+
             for package in reversed(name.split('.')):
                 dirPathTail = filePath.pop()
                 assert dirPathTail == package


### PR DESCRIPTION
Long-running tasks e.g. docker pipelines, can be abondoned on the slave nodes
when tasks are killed. Instead kill all processes belonging to the task's process
group. This requires us to make sure a new progress group is created on launching
a pipeline.

Also fixes an issue where docker containers aren't named as expected on launch.