### PR TITLE
PBSPro (Torque's proprietary version) in addition to OSS's PBS

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -32,7 +32,7 @@ from toil.fileStore import shutdownFileStore
 logger = logging.getLogger(__name__)
 
 # TODO: should this be an attribute?  Used in the worker and the batch system
-sleepSeconds = 1
+sleepSeconds = 10
 
 # A class containing the information required for worker cleanup on shutdown of the batch system.
 WorkerCleanupInfo = namedtuple('WorkerCleanupInfo', (

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -31,6 +31,7 @@ from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
 logger = logging.getLogger(__name__)
 
 # TODO: should this be an attribute?  Used in the worker and the batch system
+sleepSeconds = 10
 
 class AbstractGridEngineBatchSystem(BatchSystemSupport):
     """
@@ -117,7 +118,7 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
 
                 # submit job and get batch system ID
                 batchJobID = self.submitJob(subLine)
-                logger.debug("Submitted job %d", batchJobID)
+                logger.debug("Submitted job %s", str(batchJobID))
 
                 # Store dict for mapping Toil job ID to batch job ID
                 # TODO: Note that this currently stores a tuple of (batch system

--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -44,17 +44,26 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
         """
         def getRunningJobIDs(self):
             times = {}
-            currentjobs = dict((str(self.batchJobIDs[x][0]), x) for x in self.runningJobs)
-            process = subprocess.Popen(["qstat"], stdout=subprocess.PIPE)
+            currentjobs = dict((str(self.batchJobIDs[x][0].strip()), x) for x in self.runningJobs)
+            logger.debug("getRunningJobIDs current jobs are: " + str(currentjobs))
+            # Limit qstat to current username to avoid clogging the batch system on heavily loaded clusters
+            #job_user = os.environ.get('USER')
+            #process = subprocess.Popen(['qstat', '-u', job_user], stdout=subprocess.PIPE)
+            # -x shows exit status in PBSPro
+            process = subprocess.Popen(['qstat', '-x'], stdout=subprocess.PIPE)
             stdout, stderr = process.communicate()
 
             # qstat supports XML output which is more comprehensive, but PBSPro does not support it 
+            # so instead we stick with plain commandline "qstat" outputs
             for currline in stdout.split('\n'):
                 items = currline.strip().split()
                 if items:
-                    jobid = items[0].strip().split('.')[0]
+                    jobid = items[0].strip()
+                    if jobid in currentjobs:
+                        logger.debug("getRunningJobIDs job status for is: " + items[4])
                     if jobid in currentjobs and items[4] == 'R':
                         walltime = items[3]
+                        logger.debug("getRunningJobIDs qstat reported walltime is: " + walltime)
                         # normal qstat has a quirk with job time where it reports '0'
                         # when initially running; this catches this case
                         if walltime == '0':
@@ -63,7 +72,21 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
                             walltime = time.mktime(time.strptime(walltime, "%H:%M:%S"))
                         times[currentjobs[jobid]] = walltime
 
+            logger.debug("Job times from qstat are: " + str(times))
             return times
+
+        def getUpdatedBatchJob(self, maxWait):
+            try:
+                logger.debug("getUpdatedBatchJob: Job updates")
+                pbsJobID, retcode = self.updatedJobsQueue.get(timeout=maxWait)
+                self.updatedJobsQueue.task_done()
+                jobID, retcode = (self.jobIDs[pbsJobID], retcode)
+                self.currentjobs -= {self.jobIDs[pbsJobID]}
+            except Empty:
+                logger.debug("getUpdatedBatchJob: Job queue is empty")
+                pass
+            else:
+                return jobID, retcode, None
 
         def killJob(self, jobID):
             subprocess.check_call(['qdel', self.getBatchSystemID(jobID)])
@@ -74,20 +97,20 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
         def submitJob(self, subLine):
             process = subprocess.Popen(subLine, stdout=subprocess.PIPE)
             so, se = process.communicate()
-            # TODO: the full URI here may be needed on complex setups, stripping
-            # down to integer job ID only may be bad long-term
-            result = int(so.strip().split('.')[0])
+            result = so
             return result
 
         def getJobExitCode(self, torqueJobID):
-            args = ["qstat", "-f", str(torqueJobID)]
+            args = ["qstat", "-x", "-f", str(torqueJobID).split('.')[0]]
 
             process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             for line in process.stdout:
                 line = line.strip()
-                if line.startswith("failed") and int(line.split()[1]) == 1:
+                #logger.debug("getJobExitCode exit status: " + line)
+                # Case differences due to PBSPro vs OSS Torque qstat outputs
+                if line.startswith("failed") or line.startswith("FAILED") and int(line.split()[1]) == 1:
                     return 1
-                if line.startswith("exit_status"):
+                if line.startswith("exit_status") or line.startswith("Exit_status"):
                     status = line.split(' = ')[1]
                     logger.debug('Exit Status: ' + status)
                     return int(status)
@@ -162,18 +185,19 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
             """
             _, tmpFile = tempfile.mkstemp(suffix='.sh', prefix='torque_wrapper')
             fh = open(tmpFile , 'w')
-            fh.write("$!/bin/sh\n\n")
+            fh.write("#!/bin/sh\n")
             fh.write("cd $PBS_O_WORKDIR\n\n")
             fh.write(command + "\n")
+
             fh.close
+            
             return tmpFile
 
     @classmethod
     def obtainSystemConstants(cls):
 
         # See: https://github.com/BD2KGenomics/toil/pull/1617#issuecomment-293525747
-        logger.debug("PBS/Torque does not need obtainSystemConstants to assess global \
-                    cluster resources.")
+        logger.debug("PBS/Torque does not need obtainSystemConstants to assess global cluster resources.")
 
 
         #return maxCPU, maxMEM


### PR DESCRIPTION
This is a followup on PR #1617.

The child jobs' exit codes were not properly monitored by the leader. Flag differences between pbspro and the oss version are indeed confusing:

`qstat -x` means: XML on OSS version BUT provide exit codes on PBS pro... ¬_¬'''

Also the `qstat` polling 1 second polling is considered excessive by traditional HPC cluster operators, raised it to 10 seconds. 
 
Thanks to @cket and @hcraT for their invaluable insights on this issue over gitter: https://gitter.im/bd2k-genomics-toil/Lobby?at=5912e6b9ac693c532adb46d1