### PR TITLE
CWL: symlink jobStore files instead of copying

### DIFF
--- a/docs/running/running.rst
+++ b/docs/running/running.rst
@@ -65,6 +65,9 @@ support for the stable v1.0 specification, only lacking the following features:
   be enumerated as Files.
 - `File literals`_ that specify only ``contents`` to a File without an explicit
   file name.
+- Writable `InitialWorkDirRequirement
+  <http://www.commonwl.org/v1.0/CommandLineTool.html#InitialWorkDirRequirement>`
+  objects. Standard readable inputs do work.
 - Complex file inputs – from ExpressionTool or a default value, both of which do
   not yet get cleanly staged into Toil file management.
 

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -40,7 +40,6 @@ import json
 import sys
 import logging
 import copy
-import shutil
 import functools
 
 # Python 3 compatibility imports
@@ -127,7 +126,16 @@ def resolve_indirect(d):
     else:
         return res
 
-def getFile(fileStore, dir, fileTuple, index=None, export=False, primary=None, rename_collision=False):
+def getFile(fileStore, dir, fileTuple, index=None, export=False, primary=None, rename_collision=False,
+            existing={}):
+    """Extract input file from Toil jobstore.
+
+    Uses standard filestore to retrieve file, then provides a symlink to it
+    for running. If export is True (for final outputs), it gets copied to
+    the final location.
+
+    Keeps track of files being used locally with 'existing'
+    """
     # File literal outputs with no path, from writeFile
     if fileTuple is None:
         raise cwltool.process.UnsupportedRequirement("CWL expression file inputs not yet supported in Toil")
@@ -153,18 +161,21 @@ def getFile(fileStore, dir, fileTuple, index=None, export=False, primary=None, r
     else:
         srcPath = fileStore.readGlobalFile(fileStoreID)
         if srcPath != dstPath:
-            if copy:
-                shutil.copyfile(srcPath, dstPath)
+            if os.path.exists(dstPath):
+                if index.get(dstPath, None) != fileStoreID:
+                    raise Exception("Conflicting filesStoreID %s and %s both trying to link to %s" % (index.get(dstPath, None), fileStoreID, dstPath))
             else:
-                if os.path.exists(dstPath):
-                    if index.get(dstPath, None) != fileStoreID:
-                        raise Exception("Conflicting filesStoreID %s and %s both trying to link to %s" % (index.get(dstPath, None), fileStoreID, dstPath))
-                else:
-                    os.symlink(srcPath, dstPath)
+                os.symlink(srcPath, dstPath)
+                existing[srcPath] = dstPath
             index[dstPath] = fileStoreID
     return dstPath
 
-def writeFile(writeFunc, index, x):
+def writeFile(writeFunc, index, existing, x):
+    """Write output files back into Toil jobstore.
+
+    'existing' is a set of files retrieved as inputs from getFile. This ensures
+    they are mapped back as the same name if passed through.
+    """
     # Toil fileStore references are tuples of pickle and internal file
     if isinstance(x, tuple):
         return x
@@ -174,6 +185,7 @@ def writeFile(writeFunc, index, x):
         return None
     else:
         if x not in index:
+            x = existing.get(x, x)
             if not urlparse.urlparse(x).scheme:
                 rp = os.path.realpath(x)
             else:
@@ -200,8 +212,7 @@ def addFilePartRefs(p):
         nameroot, nameext = os.path.splitext(basename)
         for k, v in [("dirname", dirname,), ("basename", basename),
                      ("nameroot", nameroot), ("nameext", nameext)]:
-            if k not in p:
-                p[k] = v
+            p[k] = v
     return p
 
 def locToPath(p):
@@ -276,8 +287,11 @@ class CWLJob(Job):
 
         # Copy input files out of the global file store, ensure path/location synchronized
         index = {}
-        adjustFilesWithSecondary(cwljob, functools.partial(getFile, fileStore, inpdir, index=index))
+        existing = {}
+        adjustFilesWithSecondary(cwljob, functools.partial(getFile, fileStore, inpdir, index=index,
+                                                           existing=existing))
         cwltool.pathmapper.adjustFileObjs(cwljob, pathToLoc)
+        cwltool.pathmapper.adjustFileObjs(cwljob, addFilePartRefs)
 
         # Run the tool
         opts = copy.deepcopy(self.executor_options)
@@ -297,8 +311,7 @@ class CWLJob(Job):
         cwltool.pathmapper.adjustFileObjs(output, functools.partial(computeFileChecksums,
                                                                     cwltool.stdfsaccess.StdFsAccess(outdir)))
         # Copy output files into the global file store.
-        adjustFiles(output, functools.partial(writeFile, fileStore.writeGlobalFile, {}))
-
+        adjustFiles(output, functools.partial(writeFile, fileStore.writeGlobalFile, {}, existing))
         return output
 
 
@@ -606,6 +619,15 @@ def unsupportedInputCheck(p):
     if p.get("contents") and (not p.get("path") and not p.get("location")):
         raise cwltool.process.UnsupportedRequirement("CWL File literals not yet supported in Toil")
 
+def unsupportedRequirementsCheck(requirements):
+    """Check for specific requirement cases we don't support.
+    """
+    for r in requirements:
+        if r["class"] == "InitialWorkDirRequirement":
+            for l in r.get("listing", []):
+                if isinstance(l, dict) and l.get("writable"):
+                    raise cwltool.process.UnsupportedRequirement("CWL writable InitialWorkDirRequirement not yet supported in Toil")
+
 def unsupportedDefaultCheck(tool):
     """Check for file-based defaults, which don't get staged correctly in Toil.
     """
@@ -658,6 +680,7 @@ def main(args=None, stdout=sys.stdout):
     try:
         t = cwltool.load_tool.load_tool(options.cwltool, cwltool.workflow.defaultMakeTool,
                                         resolver=cwltool.resolver.tool_resolver, strict=useStrict)
+        unsupportedRequirementsCheck(t.requirements)
     except cwltool.process.UnsupportedRequirement as e:
         logging.error(e)
         return 33
@@ -710,7 +733,7 @@ def main(args=None, stdout=sys.stdout):
             cwltool.pathmapper.adjustDirObjs(tool, locToPath)
             cwltool.pathmapper.adjustFileObjs(tool, locToPath)
             adjustFiles(tool, lambda x: "file://%s" % x if not urlparse.urlparse(x).scheme else x)
-            adjustFiles(tool, functools.partial(writeFile, toil.importFile, {}))
+            adjustFiles(tool, functools.partial(writeFile, toil.importFile, {}, {}))
         t.visit(importDefault)
 
         if options.restart:
@@ -735,14 +758,14 @@ def main(args=None, stdout=sys.stdout):
             cwltool.pathmapper.adjustDirObjs(builder.job, pathToLoc)
             cwltool.pathmapper.adjustFileObjs(builder.job, pathToLoc)
             cwltool.pathmapper.adjustFileObjs(builder.job, addFilePartRefs)
-            adjustFiles(builder.job, functools.partial(writeFile, toil.importFile, {}))
+            adjustFiles(builder.job, functools.partial(writeFile, toil.importFile, {}, {}))
             wf1.cwljob = builder.job
             outobj = toil.start(wf1)
 
         outobj = resolve_indirect(outobj)
 
         try:
-            adjustFilesWithSecondary(outobj, functools.partial(getFile, toil, outdir, index={},
+            adjustFilesWithSecondary(outobj, functools.partial(getFile, toil, outdir, index={}, existing={},
                                                                export=True, rename_collision=True))
             cwltool.pathmapper.adjustFileObjs(outobj, pathToLoc)
         except cwltool.process.UnsupportedRequirement as e:


### PR DESCRIPTION
getFile would copy all input files from the jobStore previous due to a
refactoring bug: the `copy` function argument was removed but still
referenced; it picked up the `copy` module and was always true.

This moves to using symlinks to avoid the extra file copy. In doing so
it exposed some new issues, also fixed in this PR:

- Needed to correctly set basename and location in the File objects to
  avoid resolving the original Toil name instead of the actual file name.

- We don't support writable InitialWorkDirRequirement in CWL, but still
  support the more common readable case.

Fixes #1627