### PR TITLE
hard links: resolve inputs with symlinks

### DIFF
--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -169,7 +169,7 @@ class FileJobStore(AbstractJobStore):
                 os.close(fd)
                 os.unlink(absPath)
                 try:
-                    os.link(self._extractPathFromUrl(url), absPath)
+                    os.link(os.path.realpath(self._extractPathFromUrl(url)), absPath)
                 except OSError:
                     shutil.copyfile(self._extractPathFromUrl(url), absPath)
                 return FileID(self._getRelativePath(absPath), os.stat(absPath).st_size)
@@ -177,7 +177,7 @@ class FileJobStore(AbstractJobStore):
                 self._requireValidSharedFileName(sharedFileName)
                 path = self._getSharedFilePath(sharedFileName)
                 try:
-                    os.link(self._extractPathFromUrl(url), path)
+                    os.link(os.path.realpath(self._extractPathFromUrl(url)), path)
                 except:
                     shutil.copyfile(self._extractPathFromUrl(url), path)
                 return None


### PR DESCRIPTION
CJ;
Thank you for the work on hard links and avoiding file copying. I was testing this and ran into a problem when the input files were symlinks themselves. This resolves those to get it working with these cases as well. Thanks again.

Input files for hard linking into the filestore fail if they contain
relative symlinks in the input, since the hard links contain only
the original symlinks which are no longer valid:
```
$ ln -s base.txt input.txt
$ ls -lh
total 0
-rw-rw-r-- 1 chapmanb chapmanb 0 May 29 05:32 base.txt
lrwxrwxrwx 1 chapmanb chapmanb 8 May 29 05:32 input.txt -> base.txt
$ mkdir store
$ ln input.txt store/output.txt
$ ls -lh store/
total 0
lrwxrwxrwx 2 chapmanb chapmanb 8 May 29 05:32 output.txt -> base.txt
```
Supplement to #1681