### PR TITLE
Display license information in `pip show` (fixes #1670)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ def runSetup():
         author='Benedict Paten',
         author_email='benedict@soe.usc.edu',
         url="https://github.com/BD2KGenomics/toil",
+        classifiers=["License :: OSI Approved :: Apache Software License"],
+        license="Apache License v2.0",
         install_requires=[
             'bd2k-python-lib>=1.14a1.dev35',
             'dill==0.2.5',


### PR DESCRIPTION
Adds relevant `classifier` and `license` fields to `setup.py`.