### PR TITLE
Fix hot-deployment with python-3-supporting libraries (fixes #1678)

### DIFF
--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -28,7 +28,7 @@ from io import BytesIO
 from pydoc import locate
 from tempfile import mkdtemp
 from urllib2 import HTTPError
-from zipfile import ZipFile, PyZipFile
+from zipfile import ZipFile
 
 # Python 3 compatibility imports
 from bd2k.util.retry import retry
@@ -265,8 +265,8 @@ class FileResource(Resource):
 class DirectoryResource(Resource):
     """
     A resource read from a directory on the leader. The URL will point to a ZIP archive of the
-    directory. Only Python script/modules will be included. The directory may be a package but it
-    does not need to be.
+    directory. All files in that directory (and any subdirectories) will be included. The directory
+    may be a package but it does not need to be.
     """
 
     @classmethod
@@ -275,10 +275,20 @@ class DirectoryResource(Resource):
         :type path: str
         """
         bytesIO = BytesIO()
-        # PyZipFile compiles .py files on the fly, filters out any non-Python files and
-        # distinguishes between packages and simple directories.
-        with PyZipFile(file=bytesIO, mode='w') as zipFile:
-            zipFile.writepy(path)
+        initfile = os.path.join(path, '__init__.py')
+        if os.path.isfile(initfile):
+            # This is a package directory. To emulate
+            # PyZipFile.writepy's behavior, we need to keep everything
+            # relative to this path's parent directory.
+            rootDir = os.path.dirname(path)
+        else:
+            # This is a simple user script (with possibly a few helper files)
+            rootDir = path
+        with ZipFile(file=bytesIO, mode='w') as zipFile:
+            for dirName, _, fileList in os.walk(path):
+                for fileName in fileList:
+                    fullPath = os.path.join(dirName, fileName)
+                    zipFile.write(fullPath, os.path.relpath(fullPath, rootDir))
         bytesIO.seek(0)
         return bytesIO
 
@@ -297,23 +307,21 @@ class DirectoryResource(Resource):
 class VirtualEnvResource(DirectoryResource):
     """
     A resource read from a virtualenv on the leader. All modules and packages found in the
-    virtualenv's site-packages directory will be included. Any .pth or .egg-link files will be
-    ignored.
+    virtualenv's site-packages directory will be included.
     """
-
     @classmethod
     def _load(cls, path):
-        sitePackages = path
-        assert os.path.basename(sitePackages) == 'site-packages'
+        """
+        :type path: str
+        """
+        assert os.path.basename(path) == 'site-packages'
         bytesIO = BytesIO()
-        with PyZipFile(file=bytesIO, mode='w') as zipFile:
-            # This adds the .py files but omits subdirectories since site-packages is not a package
-            zipFile.writepy(sitePackages)
-            # Now add the missing packages
-            for name in os.listdir(sitePackages):
-                path = os.path.join(sitePackages, name)
-                if os.path.isdir(path) and os.path.isfile(os.path.join(path, '__init__.py')):
-                    zipFile.writepy(path)
+        with ZipFile(file=bytesIO, mode='w') as zipFile:
+            for dirName, _, fileList in os.walk(path):
+                zipFile.write(dirName)
+                for fileName in fileList:
+                    fullPath = os.path.join(dirName, fileName)
+                    zipFile.write(fullPath, os.path.relpath(fullPath, path))
         bytesIO.seek(0)
         return bytesIO
 

--- a/src/toil/test/src/resourceTest.py
+++ b/src/toil/test/src/resourceTest.py
@@ -75,7 +75,6 @@ class ResourceTest(ToilTest):
         else:
             oldPrefix = None
         try:
-            pycFiles = set(pyFile + 'c' for pyFile in pyFiles)
             for relPath in pyFiles:
                 path = os.path.join(dirPath, relPath)
                 mkdir_p(os.path.dirname(path))
@@ -86,8 +85,8 @@ class ResourceTest(ToilTest):
                 userScript = importlib.import_module(moduleName)
                 try:
                     self._test(userScript.__name__,
-                               expectedContents=pycFiles,
-                               allowExtraContents=virtualenv)
+                               expectedContents=pyFiles,
+                               allowExtraContents=True)
                 finally:
                     del userScript
                     while moduleName:


### PR DESCRIPTION
As a side-effect now *every* file in the hot-deployed directory or virtualenv is deployed, not just Python files. I'm open to changing that so that the new code still has the old behavior, but I don't know if there's really a good reason to keep the old behavior. Non-python files can be included in virtualenvs, and it's conceivable that those might need to be hot-deployed as well.