### PR TITLE
Fixed logging being initialized twice (fixes #1591)

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -598,17 +598,14 @@ class AWSProvisioner(AbstractProvisioner):
             finally:
                 s.close()
 
-
     @classmethod
     def _terminateNodes(cls, nodes, ctx):
         instanceIDs = [x.name for x in nodes]
-        logger.info('Terminating instance(s): %s', instanceIDs)
         cls._terminateIDs(instanceIDs, ctx)
 
     @classmethod
     def _terminateInstances(cls, instances, ctx):
         instanceIDs = [x.id for x in instances]
-        logger.info('Terminating instance(s): %s', instanceIDs)
         cls._terminateIDs(instanceIDs, ctx)
         logger.info('... Waiting for instance(s) to shut down...')
         for instance in instances:

--- a/src/toil/utils/toilDestroyCluster.py
+++ b/src/toil/utils/toilDestroyCluster.py
@@ -16,18 +16,17 @@ Terminates the specified cluster and associated resources
 """
 import logging
 from toil.provisioners import Cluster
-from toil.lib.bioio import parseBasicOptions, setLoggingFromOptions, getBasicOptionParser
+from toil.lib.bioio import parseBasicOptions, getBasicOptionParser
 from toil.utils import addBasicProvisionerOptions
 
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
 
 
 def main():
     parser = getBasicOptionParser()
     parser = addBasicProvisionerOptions(parser)
     config = parseBasicOptions(parser)
-    setLoggingFromOptions(config)
     cluster = Cluster(provisioner=config.provisioner,
                       clusterName=config.clusterName, zone=config.zone)
     cluster.destroyCluster()

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -15,10 +15,10 @@
 Launches a toil leader instance with the specified provisioner
 """
 import logging
-from toil.lib.bioio import parseBasicOptions, setLoggingFromOptions, getBasicOptionParser
+from toil.lib.bioio import parseBasicOptions, getBasicOptionParser
 from toil.utils import addBasicProvisionerOptions
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
 
 
 def createTagsDict(tagList):
@@ -57,7 +57,6 @@ def main():
                              "cluster is created. This can be useful if running toil without "
                              "auto-scaling but with need of more hardware support")
     config = parseBasicOptions(parser)
-    setLoggingFromOptions(config)
     tagsDict = None if config.tags is None else createTagsDict(config.tags)
 
     spotBid = None

--- a/src/toil/utils/toilRsyncCluster.py
+++ b/src/toil/utils/toilRsyncCluster.py
@@ -17,7 +17,7 @@ Rsyncs into the toil appliance container running on the leader of the cluster
 import argparse
 import logging
 
-from toil.lib.bioio import parseBasicOptions, setLoggingFromOptions, getBasicOptionParser
+from toil.lib.bioio import parseBasicOptions, getBasicOptionParser
 from toil.provisioners import Cluster
 from toil.utils import addBasicProvisionerOptions
 
@@ -35,6 +35,5 @@ def main():
                         "\nOr, to download a file from the remote:, `toil rsync-cluster"
                         " -p aws test-cluster :example.py .`")
     config = parseBasicOptions(parser)
-    setLoggingFromOptions(config)
     cluster = Cluster(provisioner=config.provisioner, clusterName=config.clusterName, zone=config.zone)
     cluster.rsyncCluster(args=config.args)

--- a/src/toil/utils/toilSSHCluster.py
+++ b/src/toil/utils/toilSSHCluster.py
@@ -17,10 +17,10 @@ SSHs into the toil appliance container running on the leader of the cluster
 import argparse
 import logging
 from toil.provisioners import Cluster
-from toil.lib.bioio import parseBasicOptions, setLoggingFromOptions, getBasicOptionParser
+from toil.lib.bioio import parseBasicOptions, getBasicOptionParser
 from toil.utils import addBasicProvisionerOptions
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -28,7 +28,6 @@ def main():
     parser = addBasicProvisionerOptions(parser)
     parser.add_argument('args', nargs=argparse.REMAINDER)
     config = parseBasicOptions(parser)
-    setLoggingFromOptions(config)
     cluster = Cluster(provisioner=config.provisioner,
                       clusterName=config.clusterName, zone=config.zone)
     cluster.sshCluster(args=config.args)


### PR DESCRIPTION
* In `launch-cluster`, `destroy-cluster`, `ssh-cluster`, and `rsync-cluster`, logging would be erroneously initialized twice, causing some messages to be logged multiple times. 
* In `awsProvisioner.py`, `_terminateNodes` and `_terminateInstances` both logged the instances to be terminated before calling `_terminateIDs`, which logged the same information again.