### PR TITLE
Skip provisioner utils test if rsync version is outdated or unavailable (resolves #1725)

### DIFF
--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -20,6 +20,7 @@ import os
 import re
 import shutil
 import signal
+import subprocess
 import tempfile
 import threading
 import time
@@ -243,6 +244,24 @@ except ImportError:
 else:
     def _mark_test(name, test_item):
         return MarkDecorator(name)(test_item)
+
+
+def needs_rsync(test_item):
+    """
+    Use as a decorator before test classes or methods that depend on any features used in rsync
+    version 3.0.0+
+    """
+    test_item = _mark_test('rsync', test_item)
+    try:
+        versionInfo = subprocess.check_output(['rsync', '--version'])
+    except CalledProcessError:
+        return unittest.skip('rsync needs to be installed to run this test.')(test_item)
+    else:
+        # version output looks like: 'rsync  version 2.6.9 ...'
+        versionNum = int(versionInfo.split()[2].split('.')[0])
+        if versionNum < 3:
+            return unittest.skip('This test depends on rsync version 3.0.0+.')
+        return test_item
 
 
 def needs_aws(test_item):

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -246,10 +246,13 @@ else:
         return MarkDecorator(name)(test_item)
 
 
-def needs_rsync(test_item):
+def needs_rsync3(test_item):
     """
     Use as a decorator before test classes or methods that depend on any features used in rsync
     version 3.0.0+
+
+    Necessary because :meth:`utilsTest.testAWSProvisionerUtils` uses option `--protect-args` which is only
+    available in rsync 3
     """
     test_item = _mark_test('rsync', test_item)
     try:

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -27,7 +27,7 @@ import toil.test.sort.sort
 from toil import resolveEntryPoint
 from toil.job import Job
 from toil.lib.bioio import getTempFile, system
-from toil.test import ToilTest, needs_aws, integrative
+from toil.test import ToilTest, needs_aws, needs_rsync, integrative
 from toil.test.sort.sortTest import makeFileToSort
 from toil.utils.toilStats import getStats, processData
 from toil.common import Toil, Config
@@ -80,6 +80,7 @@ class UtilsTest(ToilTest):
             commandTokens.append('--failIfNotComplete')
         return commandTokens
 
+    @needs_rsync
     @needs_aws
     @integrative
     def testAWSProvisionerUtils(self):

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -29,7 +29,7 @@ import toil.test.sort.sort
 from toil import resolveEntryPoint
 from toil.job import Job
 from toil.lib.bioio import getTempFile, system
-from toil.test import ToilTest, needs_aws, needs_rsync, integrative
+from toil.test import ToilTest, needs_aws, needs_rsync3, integrative
 from toil.test.sort.sortTest import makeFileToSort
 from toil.utils.toilStats import getStats, processData
 from toil.common import Toil, Config
@@ -82,7 +82,7 @@ class UtilsTest(ToilTest):
             commandTokens.append('--failIfNotComplete')
         return commandTokens
 
-    @needs_rsync
+    @needs_rsync3
     @pytest.mark.timeout(1200)
     @needs_aws
     @integrative


### PR DESCRIPTION
Previously if you had an outdated version of rsync installed (<3.0.0, like the one that comes by default with OSX) running the provisioner utils tests would fail.

This PR adds a decorator that checks if the user has rsync installed and makes sure that the version is sufficient, skipping the tests otherwise.