### PR TITLE
Fix autoscaler crash (resolves #1728, #1729)

### DIFF
--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -616,7 +616,7 @@ class ScalerThread(ExceptionalThread):
         for node, ip in ((node, node.privateIP) for node in provisionerNodes):
             info = None
             if ip not in recentMesosNodes:
-                logger.debug("Worker node at %s is not reporting executor information")
+                logger.debug("Worker node at %s is not reporting executor information", ip)
                 # we don't have up to date information about the node
                 info = _getInfo(allMesosNodes, ip)
             else:

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -553,9 +553,9 @@ class ScalerThread(ExceptionalThread):
                               )
         if not force:
             # don't terminate nodes that still have > 15% left in their allocated (prepaid) time
-            nodesToTerminate = [node for node in nodesToTerminate if
+            nodesToTerminate = [(node, i) for node, i in nodesToTerminate if
                                 self.scaler.provisioner.remainingBillingInterval(node) <= 0.15]
-        return [node for node,_ in nodesToTerminate]
+        return [node for node, _ in nodesToTerminate]
 
     def getNodes(self, preemptable):
         """


### PR DESCRIPTION
At some point nodesToTerminate changed from being a list of Nodes to a list of (Node, NodeInfo). This line didn't get updated when that changed, which caused a crash of the workflow on any downscaling attempt.