### PR TITLE
Add timeout for running pytest (resolves #1735)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ check_build_reqs:
 
 
 prepare: check_venv
-	$(pip) install sphinx==1.5.5 mock==1.0.1 pytest==2.8.3 stubserver==1.0.1
+	$(pip) install sphinx==1.5.5 mock==1.0.1 pytest==2.8.3 stubserver==1.0.1 pytest-timeout==1.2.0
 
 
 check_venv:

--- a/run_tests.py
+++ b/run_tests.py
@@ -41,7 +41,7 @@ test_suites = {
 
 
 def run_tests(keywords, index, args):
-    args = [sys.executable, '-m', 'pytest', '-vv',
+    args = [sys.executable, '-m', 'pytest', '-vv', '--timeout=600',
             '--junitxml', 'test-report-%s.xml' % index,
             '-k', keywords] + args
     log.info('Running %r', args)

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -19,6 +19,8 @@ from inspect import getsource
 from textwrap import dedent
 
 import time
+
+import pytest
 from boto.ec2.blockdevicemapping import BlockDeviceType
 from boto.exception import EC2ResponseError
 
@@ -224,6 +226,8 @@ class AWSAutoscaleTest(AbstractAWSAutoscaleTest):
     def testSpotAutoScale(self):
         self._test(spotInstances=True)
 
+
+@pytest.mark.timeout(1200)
 class AWSStaticAutoscaleTest(AWSAutoscaleTest):
     """
     Runs the tests on a statically provisioned cluster with autoscaling enabled.
@@ -239,6 +243,8 @@ class AWSStaticAutoscaleTest(AWSAutoscaleTest):
         runCommand.extend(toilOptions)
         self.sshUtil(runCommand)
 
+
+@pytest.mark.timeout(1200)
 class AWSRestartTest(AbstractAWSAutoscaleTest):
     """
     This test insures autoscaling works on a restarted Toil run

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -189,6 +189,7 @@ class AbstractAWSAutoscaleTest(ToilTest):
         assert len(self.getMatchingRoles(self.clusterName)) == 0
 
 
+@pytest.mark.timeout(1200)
 class AWSAutoscaleTest(AbstractAWSAutoscaleTest):
 
     def __init__(self, name):

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -304,6 +304,7 @@ class AWSRestartTest(AbstractAWSAutoscaleTest):
         self._test()
 
 
+@pytest.mark.timeout(1200)
 class PremptableDeficitCompensationTest(AbstractAWSAutoscaleTest):
 
     def __init__(self, name):

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -21,6 +21,8 @@ import shutil
 from subprocess import CalledProcessError, check_call
 import tempfile
 
+import pytest
+
 import toil
 import logging
 import toil.test.sort.sort
@@ -80,6 +82,7 @@ class UtilsTest(ToilTest):
             commandTokens.append('--failIfNotComplete')
         return commandTokens
 
+    @pytest.mark.timeout(1200)
     @needs_aws
     @integrative
     def testAWSProvisionerUtils(self):


### PR DESCRIPTION
This amends the call to `pytest` in run_test.py by adding the option `--timeout=600` which gives any particular test 10 minutes to run. I imagine this may be enough time for all of the tests. If it is not, we can increase the overall timeout by adjusting the option above, or any particularly lengthy tests can be given their own timeout by adding the decorator `@pytest.mark.timeout(XXX)` where `XXX` is some number of seconds.

This passes tests locally, but pytest-timeout may need to be installed on Jenkins for this to work.