### PR TITLE
Allow batch creation of jobs

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -993,7 +993,7 @@ class Job(JobLikeObject):
         """
         # set _config to determine user determined default values for resource requirements
         self._config = jobStore.config
-        return jobStore.create(JobNode.fromJob(self, command=command,
+        return jobStore.getJobGraph(JobNode.fromJob(self, command=command,
                                                predecessorNumber=predecessorNumber))
 
     def _makeJobGraphs(self, jobGraph, jobStore):
@@ -1005,6 +1005,9 @@ class Job(JobLikeObject):
             jobs = map(lambda successor:
                 successor._makeJobGraphs2(jobStore, jobsToJobGraphs), successors)
             jobGraph.stack.append(jobs)
+
+        #Write the jobs to the jobStore all at once
+        jobStore.batchCreate(jobsToJobGraphs.values())
         return jobsToJobGraphs
 
     def _makeJobGraphs2(self, jobStore, jobsToJobGraphs):

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -993,7 +993,7 @@ class Job(JobLikeObject):
         """
         # set _config to determine user determined default values for resource requirements
         self._config = jobStore.config
-        return jobStore.getJobGraph(JobNode.fromJob(self, command=command,
+        return jobStore.create(JobNode.fromJob(self, command=command,
                                                predecessorNumber=predecessorNumber))
 
     def _makeJobGraphs(self, jobGraph, jobStore):
@@ -1005,9 +1005,6 @@ class Job(JobLikeObject):
             jobs = map(lambda successor:
                 successor._makeJobGraphs2(jobStore, jobsToJobGraphs), successors)
             jobGraph.stack.append(jobs)
-
-        #Write the jobs to the jobStore all at once
-        jobStore.batchCreate(jobsToJobGraphs.values())
         return jobsToJobGraphs
 
     def _makeJobGraphs2(self, jobStore, jobsToJobGraphs):
@@ -1147,44 +1144,46 @@ class Job(JobLikeObject):
         self.checkJobGraphForDeadlocks()
 
         #Create the jobGraphs for followOns/children
-        jobsToJobGraphs = self._makeJobGraphs(jobGraph, jobStore)
+        with jobStore.batch():
+            jobsToJobGraphs = self._makeJobGraphs(jobGraph, jobStore)
         #Get an ordering on the jobs which we use for pickling the jobs in the
         #correct order to ensure the promises are properly established
         ordering = self.getTopologicalOrderingOfJobs()
         assert len(ordering) == len(jobsToJobGraphs)
 
-        # Temporarily set the jobStore locators for the promise call back functions
-        for job in ordering:
-            job.prepareForPromiseRegistration(jobStore)
-            def setForServices(serviceJob):
-                serviceJob.prepareForPromiseRegistration(jobStore)
-                for childServiceJob in serviceJob.service._childServices:
-                    setForServices(childServiceJob)
-            for serviceJob in job._services:
-                setForServices(serviceJob)
-
-        ordering.reverse()
-        assert self == ordering[-1]
-        if firstJob:
-            #If the first job we serialise all the jobs, including the root job
+        with jobStore.batch():
+            # Temporarily set the jobStore locators for the promise call back functions
             for job in ordering:
-                # Pickle the services for the job
-                job._serialiseServices(jobStore, jobsToJobGraphs[job], jobGraph)
-                # Now pickle the job
-                job._serialiseJob(jobStore, jobsToJobGraphs, jobGraph)
-        else:
-            #We store the return values at this point, because if a return value
-            #is a promise from another job, we need to register the promise
-            #before we serialise the other jobs
-            self._fulfillPromises(returnValues, jobStore)
-            #Pickle the non-root jobs
-            for job in ordering[:-1]:
-                # Pickle the services for the job
-                job._serialiseServices(jobStore, jobsToJobGraphs[job], jobGraph)
-                # Pickle the job itself
-                job._serialiseJob(jobStore, jobsToJobGraphs, jobGraph)
-            # Pickle any services for the job
-            self._serialiseServices(jobStore, jobGraph, jobGraph)
+                job.prepareForPromiseRegistration(jobStore)
+                def setForServices(serviceJob):
+                    serviceJob.prepareForPromiseRegistration(jobStore)
+                    for childServiceJob in serviceJob.service._childServices:
+                        setForServices(childServiceJob)
+                for serviceJob in job._services:
+                    setForServices(serviceJob)
+
+            ordering.reverse()
+            assert self == ordering[-1]
+            if firstJob:
+                #If the first job we serialise all the jobs, including the root job
+                for job in ordering:
+                    # Pickle the services for the job
+                    job._serialiseServices(jobStore, jobsToJobGraphs[job], jobGraph)
+                    # Now pickle the job
+                    job._serialiseJob(jobStore, jobsToJobGraphs, jobGraph)
+            else:
+                #We store the return values at this point, because if a return value
+                #is a promise from another job, we need to register the promise
+                #before we serialise the other jobs
+                self._fulfillPromises(returnValues, jobStore)
+                #Pickle the non-root jobs
+                for job in ordering[:-1]:
+                    # Pickle the services for the job
+                    job._serialiseServices(jobStore, jobsToJobGraphs[job], jobGraph)
+                    # Pickle the job itself
+                    job._serialiseJob(jobStore, jobsToJobGraphs, jobGraph)
+                # Pickle any services for the job
+                self._serialiseServices(jobStore, jobGraph, jobGraph)
 
     def _serialiseFirstJob(self, jobStore):
         """

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -629,6 +629,24 @@ class AbstractJobStore(object):
         raise NotImplementedError()
 
     @abstractmethod
+    def getJobGraph(self, jobNode):
+        """
+        Creates a job graph from the given job node without writing it to the job store.
+
+        :rtype: toil.jobGraph.JobGraph
+        """
+        raise NotImplementedError()
+    
+    @abstractmethod
+    def batchCreate(self, jobGraphs):
+        """
+        Writes several job graphs to the jobstore with one query.
+
+        :rtype: None
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def exists(self, jobStoreID):
         """
         Indicates whether the job with the specified jobStoreID exists in the job store

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -619,30 +619,26 @@ class AbstractJobStore(object):
     # existence of jobs
     ##########################################
 
+    @contextmanager
+    def batch(self):
+        """
+        All calls to create() with this context manager active will be performed in a batch
+        after the context manager is released.
+
+        :rtype: None
+        """
+        self._batchedJobGraphs = []
+        yield
+        for jobGraph in self._batchedJobGraphs:
+            self.update(jobGraph)
+        self._batchedJobGraphs = None
+
     @abstractmethod
     def create(self, jobNode):
         """
         Creates a job graph from the given job node & writes it to the job store.
 
         :rtype: toil.jobGraph.JobGraph
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def getJobGraph(self, jobNode):
-        """
-        Creates a job graph from the given job node without writing it to the job store.
-
-        :rtype: toil.jobGraph.JobGraph
-        """
-        raise NotImplementedError()
-    
-    @abstractmethod
-    def batchCreate(self, jobGraphs):
-        """
-        Writes several job graphs to the jobstore with one query.
-
-        :rtype: None
         """
         raise NotImplementedError()
 

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -627,11 +627,7 @@ class AbstractJobStore(object):
 
         :rtype: None
         """
-        self._batchedJobGraphs = []
         yield
-        for jobGraph in self._batchedJobGraphs:
-            self.update(jobGraph)
-        self._batchedJobGraphs = None
 
     @abstractmethod
     def create(self, jobNode):

--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -248,26 +248,35 @@ class AWSJobStore(AbstractJobStore):
             item = SDBHelper.binaryToAttributes(binary)
         return item
 
-    def getJobGraph(self, jobNode):
+    jobsPerBatchInsert = 25
+
+    @contextmanager
+    def batch(self):
+        self._batchedJobGraphs = []
+        yield
+        batches = [self._batchedJobGraphs[i:i + self.jobsPerBatchInsert] for i in range(0, len(self._batchedJobGraphs), self.jobsPerBatchInsert)]
+
+        for batch in batches:
+            items = {jobGraph.jobStoreID:self._awsJobToItem(jobGraph) for jobGraph in batch}
+            for attempt in retry_sdb():
+                with attempt:
+                    assert self.jobsDomain.batch_put_attributes(items)
+        self._batchedJobGraphs = None
+            
+
+    def create(self, jobNode):
         jobStoreID = self._newJobID()
         log.debug("Creating job %s for '%s'",
                   jobStoreID, '<no command>' if jobNode.command is None else jobNode.command)
         job = JobGraph.fromJobNode(jobNode, jobStoreID=jobStoreID, tryCount=self._defaultTryCount())
+        if hasattr(self, "_batchedJobGraphs") and self._batchedJobGraphs is not None:
+            self._batchedJobGraphs.append(job)
+        else:
+            item = self._awsJobToItem(job)
+            for attempt in retry_sdb():
+                with attempt:
+                    assert self.jobsDomain.put_attributes(job.jobStoreID, item)
         return job
-
-    def create(self, jobNode):
-        jobGraph = self.getJobGraph(jobNode)
-        item = self._awsJobToItem(jobGraph)
-        for attempt in retry_sdb():
-            with attempt:
-                assert self.jobsDomain.put_attributes(jobGraph.jobStoreID, item)
-        return jobGraph
-
-    def batchCreate(self, jobGraphs):
-        items = {job.jobStoreID:self._awsJobToItem(job) for job in jobGraphs}
-        for attempt in retry_sdb():
-            with attempt:
-                assert self.jobsDomain.batch_put_attributes(items)
 
     def exists(self, jobStoreID):
         for attempt in retry_sdb():

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -225,24 +225,27 @@ class AzureJobStore(AbstractJobStore):
 
         logger.debug("Processed %d total jobs" % total_processed)
 
-    def getJobGraph(self, jobNode):
+    def create(self, jobNode):
         jobStoreID = self._newJobID()
         job = AzureJob.fromJobNode(jobNode, jobStoreID, self._defaultTryCount())
+        if hasattr(self, "_batchedJobGraphs") and self._batchedJobGraphs is not None:
+            self._batchedJobGraphs.append(job)
+        else:
+            entity = job.toItem(chunkSize=self.jobChunkSize)
+            entity['RowKey'] = jobStoreID
+            self.jobItems.insert_entity(entity=entity)
         return job
 
-    def create(self, jobNode):
-        job = self.getJobGraph(jobNode)
-        entity = job.toItem(chunkSize=self.jobChunkSize)
-        entity['RowKey'] = job.jobStoreID
-        self.jobItems.insert_entity(entity=entity)
-        return job
-
-    def batchCreate(self, jobGraphs):
-        with self.jobItems.batch() as batch:
-            for job in jobGraphs:
+    @contextmanager
+    def batch(self):
+        self._batchedJobGraphs = []
+        yield
+        with self.tableService.batch('jobItems') as batch:
+            for job in self._batchedJobGraphs:
                 entity = job.toItem(chunkSize=self.jobChunkSize)
-                entity['RowKey'] = job.jobStoreID
+                entity["RowKey"] = job.jobStoreID
                 batch.insert_entity(entity)
+        self._batchedJobGraphs = None
 
     def exists(self, jobStoreID):
         if self.jobItems.get_entity(row_key=jobStoreID) is None:

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -89,7 +89,7 @@ class FileJobStore(AbstractJobStore):
     # existence of jobs
     ##########################################
 
-    def getJobGraph(self, jobNode):
+    def create(self, jobNode):
         # The absolute path to the job directory.
         absJobDir = tempfile.mkdtemp(prefix="job", dir=self._getTempSharedDir())
         # Sub directory to put temporary files associated with the job in
@@ -97,17 +97,11 @@ class FileJobStore(AbstractJobStore):
         # Make the job
         job = JobGraph.fromJobNode(jobNode, jobStoreID=self._getRelativePath(absJobDir),
                                    tryCount=self._defaultTryCount())
+        if hasattr(self, "_batchedJobGraphs") and self._batchedJobGraphs is not None:
+            self._batchedJobGraphs.append(job)
+        else:
+            self.update(job)
         return job
-        
-    def create(self, jobNode):
-        jobGraph = self.getJobGraph(jobNode)
-        # Write job file to disk
-        self.update(jobGraph)
-        return jobGraph
-
-    def batchCreate(self, jobGraphs):
-        for jobGraph in jobGraphs:
-            self.update(jobGraph)
 
     def exists(self, jobStoreID):
         return os.path.exists(self._getJobFileName(jobStoreID))

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -89,7 +89,7 @@ class FileJobStore(AbstractJobStore):
     # existence of jobs
     ##########################################
 
-    def create(self, jobNode):
+    def getJobGraph(self, jobNode):
         # The absolute path to the job directory.
         absJobDir = tempfile.mkdtemp(prefix="job", dir=self._getTempSharedDir())
         # Sub directory to put temporary files associated with the job in
@@ -97,9 +97,17 @@ class FileJobStore(AbstractJobStore):
         # Make the job
         job = JobGraph.fromJobNode(jobNode, jobStoreID=self._getRelativePath(absJobDir),
                                    tryCount=self._defaultTryCount())
-        # Write job file to disk
-        self.update(job)
         return job
+        
+    def create(self, jobNode):
+        jobGraph = self.getJobGraph(jobNode)
+        # Write job file to disk
+        self.update(jobGraph)
+        return jobGraph
+
+    def batchCreate(self, jobGraphs):
+        for jobGraph in jobGraphs:
+            self.update(jobGraph)
 
     def exists(self, jobStoreID):
         return os.path.exists(self._getJobFileName(jobStoreID))

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -103,6 +103,14 @@ class FileJobStore(AbstractJobStore):
             self.update(job)
         return job
 
+    @contextmanager
+    def batch(self):
+        self._batchedJobGraphs = []
+        yield
+        for jobGraph in self._batchedJobGraphs:
+            self.update(jobGraph)
+        self._batchedJobGraphs = None
+
     def exists(self, jobStoreID):
         return os.path.exists(self._getJobFileName(jobStoreID))
 

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -112,14 +112,22 @@ class GoogleJobStore(AbstractJobStore):
                 except boto.exception.GSResponseError:
                     pass
 
-    def create(self, jobNode):
+    def getJobGraph(self, jobNode):
         jobStoreID = self._newID()
         job = JobGraph(jobStoreID=jobStoreID, unitName=jobNode.name, jobName=jobNode.job,
                        command=jobNode.command, remainingRetryCount=self._defaultTryCount(),
                        logJobStoreFileID=None, predecessorNumber=jobNode.predecessorNumber,
                        **jobNode._requirements)
+        return job
+
+    def create(self, jobNode):
+        job = self.getJobGraph(jobNode)
         self._writeString(jobStoreID, cPickle.dumps(job, protocol=cPickle.HIGHEST_PROTOCOL))
         return job
+
+    def batchCreate(self, jobGraphs):
+        for job in jobGraphs:
+            self._writeString(jobStoreID, cPickle.dumps(job, protocol=cPickle.HIGHEST_PROTOCOL))
 
     def exists(self, jobStoreID):
         # used on job files, which will be encrypted if avaliable

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -112,22 +112,14 @@ class GoogleJobStore(AbstractJobStore):
                 except boto.exception.GSResponseError:
                     pass
 
-    def getJobGraph(self, jobNode):
-        jobStoreID = self._newID()
-        job = JobGraph(jobStoreID=jobStoreID, unitName=jobNode.name, jobName=jobNode.job,
-                       command=jobNode.command, remainingRetryCount=self._defaultTryCount(),
-                       logJobStoreFileID=None, predecessorNumber=jobNode.predecessorNumber,
-                       **jobNode._requirements)
-        return job
-
     def create(self, jobNode):
         job = self.getJobGraph(jobNode)
         self._writeString(jobStoreID, cPickle.dumps(job, protocol=cPickle.HIGHEST_PROTOCOL))
-        return job
-
-    def batchCreate(self, jobGraphs):
-        for job in jobGraphs:
+        if hasattr(self, "_batchedJobGraphs") and self._batchedJobGraphs is not None:
+            self._batchedJobGraphs.append(job)
+        else:
             self._writeString(jobStoreID, cPickle.dumps(job, protocol=cPickle.HIGHEST_PROTOCOL))
+        return job
 
     def exists(self, jobStoreID):
         # used on job files, which will be encrypted if avaliable

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -361,7 +361,19 @@ class AbstractJobStoreTest:
             self.assertFalse(master.exists(jobOnMaster.jobStoreID))
             # TODO: Who deletes the shared files?
 
-
+        def testBatchCreate(self):
+            master = self.master
+            masterRequirements = dict(memory=12, cores=34, disk=35, preemptable=True)
+            jobGraphs = []
+            for i in range(10):
+                overlargeJobNodeOnMaster = JobNode(command='master-overlarge',
+                                    requirements=masterRequirements,
+                                    jobName='test-overlarge', unitName='onMaster',
+                                    jobStoreID=None, predecessorNumber=0)
+                jobGraphs.append(master.getJobGraph(overlargeJobNodeOnMaster))
+            master.batchCreate(jobGraphs)
+            for jobGraph in jobGraphs:
+                self.assertTrue(master.exists(jobGraph.jobStoreID))
 
         def _prepareTestFile(self, store, size=None):
             """

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -365,13 +365,13 @@ class AbstractJobStoreTest:
             master = self.master
             masterRequirements = dict(memory=12, cores=34, disk=35, preemptable=True)
             jobGraphs = []
-            for i in range(10):
-                overlargeJobNodeOnMaster = JobNode(command='master-overlarge',
-                                    requirements=masterRequirements,
-                                    jobName='test-overlarge', unitName='onMaster',
-                                    jobStoreID=None, predecessorNumber=0)
-                jobGraphs.append(master.getJobGraph(overlargeJobNodeOnMaster))
-            master.batchCreate(jobGraphs)
+            with master.batch():
+                for i in range(100):
+                    overlargeJobNodeOnMaster = JobNode(command='master-overlarge',
+                                        requirements=masterRequirements,
+                                        jobName='test-overlarge', unitName='onMaster',
+                                        jobStoreID=None, predecessorNumber=0)
+                    jobGraphs.append(master.create(overlargeJobNodeOnMaster))
             for jobGraph in jobGraphs:
                 self.assertTrue(master.exists(jobGraph.jobStoreID))
 


### PR DESCRIPTION
Create SDB items representing the job graph with a batch insertion, to avoid large numbers of transactions when there are many child jobs. 