### PR TITLE
Fix getEmptyFileStoreID on AWS and Azure JobStores (resolves #1705)

### DIFF
--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -344,6 +344,9 @@ class AWSJobStore(AbstractJobStore):
 
     def getEmptyFileStoreID(self, jobStoreID=None):
         info = self.FileInfo.create(jobStoreID)
+        with info.uploadStream() as _:
+            # Empty
+            pass
         info.save()
         log.debug("Created %r.", info)
         return info.fileID

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -377,6 +377,7 @@ class AzureJobStore(AbstractJobStore):
         jobStoreFileID = self._newFileID()
         with self._uploadStream(jobStoreFileID, self.files) as _:
             pass
+        self._associateFileWithJob(jobStoreFileID, jobStoreID)
         return jobStoreFileID
 
     @contextmanager

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -375,11 +375,8 @@ class AzureJobStore(AbstractJobStore):
 
     def getEmptyFileStoreID(self, jobStoreID=None):
         jobStoreFileID = self._newFileID()
-        for attempt in retry_azure(timeout=45):
-            with attempt:
-                self.files.put_blob(blob_name=jobStoreFileID, blob='',
-                                    x_ms_blob_type='BlockBlob')
-        self._associateFileWithJob(jobStoreFileID, jobStoreID)
+        with self._uploadStream(jobStoreFileID, self.files) as _:
+            pass
         return jobStoreFileID
 
     @contextmanager

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -738,6 +738,16 @@ class AbstractJobStoreTest:
             cleaner = self._createJobStore()
             cleaner.destroy()
 
+        def testEmptyFileStoreIDIsReadable(self):
+            """Simply creates an empty fileStoreID and attempts to read from it."""
+            id = self.master.getEmptyFileStoreID()
+            fh, path = tempfile.mkstemp()
+            try:
+                self.master.readFile(id, path)
+                self.assertTrue(os.path.isfile(path))
+            finally:
+                os.unlink(path)
+
         def _largeLogEntrySize(self):
             """
             Sub-classes may want to override these in order to maximize test coverage


### PR DESCRIPTION
The old version didn't create an empty file. This also adds a test to
ensure it works with other job stores.