### PR TITLE
Fix AWS readFileStream deadlock on partial reads (resolves #1748)

### DIFF
--- a/src/toil/jobStores/utils.py
+++ b/src/toil/jobStores/utils.py
@@ -119,13 +119,6 @@ class WritablePipe(object):
                 os.close(readable_fh)
 
 
-# FIXME: Unfortunately these two classes are almost an exact mirror image of each other.
-# Basically, read and write are swapped. The only asymmetry lies in how shutdown is handled. I
-# tried generalizing but the code becomes inscrutable. Until I (or someone else) has a better
-# idea how to solve this, I think its better to have code that is readable at the expense of
-# duplication.
-
-
 class ReadablePipe(object):
     """
     An object-oriented wrapper for os.pipe. Clients should subclass it, implement
@@ -201,10 +194,14 @@ class ReadablePipe(object):
         raise NotImplementedError()
 
     def _writer(self):
-        with os.fdopen(self.writable_fh, 'w') as writable:
-            # FIXME: another race here, causing a redundant attempt to close in the main thread
-            self.writable_fh = None  # signal to parent thread that we've taken over
-            self.writeTo(writable)
+        try:
+            with os.fdopen(self.writable_fh, 'w') as writable:
+                self.writeTo(writable)
+        except IOError as e:
+            # The file may have been closed by the reading thread,
+            # which is OK.
+            if e.strerror != 'Broken pipe':
+                raise
 
     def __init__(self):
         super(ReadablePipe, self).__init__()
@@ -220,17 +217,11 @@ class ReadablePipe(object):
         return self.readable
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        try:
-            if exc_type is None:
-                if self.thread is not None:
-                    # reraises any exception that was raised in the thread
-                    self.thread.join()
-        finally:
-            self.readable.close()
-            # The responsibility for closing the writable end is generally that of the writer
-            # thread. To cover the small window before the writer takes over we also close it here.
-            writable_fh = self.writable_fh
-            if writable_fh is not None:
-                # FIXME: This is still racy. The writer thread could close it now, and someone
-                # else may immediately open a new file, reusing the file handle.
-                os.close(writable_fh)
+        # Close the write end of the pipe. The writing thread may
+        # still be writing to the other end, but this will wake it up
+        # if that's the case.
+        self.readable.close()
+        if exc_type is None:
+            if self.thread is not None:
+                # reraises any exception that was raised in the thread
+                self.thread.join()

--- a/src/toil/jobStores/utils.py
+++ b/src/toil/jobStores/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import errno
 from abc import ABCMeta
 from abc import abstractmethod
 
@@ -105,10 +106,14 @@ class WritablePipe(object):
             self.writable.close()
             # Closeing the writable end will send EOF to the readable and cause the reader thread
             # to finish.
+            if self.thread is not None:
+                # reraises any exception that was raised in the thread
+                self.thread.join()
+        except:
             if exc_type is None:
-                if self.thread is not None:
-                    # reraises any exception that was raised in the thread
-                    self.thread.join()
+                # Only raise the child exception if there wasn't
+                # already an exception in the main thread
+                raise
         finally:
             # The responsibility for closing the readable end is generally that of the reader
             # thread. To cover the small window before the reader takes over we also close it here.
@@ -200,7 +205,7 @@ class ReadablePipe(object):
         except IOError as e:
             # The other side of the pipe may have been closed by the
             # reading thread, which is OK.
-            if e.strerror != 'Broken pipe':
+            if e.errno != errno.EPIPE:
                 raise
 
     def __init__(self):
@@ -221,7 +226,12 @@ class ReadablePipe(object):
         # still be writing to the other end, but this will wake it up
         # if that's the case.
         self.readable.close()
-        if exc_type is None:
+        try:
             if self.thread is not None:
                 # reraises any exception that was raised in the thread
                 self.thread.join()
+        except:
+            if exc_type is None:
+                # Only raise the child exception if there wasn't
+                # already an exception in the main thread
+                raise

--- a/src/toil/jobStores/utils.py
+++ b/src/toil/jobStores/utils.py
@@ -198,8 +198,8 @@ class ReadablePipe(object):
             with os.fdopen(self.writable_fh, 'w') as writable:
                 self.writeTo(writable)
         except IOError as e:
-            # The file may have been closed by the reading thread,
-            # which is OK.
+            # The other side of the pipe may have been closed by the
+            # reading thread, which is OK.
             if e.strerror != 'Broken pipe':
                 raise
 
@@ -217,7 +217,7 @@ class ReadablePipe(object):
         return self.readable
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        # Close the write end of the pipe. The writing thread may
+        # Close the read end of the pipe. The writing thread may
         # still be writing to the other end, but this will wake it up
         # if that's the case.
         self.readable.close()

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 
+import pytest
 import SocketServer
 import hashlib
 import logging
@@ -712,6 +713,25 @@ class AbstractJobStoreTest:
             # Make sure we have the right number of jobs. Cannot be precise because of limitations
             # on the jobs iterator for certain cloud providers
             self.assertTrue(len(allJobs) <= 3001)
+
+        # NB: the 'thread' method seems to be needed here to actually
+        # ensure the timeout is raised, probably because the only
+        # "live" thread doesn't hold the GIL.
+        @pytest.mark.timeout(45, method='thread')
+        def testPartialReadFromStream(self):
+            """Test whether readFileStream will deadlock on a partial read."""
+            job = self.master.create(self.arbitraryJob)
+            with self.master.writeFileStream(job.jobStoreID) as (f, fileID):
+                # Write enough data to make sure the writer thread
+                # will get blocked on the write. Technically anything
+                # greater than the pipe buffer size plus the libc
+                # buffer size (64K + 4K(?))  should trigger this bug,
+                # but this gives us a lot of extra room just to be
+                # sure.
+                f.write('a' * 300000)
+            with self.master.readFileStream(fileID) as f:
+                self.assertEquals(f.read(1), "a")
+            # If it times out here, there's a deadlock
 
         @abstractmethod
         def _corruptJobStore(self):


### PR DESCRIPTION
This should also fix the problem for jobStores other than AWS, but I haven't tested it on anything else yet. I added a unit test to catch this error in all jobStores, so if the tests pass everything should be OK.

The basic idea is to always close the file on exit in the reader thread, which wakes the writer up and causes an exception in its thread. Thanks to @diekhans for the suggestion.