### PR TITLE
Update worker instance before checking block_device_mapping (resolves #1742)

### DIFF
--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -277,7 +277,7 @@ class AWSStaticAutoscaleTest(AWSAutoscaleTest):
         # test that workers have expected storage size
         # just use the first worker
         worker = workers[0]
-        wait_instances_running(ctx.ec2, [worker])
+        worker = next(wait_instances_running(ctx.ec2, [worker]))
         rootBlockDevice = worker.block_device_mapping["/dev/xvda"]
         self.assertTrue(isinstance(rootBlockDevice, BlockDeviceType))
         rootVolume = ctx.ec2.get_all_volumes(volume_ids=[rootBlockDevice.volume_id])[0]


### PR DESCRIPTION
credit to fix from @joelarmstrong [here](https://github.com/BD2KGenomics/toil/pull/1743#issuecomment-314181619).

Hopefully this should fix #1742 for good.