### PR TITLE
Add local testing targets (resolves #1741)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ integration_test_local: check_venv check_build_reqs sdist push_docker
 # FIXME when they are removed add check_running_on_jenkins to the jenkins targets
 test_parallel: jenkins_test_parallel
 
-test_integration: jenkins_test_integration
+integration_test: jenkins_test_integration
 
 # This target is designed only for use on Jenkins
 jenkins_test_parallel: check_venv check_build_reqs docker
@@ -288,7 +288,7 @@ check_cpickle:
 		check_cpickle \
 		develop clean_develop \
 		sdist clean_sdist \
-		test test_all test_appliance test_parallel integration_test \
+		test test_offline test_parallel integration_test \
 		jenkins_test_parallel jenkins_test_integration \
 		pypi clean_pypi \
 		docs clean_docs \

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,25 @@ uploaded to PyPI.
 
 The 'docs' target uses Sphinx to create HTML documentation in the docs/_build directory
 
-The 'test' target runs Toil's unit tests serially with pytest.
+The 'test' target runs Toil's unit tests serially with pytest. It will run some docker tests and
+setup. If you wish to avoid this, use the 'test_local' target instead. Note: this target does not
+capture output from the terminal. For any of the test targets, set the 'tests' variable to run a
+particular test, e.g.
 
-The 'test_parallel' target runs Toil's unit tests in parallel and generates a test report
-from the results. Set the 'tests' variable to run a particular test, e.g.
+	make test tests=src/toil/test/sort/sortTest.py::SortTest::testSort
 
-	make test_parallel tests=src/toil/test/sort/sortTest.py::SortTest::testSort
+The 'test_local' target is similar to 'test' but it skips the docker dependent tests and their
+setup.
+
+The 'integration_test_local' target runs toil's integration tests. This are more thorough but also
+more costly than the regular unit tests. For the AWS integration tests to run, the environment
+variable 'TOIL_AWS_KEYNAME' must be set. This user will be chargedfor expenses acrued during the
+test. This test does not capture terminal output.
+
+The 'integration_test' target is the same as the previous except that it does capture output.
+
+The 'test_parallel' target runs Toil's unit tests in parallel and generates an XML test report
+from the results. It is designed to be used only in Jenkins.
 
 The 'pypi' target publishes the current commit of Toil to PyPI after enforcing that the working
 copy and the index are clean.
@@ -75,6 +88,7 @@ SHELL=bash
 python=python2.7
 pip=pip2.7
 tests=src
+pytest_args_local=-vv -s --timeout=600
 extras=
 
 dist_version:=$(shell $(python) version_template.py distVersion)
@@ -128,15 +142,28 @@ clean_sdist:
 	- rm src/toil/version.py
 
 
+# This target will skip building docker and all docker based tests
+test_local: check_venv check_build_reqs
+	@printf "$(cyan)All docker related tests will be skipped.$(normal)\n"
+	TOIL_SKIP_DOCKER=True \
+		$(python) -m pytest $(pytest_args_local) $(tests)
+
+# For running integration tests locally (uses the -s argument for pyTest)
+# probably should do this not in parallel...
+integration_test_local: check_venv check_build_reqs sdist push_docker
+	TOIL_TEST_INTEGRATIVE=True $(python) run_tests.py integration-test $(tests) -s
+
+# The hot deployment test needs the docker appliance
 test: check_venv check_build_reqs docker
 	TOIL_APPLIANCE_SELF=$(docker_registry)/$(docker_base_name):$(docker_tag) \
-	    $(python) -m pytest -vv $(tests)
+	    $(python) -m pytest $(pytest_args_local) $(tests)
 
 
+# This target is designed only for use on Jenkins
 test_parallel: check_venv check_build_reqs docker
 	$(python) run_tests.py test $(tests)
 
-
+# This target is designed only for use on Jenkins
 integration_test: check_venv check_build_reqs sdist push_docker
 	TOIL_TEST_INTEGRATIVE=True $(python) run_tests.py integration-test $(tests)
 
@@ -256,7 +283,7 @@ check_cpickle:
 		check_cpickle \
 		develop clean_develop \
 		sdist clean_sdist \
-		test \
+		test test_all test_appliance test_parallel integration_test \
 		pypi clean_pypi \
 		docs clean_docs \
 		clean \

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SHELL=bash
 python=python2.7
 pip=pip2.7
 tests=src
-pytest_args_local=-vv -s --timeout=600
+pytest_args_local=-vv --timeout=600
 extras=
 
 dist_version:=$(shell $(python) version_template.py distVersion)

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -65,6 +65,21 @@ To invoke all integration tests, including AWS tests, use
 
     $ export TOIL_AWS_KEYNAME=<aws_keyname>; make integration_test
 
+To skip building the Docker appliance and run tests that have no docker dependency use
+
+::
+
+    $ make test_offline
+
+To make integration tests easier to debug locally one can use
+
+::
+
+    $ make integration_test_local
+
+which runs the integration tests in serial and doesn't redirect output. This makes it appears on the terminal as
+expected.
+
 
 .. topic:: Installing Docker with Quay
 

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -448,6 +448,8 @@ def needs_cwl(test_item):
 def needs_appliance(test_item):
     import json
     test_item = _mark_test('appliance', test_item)
+    if less_strict_bool(os.getenv('TOIL_SKIP_DOCKER')):
+        return unittest.skip('Skipping docker test.')(test_item)
     if next(which('docker'), None):
         image = applianceSelf()
         try:
@@ -457,7 +459,8 @@ def needs_appliance(test_item):
         else:
             images = {i['Id'] for i in json.loads(images) if image in i['RepoTags']}
         if len(images) == 0:
-            return unittest.skip("Cannot find appliance image %s. Be sure to run 'make docker' "
+            return unittest.skip("Cannot find appliance image %s. Use 'make test' target to "
+                                 "automatically build appliance, or just run 'make docker' "
                                  "prior to running this test." % image)(test_item)
         elif len(images) == 1:
             return test_item


### PR DESCRIPTION
This PR adds two new targets to the makefile for testing locally:
- `test_offline` and
- `integration_test_local`.

The `test_offline` target gives a cleaner interface to run unit tests without running the docker/appliance tests. Previously, one had to set the environment variable `TOIL_DOCKER_REGISTRY` to the empty string and _then_ run `make test`. Now, one can simply run `make test_offline` and get the results that they expect. Help messages were changed to clarify the new process. Name taken from 

The `integration_test_local` target now runs in series and output is not captured. This can still use some improvement however because running all of the tests in series takes a looong time and produces a _lot_ of output.

Other changes:
- target that are _only_ designed to be run on Jenkins have updated names (previously this was `test_parallel` and `integration_test`) prepended with `jenkins_`. The old target names still exist temporarily, but will be phased out soon. Probably no one was using the to develop locally anyway.
- targets that meant to run locally: `test`, `test_offline`, and `integration_test_local` are now all run using pytest's `-s` option which allows the output to be printed to the stdout like one expects.

Things that still need to happen (though not necessarily right now):
- add to the documentation information on how to use these targets, etc.
- The "jenkins only" targets should depend upon the `check_running_on_jenkins` targets. This was held off because it's possible someone _is_ using these targets locally and this would be disruptive.