### PR TITLE
Add option to link files when importing into fileJobStore (resolves #1755)

### DIFF
--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -24,14 +24,20 @@ def _parasolOptions(addOptionFn):
                      "batch is created for jobs with a a unique set of resource requirements. "
                      "default=%i" % 1000)
 
+
 def _singleMachineOptions(addOptionFn):
     addOptionFn("--scale", dest="scale", default=None,
-        help=("A scaling factor to change the value of all submitted tasks's submitted cores. "
-              "Used in singleMachine batch system. default=%s" % 1))
+                help=("A scaling factor to change the value of all submitted tasks's submitted cores. "
+                      "Used in singleMachine batch system. default=%s" % 1))
+    addOptionFn("--linkImports", dest="linkImports", default=False, action='store_true',
+                help=("When using Toil's importFile function for staging, input files are copied to the job store. "
+                      "Specifying this option saves space by hard-linking imported files. As long as caching is "
+                      "enabled Toil will protect the file automatically by changing the permissions to read-only."))
+
 
 def _mesosOptions(addOptionFn):
     addOptionFn("--mesosMaster", dest="mesosMasterAddress", default=None,
-        help=("The host and port of the Mesos master separated by colon. default=%s" % 'localhost:5050'))
+                help=("The host and port of the Mesos master separated by colon. default=%s" % 'localhost:5050'))
 
 # Built in batch systems that have options
 _OPTIONS = [
@@ -41,6 +47,7 @@ _OPTIONS = [
     ]
 
 _options = list(_OPTIONS)
+
 
 def addOptionsDefinition(optionsDefinition):
     _options.append(optionsDefinition)
@@ -54,11 +61,11 @@ def setOptions(config, setOption):
 
     batchSystem.setOptions(setOption)
 
-def addOptions(addOptionFn):
 
+def addOptions(addOptionFn):
     addOptionFn("--batchSystem", dest="batchSystem", default=defaultBatchSystem(),
-              help=("The type of batch system to run the job(s) with, currently can be one "
-                    "of %s'. default=%s" % (', '.join(uniqueNames()), defaultBatchSystem())))
+                help=("The type of batch system to run the job(s) with, currently can be one "
+                      "of %s'. default=%s" % (', '.join(uniqueNames()), defaultBatchSystem())))
     addOptionFn("--disableHotDeployment", dest="disableHotDeployment", action='store_true', default=None,
                 help=("Should hot-deployment of the user script be deactivated? If True, the user "
                       "script/package should be present at the same location on all workers. "
@@ -68,17 +75,17 @@ def addOptions(addOptionFn):
         o(addOptionFn)
 
 def setDefaultOptions(config):
-    '''
+    """
     Set default options for builtin batch systems. This is required if a Config
     object is not constructed from an Options object.
-    '''
-
+    """
     config.batchSystem = "singleMachine"
     config.disableHotDeployment = False
     config.environment = {}
 
     # single machine
     config.scale = 1
+    config.linkImports = False
 
     # mesos
     config.mesosMasterAddress = 'localhost:5050'

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -195,6 +195,7 @@ class Config(object):
         setOption("mesosMasterAddress")
         setOption("parasolCommand")
         setOption("parasolMaxBatches", int, iC(1))
+        setOption("linkImports")
 
         setOption("environment", parseSetEnv)
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -435,11 +435,10 @@ def _addOptions(addGroupFn, config):
     addOptionFn('--defaultPreemptable', dest='defaultPreemptable', action='store_true')
     addOptionFn("--readGlobalFileMutableByDefault", dest="readGlobalFileMutableByDefault",
                 action='store_true', default=None, help='Toil disallows modification of read '
-                                                        'global files by default. This flag makes '
-                                                        'it makes read file mutable by default, '
-                                                        'however it also defeats the purpose of '
-                                                        'shared caching via hard links to save '
-                                                        'space. Default is False')
+                                                        'global files. Setting this flag causes '
+                                                        'them to be mutable. Unfortunately, this '
+                                                        'prevents saving space by caching files '
+                                                        'with hardlinks.')
     addOptionFn('--maxCores', dest='maxCores', default=None, metavar='INT',
                 help='The maximum number of CPU cores to request from the batch system at any one '
                      'time. Standard suffixes like K, Ki, M, Mi, G or Gi are supported. Default '

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -318,14 +318,16 @@ def _addOptions(addGroupFn, config):
                              "Allows the restart of an existing workflow")
     addOptionFn("--restart", dest="restart", default=None, action="store_true",
                 help="If --restart is specified then will attempt to restart existing workflow "
-                "at the location pointed to by the --jobStore option. Will raise an exception if the workflow does not exist")
+                     "at the location pointed to by the --jobStore option. Will raise an exception "
+                     "if the workflow does not exist")
 
     #
     #Batch system options
     #
 
     addOptionFn = addGroupFn("toil options for specifying the batch system",
-                             "Allows the specification of the batch system, and arguments to the batch system/big batch system (see below).")
+                             "Allows the specification of the batch system, and arguments to the "
+                             "batch system/big batch system (see below).")
     addBatchOptions(addOptionFn)
 
     #
@@ -467,7 +469,8 @@ def _addOptions(addGroupFn, config):
                             "the job may be longer). default=%s" % config.maxJobDuration))
     addOptionFn("--rescueJobsFrequency", dest="rescueJobsFrequency", default=None,
                       help=("Period of time to wait (in seconds) between checking for "
-                            "missing/overlong jobs, that is jobs which get lost by the batch system. Expert parameter. default=%s" % config.rescueJobsFrequency))
+                            "missing/overlong jobs, that is jobs which get lost by the batch "
+                            "system. Expert parameter. default=%s" % config.rescueJobsFrequency))
 
     #
     #Misc options

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -164,15 +164,19 @@ class FileJobStore(AbstractJobStore):
     # Functions that deal with temporary files associated with jobs
     ##########################################
 
-    def _copyOrLink(self, url, path):
+    def _copyOrLink(self, srcURL, destPath):
         # linking is not done be default because of issue #1755
+        srcPath = self._extractPathFromUrl(srcURL)
         if self.linkImports:
             try:
-                os.link(os.path.realpath(self._extractPathFromUrl(url)), path)
+                os.link(os.path.realpath(srcPath), destPath)
             except OSError:
-                shutil.copyfile(self._extractPathFromUrl(url), path)
+                shutil.copyfile(srcPath, destPath)
+            else:
+                # make imported files read-only if they're linked for protection
+                os.chmod(destPath, 0o444)
         else:
-            shutil.copyfile(self._extractPathFromUrl(url), path)
+            shutil.copyfile(srcPath, destPath)
 
     def _importFile(self, otherCls, url, sharedFileName=None):
         if issubclass(otherCls, FileJobStore):

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -189,7 +189,6 @@ class FileJobStore(AbstractJobStore):
             else:
                 self._requireValidSharedFileName(sharedFileName)
                 path = self._getSharedFilePath(sharedFileName)
-                # linking is not done be default because of issue #1755
                 self._copyOrLink(url, path)
                 return None
         else:

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -60,6 +60,7 @@ class FileJobStore(AbstractJobStore):
         logger.debug("Path to job store directory is '%s'.", self.jobStoreDir)
         # Directory where temporary files go
         self.tempFilesDir = os.path.join(self.jobStoreDir, 'tmp')
+        self.linkImports = None
 
     def initialize(self, config):
         try:
@@ -70,6 +71,7 @@ class FileJobStore(AbstractJobStore):
             else:
                 raise
         os.mkdir(self.tempFilesDir)
+        self.linkImports = config.linkImports
         super(FileJobStore, self).initialize(config)
 
     def resume(self):
@@ -162,24 +164,29 @@ class FileJobStore(AbstractJobStore):
     # Functions that deal with temporary files associated with jobs
     ##########################################
 
+    def _copyOrLink(self, url, path):
+        # linking is not done be default because of issue #1755
+        if self.linkImports:
+            try:
+                os.link(os.path.realpath(self._extractPathFromUrl(url)), path)
+            except OSError:
+                shutil.copyfile(self._extractPathFromUrl(url), path)
+        else:
+            shutil.copyfile(self._extractPathFromUrl(url), path)
+
     def _importFile(self, otherCls, url, sharedFileName=None):
         if issubclass(otherCls, FileJobStore):
             if sharedFileName is None:
                 fd, absPath = self._getTempFile()  # use this to get a valid path to write to in job store
                 os.close(fd)
                 os.unlink(absPath)
-                try:
-                    os.link(os.path.realpath(self._extractPathFromUrl(url)), absPath)
-                except OSError:
-                    shutil.copyfile(self._extractPathFromUrl(url), absPath)
+                self._copyOrLink(url, absPath)
                 return FileID(self._getRelativePath(absPath), os.stat(absPath).st_size)
             else:
                 self._requireValidSharedFileName(sharedFileName)
                 path = self._getSharedFilePath(sharedFileName)
-                try:
-                    os.link(os.path.realpath(self._extractPathFromUrl(url)), path)
-                except:
-                    shutil.copyfile(self._extractPathFromUrl(url), path)
+                # linking is not done be default because of issue #1755
+                self._copyOrLink(url, path)
                 return None
         else:
             return super(FileJobStore, self)._importFile(otherCls, url,

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -156,7 +156,7 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
                 except JobException:
                     pass
                 else:
-                    self.fail('Expected %s to be raised' % JobException )
+                    self.fail('Expected %s to be raised' % JobException)
 
                 # Now check the file is properly sorted..
                 with open(tempSortFile, 'r') as fileHandle:


### PR DESCRIPTION
Previously when using importFile function hard-links were made if possible in the fileJobStore. Caching code changes permissions of the imported file to read-only which can have unexpected results. 

This PR changes importFile to copy by default instead. It also add a command line option `--linkImports` which will cause linking if desired. The help message explains the permissions side affect.

Also I did a few minor style changes in nearby areas.