### PR TITLE
fix failure in resolve_indirect_inner in cwltoil.py (resolves #1761)

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -100,7 +100,7 @@ def resolve_indirect_inner(d):
             if isinstance(v, MergeInputs):
                 r[k] = v.resolve()
             else:
-                r[k] = v[1][v[0]]
+                r[k] = v[1].get(v[0])
         return r
     else:
         return d

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -93,7 +93,7 @@ class StepValueFrom(object):
         return cwltool.expression.do_eval(self.expr, inputs, self.req,
                                           None, None, {}, context=ctx)
 
-def resolve_indirect_inner(d):
+def _resolve_indirect_inner(d):
     if isinstance(d, IndirectDict):
         r = {}
         for k, v in d.items():
@@ -114,7 +114,7 @@ def resolve_indirect(d):
             needEval = True
         else:
             inner[k] = v
-    res = resolve_indirect_inner(inner)
+    res = _resolve_indirect_inner(inner)
     if needEval:
         ev = {}
         for k, v in iteritems(d):

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -13,7 +13,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License. 
+# limitations under the License.
 
 from toil.job import Job
 from toil.common import Toil

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -13,7 +13,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License. 
 
 from toil.job import Job
 from toil.common import Toil


### PR DESCRIPTION
fix failure in resolve_indirect_inner in cwltoil.py for Workflow if substep is a workflow and some inputs are optional and empty. see #1761