### PR TITLE
Fix docker tests failing on mac. resolves #1778

### DIFF
--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -151,7 +151,7 @@ class ToilTest(unittest.TestCase):
         prefix = ['toil', 'test', strclass(cls)]
         prefix.extend(filter(None, names))
         prefix.append('')
-        temp_dir_path = tempfile.mkdtemp(dir=cls._tempBaseDir, prefix='-'.join(prefix))
+        temp_dir_path = os.path.realpath(tempfile.mkdtemp(dir=cls._tempBaseDir, prefix='-'.join(prefix)))
         cls._tempDirs.append(temp_dir_path)
         return temp_dir_path
 


### PR DESCRIPTION
Docker on mac requires whitelisting directories before mounting them into docker images. Temp files are created in `/var/folders/...`. `/var` is a symlink to `/var/private`. `/private` is in the whitelist, but since the canonical name is not being used docker doesn't recognize it.

The workaround of adding `/var/folders` fails because the GUI will only select the canonical name (`/private/var/folders`) and because `/private` is already on the list the change is rejected.

resolves #1778