### PR TITLE
Quick fix for running toil from IPython

### DIFF
--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -504,7 +504,15 @@ class ModuleDescriptor(namedtuple('ModuleDescriptor', ('dirPath', 'name', 'fromV
             log.warning('Cannot determine main program module.')
             return False
         else:
-            mainModuleFile = os.path.basename(mainModule.__file__)
+            # If __file__ is not a valid attribute, it's because
+            # toil is being run interactively, in which case
+            # we can reasonably assume that we are not running
+            # on a worker node.
+            try:
+                mainModuleFile = os.path.basename(mainModule.__file__)
+            except AttributeError:
+                return False
+
             workerModuleFiles = concat(('worker' + ext for ext in self.moduleExtensions),
                                        '_toil_worker')  # the setuptools entry point
             return mainModuleFile in workerModuleFiles


### PR DESCRIPTION
Hello! Thanks for the great software. I'm working on a workflow interface to @jupyter, and toil is seeming like the best option for a workflow engine so far, especially once Python 3 is supported. Obviously, interactivity will be very useful.

Please excuse my ignorance of the code base, and feel free to suggest any improvements. I'd be happy to be helpful however is best.

Anyways, here's my quick solution:

Presently, trying to copy and paste [HelloWorld.py](https://toil.readthedocs.io/en/latest/running/running.html) into an IPython interpreter results in `'module' object has no attribute '__file__'` as described in #673.

From my quick investigation, this seems to be because when running jobs on workers, toil collects information about any packages which have been imported, and distributes the paths to the files where those modules are defined to any workers. Obviously, if a function is defined interactively, then there's no path that toil can provide.

So, okay. Let's assume that we're okay with *defining* functions in files, but we want to create and run workflows from IPython. That eliminates most of the issue already. There's one snag left, though, which occurs in [_runningOnWorker](https://github.com/BD2KGenomics/toil/blob/master/src/toil/resource.py#L500) in `resource.py`, where toil determines whether a module is running on a worker node. To do this, it determines the path for each module. But when it gets to `__main__` run from IPython, there's no path and it fails.

So I figure that it's safe to assume that:
- if you're running toil under IPython, you'll only be doing so from the master node
- This is the only situation that would cause an AttributeError in _runningOnWorker

Then, we can just catch the error and report that we are not running this module on a woker.

---

After changing those few lines, I can write the following to the file `HelloWorld.py`:
```
def helloWorld(message, memory="2G", cores=2, disk="1G"):
    return "Hello, world!, here's a message: %s" % message
```

and then, I can manually define options which would normally be coming from command line flags, and start the workflow from the IPython interpreter as follows.

```
(py2) oliver@oliver-arch:~/lbl/toil % ipython               
Python 2.7.13 |Continuum Analytics, Inc.| (default, Dec 20 2016, 23:09:15) 
Type "copyright", "credits" or "license" for more information.

IPython 5.4.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from toil.job import Job
   ...: import os
   ...: from HelloWorld import helloWorld
   ...: 
   ...: j = Job.wrapFn(helloWorld, "You did it!")
   ...: 
   ...: if __name__=="__main__":
   ...:     jobstore="file:jobStore"
   ...:     options = Job.Runner.getDefaultOptions(jobstore)
   ...:     print(Job.Runner.startToil(j, options)) #Prints Hello, world!, ...
   ...:     
```
which produces the expected output.
```
oliver-arch 2017-07-28 14:39:13,846 MainThread INFO toil.lib.bioio: Root logger is at level 'INFO', 'toil' logger at level 'INFO'.
oliver-arch 2017-07-28 14:39:13,846 MainThread INFO toil.lib.bioio: Root logger is at level 'INFO', 'toil' logger at level 'INFO'.
oliver-arch 2017-07-28 14:39:13,848 MainThread INFO toil.jobStores.abstractJobStore: The workflow ID is: 'c29dd384-a9d4-4d1a-9334-c7a1c12f4fcb'
oliver-arch 2017-07-28 14:39:13,851 MainThread INFO toil.common: Using the single machine batch system
oliver-arch 2017-07-28 14:39:13,851 MainThread WARNING toil.batchSystems.singleMachine: Limiting maxCores to CPU count of system (4).
oliver-arch 2017-07-28 14:39:13,851 MainThread WARNING toil.batchSystems.singleMachine: Limiting maxMemory to physically available memory (6142902272).
oliver-arch 2017-07-28 14:39:13,852 MainThread INFO toil.common: Created the workflow directory at /tmp/toil-c29dd384-a9d4-4d1a-9334-c7a1c12f4fcb-248fe4da-3d63-4245-8143-8f0f876bf6d0
oliver-arch 2017-07-28 14:39:13,852 MainThread WARNING toil.batchSystems.singleMachine: Limiting maxDisk to physically available disk (2262159360).
oliver-arch 2017-07-28 14:39:13,864 MainThread INFO toil.common: No user script to hot-deploy.
oliver-arch 2017-07-28 14:39:13,864 MainThread INFO toil.common: Written the environment for the jobs to the environment file
oliver-arch 2017-07-28 14:39:13,864 MainThread INFO toil.common: Caching all jobs in job store
oliver-arch 2017-07-28 14:39:13,865 MainThread INFO toil.common: 0 jobs downloaded.
oliver-arch 2017-07-28 14:39:13,874 MainThread INFO toil: Running Toil version 3.10.0a1-38577c704edb92c8c1d2c3274c46f1f6c04e9def.
oliver-arch 2017-07-28 14:39:13,874 MainThread INFO toil.realtimeLogger: Real-time logging disabled
oliver-arch 2017-07-28 14:39:13,877 MainThread INFO toil.toilState: (Re)building internal scheduler state
oliver-arch 2017-07-28 14:39:13,877 MainThread INFO toil.leader: Found 1 jobs to start and 0 jobs with successors to run
oliver-arch 2017-07-28 14:39:13,877 MainThread INFO toil.leader: Checked batch system has no running jobs and no updated jobs
oliver-arch 2017-07-28 14:39:13,878 MainThread INFO toil.leader: Starting the main loop
oliver-arch 2017-07-28 14:39:13,878 MainThread INFO toil.leader: Issued job 'helloWorld' 5/x/jobnnkBip with job batch system ID: 0 and cores: 2, disk: 1.0 G, and memory: 2.0 G
oliver-arch 2017-07-28 14:39:14,245 MainThread INFO toil.leader: Job ended successfully: 'helloWorld' 5/x/jobnnkBip
oliver-arch 2017-07-28 14:39:14,246 MainThread INFO toil.leader: No jobs left to run so exiting.
oliver-arch 2017-07-28 14:39:14,246 MainThread INFO toil.leader: Finished the main loop
oliver-arch 2017-07-28 14:39:14,246 MainThread INFO toil.serviceManager: Waiting for service manager thread to finish ...
oliver-arch 2017-07-28 14:39:14,879 MainThread INFO toil.serviceManager: ... finished shutting down the service manager. Took 0.632889986038 seconds
oliver-arch 2017-07-28 14:39:14,880 MainThread INFO toil.statsAndLogging: Waiting for stats and logging collator thread to finish ...
oliver-arch 2017-07-28 14:39:14,885 MainThread INFO toil.statsAndLogging: ... finished collating stats and logs. Took 0.00534582138062 seconds
oliver-arch 2017-07-28 14:39:14,886 MainThread INFO toil.leader: Finished toil run successfully
oliver-arch 2017-07-28 14:39:14,898 MainThread INFO toil.common: Attempting to delete the job store
oliver-arch 2017-07-28 14:39:14,900 MainThread INFO toil.common: Successfully deleted the job store
Hello, world!, here's a message: You did it!
```

I haven't tried this with workers, and I may very well be misunderstanding the `_runningOnWorker` function. Or there may be other unintended consequences that I'm not aware of.

Thanks, and let me know what you think!
Oliver