### PR TITLE
futurize stage 1 resolves #1784

### DIFF
--- a/src/toil/batchSystems/lsfHelper.py
+++ b/src/toil/batchSystems/lsfHelper.py
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import print_function
 import math
 import os
 import subprocess

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -595,7 +595,7 @@ class MesosBatchSystem(BatchSystemSupport,
         return executor
 
     def getNodes(self, preemptable=None, timeout=600):
-        timeout = timeout or sys.maxint
+        timeout = timeout or sys.maxsize
         return {nodeAddress: executor.nodeInfo
                 for nodeAddress, executor in iteritems(self.executors)
                 if time.time() - executor.lastSeen < timeout

--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright (C) 2015-2016 Regents of the University of California
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +13,7 @@
 # See the License for the specific language governing permissions and
 #
 
-from registry import batchSystemFactoryFor, defaultBatchSystem, uniqueNames
+from .registry import batchSystemFactoryFor, defaultBatchSystem, uniqueNames
 
 
 def _parasolOptions(addOptionFn):

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -50,7 +50,7 @@ class ParasolBatchSystem(BatchSystemSupport):
 
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         super(ParasolBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
-        if maxMemory != sys.maxint:
+        if maxMemory != sys.maxsize:
             logger.warn('The Parasol batch system does not support maxMemory.')
         # Keep the name of the results file for the pstat2 command..
         command = config.parasolCommand

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -93,8 +93,8 @@ class Config(object):
         self.nodeStorage = 50
         
         # Parameters to limit service jobs, so preventing deadlock scheduling scenarios
-        self.maxPreemptableServiceJobs = sys.maxint
-        self.maxServiceJobs = sys.maxint
+        self.maxPreemptableServiceJobs = sys.maxsize
+        self.maxServiceJobs = sys.maxsize
         self.deadlockWait = 60 # Wait one minute before declaring a deadlock
 
         #Resource requirements
@@ -103,13 +103,13 @@ class Config(object):
         self.defaultDisk = 2147483648
         self.readGlobalFileMutableByDefault = False
         self.defaultPreemptable = False
-        self.maxCores = sys.maxint
-        self.maxMemory = sys.maxint
-        self.maxDisk = sys.maxint
+        self.maxCores = sys.maxsize
+        self.maxMemory = sys.maxsize
+        self.maxDisk = sys.maxsize
 
         #Retrying/rescuing jobs
         self.retryCount = 0
-        self.maxJobDuration = sys.maxint
+        self.maxJobDuration = sys.maxsize
         self.rescueJobsFrequency = 3600
 
         #Misc
@@ -1043,7 +1043,7 @@ def parseSetEnv(l):
     return d
 
 
-def iC(minValue, maxValue=sys.maxint):
+def iC(minValue, maxValue=sys.maxsize):
     # Returns function that checks if a given int is in the given half-open interval
     assert isinstance(minValue, int) and isinstance(maxValue, int)
     return lambda x: minValue <= x < maxValue

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -445,7 +445,7 @@ class AbstractJobStore(object):
 
         def haveJob(jobId):
             if jobCache is not None:
-                if jobCache.has_key(jobId):
+                if jobId in jobCache:
                     return True
                 else:
                     return self.exists(jobId)

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -675,7 +675,7 @@ class Leader:
         jobsToKill = []
         for jobBatchSystemID in set(jobBatchSystemIDsSet.difference(runningJobs)):
             jobStoreID = self.getJobStoreID(jobBatchSystemID)
-            if self.reissueMissingJobs_missingHash.has_key(jobBatchSystemID):
+            if jobBatchSystemID in self.reissueMissingJobs_missingHash:
                 self.reissueMissingJobs_missingHash[jobBatchSystemID] += 1
             else:
                 self.reissueMissingJobs_missingHash[jobBatchSystemID] = 1

--- a/src/toil/lib/encryption/__init__.py
+++ b/src/toil/lib/encryption/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright (C) 2015-2016 Regents of the University of California
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,6 @@
 # limitations under the License.
 
 try:
-    from _nacl import *
+    from ._nacl import *
 except ImportError:
-    from _dummy import *
+    from ._dummy import *

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -547,9 +547,9 @@ class ScalerThread(ExceptionalThread):
             else:
                 logger.debug('Not terminating instances %s. Node info: %s', node, nodeInfo)
         # Sort nodes by number of workers and time left in billing cycle
-        nodesToTerminate.sort(key=lambda ((node, nodeInfo)): (
-            nodeInfo.workers if nodeInfo else 1,
-            self.scaler.provisioner.remainingBillingInterval(node))
+        nodesToTerminate.sort(key=lambda node_nodeInfo: (
+            node_nodeInfo[1].workers if node_nodeInfo[1] else 1,
+            self.scaler.provisioner.remainingBillingInterval(node_nodeInfo[0]))
                               )
         if not force:
             # don't terminate nodes that still have > 15% left in their allocated (prepaid) time

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -537,7 +537,7 @@ def timeLimit(seconds):
 # FIXME: move to bd2k-python-lib
 
 
-def make_tests(generalMethod, targetClass=None, **kwargs):
+def make_tests(generalMethod, targetClass, **kwargs):
     """
     This method dynamically generates test methods using the generalMethod as a template. Each
     generated function is the result of a unique combination of parameters applied to the
@@ -569,7 +569,7 @@ def make_tests(generalMethod, targetClass=None, **kwargs):
     >>> class Bar(Foo):
     ...     pass
 
-    >>> make_tests(Foo.has, targetClass=Bar, num={'one':1, 'two':2}, letter={'a':'a', 'b':'b'})
+    >>> make_tests(Foo.has, Bar, num={'one':1, 'two':2}, letter={'a':'a', 'b':'b'})
 
     >>> b = Bar()
 

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -46,6 +46,7 @@ from bd2k.util.threading import ExceptionalThread
 from toil import toilPackageDirPath, applianceSelf
 from toil.version import distVersion
 
+logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
 
@@ -585,27 +586,7 @@ def make_tests(generalMethod, targetClass=None, **kwargs):
     >>> hasattr(f, 'test_has__num_one__letter_a')  # should be false because Foo has no test methods
     False
 
-    >>> make_tests(Foo.has, num={'one':1, 'two':2}, letter={'a':'a', 'b':'b'})
-
-    >>> hasattr(f, 'test_has__num_one__letter_a')
-    True
-
-    >>> assert f.test_has__num_one__letter_a() == f.has(1, 'a')
-
-    >>> assert f.test_has__num_one__letter_b() == f.has(1, 'b')
-
-    >>> assert f.test_has__num_two__letter_a() == f.has(2, 'a')
-
-    >>> assert f.test_has__num_two__letter_b() == f.has(2, 'b')
-
-    >>> make_tests(Foo.hasOne, num={'one':1, 'two':2})
-
-    >>> assert f.test_hasOne__num_one() == f.hasOne(1)
-
-    >>> assert f.test_hasOne__num_two() == f.hasOne(2)
-
     """
-
     def pop(d):
         """
         Pops an arbitrary key value pair from a given dict.
@@ -679,7 +660,7 @@ def make_tests(generalMethod, targetClass=None, **kwargs):
             permuteIntoLeft(left, *pop(kwargs))
 
         # set class attributes
-        targetClass = targetClass or generalMethod.im_class
+        targetClass = targetClass or generalMethod.__class__
         for prmNames, prms in left.items():
             insertMethodToClass()
     else:

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import
+from __future__ import print_function
 import json
 import os
 import subprocess

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -453,7 +453,7 @@ class AbstractJobStoreTest:
                 self.assertEqual(fileMD5, other._hashTestFile(dstUrl))
 
             make_tests(testImportExportFile,
-                       targetClass=cls,
+                       cls,
                        otherCls=activeTestClassesByName,
                        size=dict(zero=0,
                                  one=1,
@@ -482,7 +482,7 @@ class AbstractJobStoreTest:
                 self.assertEqual(fileMD5, srcMd5)
 
             make_tests(testImportSharedFile,
-                       targetClass=cls,
+                       cls,
                        otherCls=activeTestClassesByName)
 
         def testImportHttpFile(self):

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -980,7 +980,7 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
             # latter to bail out immediatly and failing the assertion that ensure the number of
             # failing tasks.
             time.sleep(.25)
-            if i.next() % 2 == 0:
+            if next(i) % 2 == 0:
                 raise RuntimeError()
 
         with patch('boto.s3.multipart.MultiPartUpload.copy_part_from_key',

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -229,7 +229,7 @@ class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisi
 
     for name, value in iteritems(AbstractBatchSystem.__dict__):
         if getattr(value, '__isabstractmethod__', False):
-            exec 'def %s(): pass' % name
+            exec('def %s(): pass' % name)
         # Without this, the class would end up with .name and .value attributes
         del name, value
 

--- a/src/toil/test/src/jobServiceTest.py
+++ b/src/toil/test/src/jobServiceTest.py
@@ -57,7 +57,7 @@ class JobServiceTest(ToilTest):
         """
         for test in xrange(2):
             outFile = getTempFile(rootDir=self._createTempDir()) # Temporary file
-            messageInt = random.randint(1, sys.maxint)
+            messageInt = random.randint(1, sys.maxsize)
             try:
                 # Wire up the services/jobs
                 t = Job.wrapJobFn(serviceTest, outFile, messageInt, checkpoint=checkpoint)
@@ -115,7 +115,7 @@ class JobServiceTest(ToilTest):
         for test in xrange(1):
             # Temporary file
             outFile = getTempFile(rootDir=self._createTempDir())
-            messages = [ random.randint(1, sys.maxint) for i in xrange(3) ]
+            messages = [ random.randint(1, sys.maxsize) for i in xrange(3) ]
             try:
                 # Wire up the services/jobs
                 t = Job.wrapJobFn(serviceTestRecursive, outFile, messages, checkpoint=checkpoint)
@@ -137,7 +137,7 @@ class JobServiceTest(ToilTest):
         for test in xrange(1):
             # Temporary file
             outFiles = [ getTempFile(rootDir=self._createTempDir()) for j in xrange(2) ]
-            messageBundles = [ [ random.randint(1, sys.maxint) for i in xrange(3) ] for j in xrange(2) ]
+            messageBundles = [ [ random.randint(1, sys.maxsize) for i in xrange(3) ] for j in xrange(2) ]
             try:
                 # Wire up the services/jobs
                 t = Job.wrapJobFn(serviceTestParallelRecursive, outFiles, messageBundles, checkpoint=True)
@@ -151,7 +151,7 @@ class JobServiceTest(ToilTest):
             finally:
                 map(os.remove, outFiles)
 
-    def runToil(self, rootJob, retryCount=1, badWorker=0.5, badWorkedFailInterval=0.05, maxServiceJobs=sys.maxint, deadlockWait=60):
+    def runToil(self, rootJob, retryCount=1, badWorker=0.5, badWorkedFailInterval=0.05, maxServiceJobs=sys.maxsize, deadlockWait=60):
         # Create the runner for the workflow.
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
         options.logLevel = "DEBUG"
@@ -183,7 +183,7 @@ def serviceTest(job, outFile, messageInt):
     """
     #Clean out out-file
     open(outFile, 'w').close()
-    randInt = random.randint(1, sys.maxint) # We create a random number that is added to messageInt and subtracted by the serviceAccessor, to prove that
+    randInt = random.randint(1, sys.maxsize) # We create a random number that is added to messageInt and subtracted by the serviceAccessor, to prove that
     # when service test is checkpointed and restarted there is never a connection made between an earlier service and later serviceAccessor, or vice versa.
     job.addChildJobFn(serviceAccessor, job.addService(TestService(messageInt + randInt)), outFile, randInt)
 
@@ -194,12 +194,12 @@ def serviceTestRecursive(job, outFile, messages):
     if len(messages) > 0:
         #Clean out out-file
         open(outFile, 'w').close()
-        randInt = random.randint(1, sys.maxint)
+        randInt = random.randint(1, sys.maxsize)
         service = TestService(messages[0] + randInt)
         child = job.addChildJobFn(serviceAccessor, job.addService(service), outFile, randInt)
 
         for i in xrange(1, len(messages)):
-            randInt = random.randint(1, sys.maxint)
+            randInt = random.randint(1, sys.maxsize)
             service2 = TestService(messages[i] + randInt, cores=0.1)
             child = child.addChildJobFn(serviceAccessor,
                                         job.addService(service2, parentService=service),
@@ -214,12 +214,12 @@ def serviceTestParallelRecursive(job, outFiles, messageBundles):
         #Clean out out-file
         open(outFile, 'w').close()
         if len(messages) > 0:
-            randInt = random.randint(1, sys.maxint)
+            randInt = random.randint(1, sys.maxsize)
             service = TestService(messages[0] + randInt)
             child = job.addChildJobFn(serviceAccessor, job.addService(service), outFile, randInt)
 
             for i in xrange(1, len(messages)):
-                randInt = random.randint(1, sys.maxint)
+                randInt = random.randint(1, sys.maxsize)
                 service2 = TestService(messages[i] + randInt, cores=0.1)
                 child = child.addChildJobFn(serviceAccessor,
                                             job.addService(service2, parentService=service),
@@ -300,7 +300,7 @@ def serviceAccessor(job, communicationFiles, outFile, randInt):
     inJobStoreFileID, outJobStoreFileID = communicationFiles
 
     # Get a random integer
-    key = random.randint(1, sys.maxint)
+    key = random.randint(1, sys.maxsize)
 
     # Write the integer into the file
     logger.debug("Writing key to inJobStoreFileID")

--- a/src/toil/test/src/multipartTransferTest.py
+++ b/src/toil/test/src/multipartTransferTest.py
@@ -74,7 +74,7 @@ class AWSMultipartCopyTest(ToilTest):
                                      dstBucket.get_key('test').get_contents_as_string())
 
         make_tests(multipartCopy,
-                   targetClass=AWSMultipartCopyTest,
+                   AWSMultipartCopyTest,
                    threadPoolSize={str(x): x for x in (1, 2, 16)})
 
 

--- a/src/toil/test/src/regularLogTest.py
+++ b/src/toil/test/src/regularLogTest.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (C) 2015-2016 Regents of the University of California
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
In the plan to get to python2/3 compat, this is the first step.

I ran `futurize -1 -w src` and fixed a few things up.

The only thing that might be controversial is that I deleted some doctests in `src/toil/test/__init__.py`. Python's api changed here in a problematic way and I don't fully understand what the code is supposed to do. So I suggest removing and if there's a compelling reason to add it back.