### PR TITLE
Add (incomplete) singularity interface

### DIFF
--- a/src/toil/lib/singularity.py
+++ b/src/toil/lib/singularity.py
@@ -1,0 +1,128 @@
+"""
+    Module for running Singularity (and Docker) images with Singularity.   
+    Derived from https://github.com/BD2KGenomics/toil/blob/master/src/toil/lib/docker.py
+    with which nearly all code is shared, save the command lines used to run the containers.
+
+    Docker images can be run by prefacing the input tool with docker:// In this case, Singularity
+    will download, convert, and cache the image on the fly.  This cache can be set with 
+    SINGULARITY_CACHEDIR, and defaults to the user's home directory.  This cache can be a major
+    bottleneck when repeatedly more different images than it can hold (not very many).  So for this
+    type of usage pattern (concurrent or short consecutive calls to different images), it is 
+    best to run Singularity images natively.
+    
+"""
+import base64
+import logging
+import subprocess
+import pipes
+import os
+from bd2k.util.exceptions import require
+
+_logger = logging.getLogger(__name__)
+
+
+def singularityCall(job,
+               tool,
+               parameters=None,
+               workDir=None,
+               singularityParameters=None,
+               outfile=None):
+    """
+    Throws CalledProcessorError if the Singularity invocation returns a non-zero exit code
+    This function blocks until the subprocess call to Singularity returns
+    :param toil.Job.job job: The Job instance for the calling function.
+    :param str tool: Name of the Singularity image to be used (preface with docker:// to use a Docker image)
+    :param list[str] parameters: Command line arguments to be passed to the tool.
+           If list of lists: list[list[str]], then treat as successive commands chained with pipe.
+    :param str workDir: Directory to mount into the container via `-v`. Destination convention is /data
+    :param list[str] singularityParameters: Parameters to pass to Singularity. Default parameters are `--rm`,
+            `--log-driver none`, and the mountpoint `-v work_dir:/data` where /data is the destination convention.
+             These defaults are removed if singularity_parmaters is passed, so be sure to pass them if they are desired.
+    :param file outfile: Pipe output of Singularity call to file handle
+    """
+    _singularity(job, tool=tool, parameters=parameters, workDir=workDir, singularityParameters=singularityParameters,
+            outfile=outfile, checkOutput=False)
+
+
+def singularityCheckOutput(job,
+                      tool,
+                      parameters=None,
+                      workDir=None,
+                      singularityParameters=None):
+    """
+    Returns the stdout from the Singularity invocation (via subprocess.check_output)
+    Throws CalledProcessorError if the Singularity invocation returns a non-zero exit code
+    This function blocks until the subprocess call to Singularity returns
+    :param toil.Job.job job: The Job instance for the calling function.
+    :param str tool: Name of the Singularity image to be used (preface with docker:// to use a Docker image)
+    :param list[str] parameters: Command line arguments to be passed to the tool.
+           If list of lists: list[list[str]], then treat as successive commands chained with pipe.
+    :param str workDir: Directory to mount into the container via `-v`. Destination convention is /data
+    :param list[str] singularityParameters: Parameters to pass to Singularity. Default parameters are `--rm`,
+            `--log-driver none`, and the mountpoint `-v work_dir:/data` where /data is the destination convention.
+             These defaults are removed if singularity_parmaters is passed, so be sure to pass them if they are desired.
+    :returns: Stdout from the singularity call
+    :rtype: str
+    """
+    return _singularity(job, tool=tool, parameters=parameters, workDir=workDir,
+                   singularityParameters=singularityParameters, checkOutput=True)
+
+
+def _singularity(job,
+            tool,
+            parameters=None,
+            workDir=None,
+            singularityParameters=None,
+            outfile=None,
+            checkOutput=False):
+    """
+    :param toil.Job.job job: The Job instance for the calling function.
+    :param str tool: Name of the Singularity image to be used (preface with docker:// to use a Docker image)
+    :param list[str] parameters: Command line arguments to be passed to the tool.
+           If list of lists: list[list[str]], then treat as successive commands chained with pipe.
+    :param str workDir: Directory to mount into the container via `--bind`. Destination convention is /data
+    :param list[str] singularityrParameters: Parameters to pass to Singularity. Default parameters are the mountpoint
+             `--bind work_dir:/data` where /data is the destination convention.
+             These defaults are removed if singularity_parmaters is passed, so be sure to pass them if they are desired.
+    :param file outfile: Pipe output of Singularity call to file handle
+    :param bool checkOutput: When True, this function returns singularity's output.
+    """
+    if parameters is None:
+        parameters = []
+    if workDir is None:
+        workDir = os.getcwd()
+
+    # Setup the outgoing subprocess call for singularity
+    baseSingularityCall = ['singularity', '-q', 'exec']
+    if singularityParameters:
+        baseSingularityCall += singularityParameters
+    else:
+        # We default to running on the container's home directory, because it is most likely to be mounted
+        # in singularity.conf (this was an issue on Biowolf at NIH)
+        baseSingularityCall += ['-H', '{}:{}'.format(os.path.abspath(workDir), os.environ.get('HOME')), '--pwd', os.environ.get('HOME')]
+
+    # Make subprocess call
+
+    # If parameters is list of lists, treat each list as separate command and chain with pipes
+    if len(parameters) > 0 and type(parameters[0]) is list:
+        # When piping, all arguments now get merged into a single string to bash -c.
+        # We try to support spaces in paths by wrapping them all in quotes first.
+        chain_params = [' '.join(p) for p in [map(pipes.quote, q) for q in parameters]]
+        # Use bash's set -eo pipefail to detect and abort on a failure in any command in the chain
+        call = baseSingularityCall + [tool, '/bin/bash', '-c',
+                                 'set -eo pipefail && {}'.format(' | '.join(chain_params))]
+    else:
+        call = baseSingularityCall + [tool] + parameters
+    _logger.info("Calling singularity with " + repr(call))
+
+    params = {}
+    if outfile:
+        params['stdout'] = outfile
+    if checkOutput:
+        callMethod = subprocess.check_output
+    else:
+        callMethod = subprocess.check_call
+
+    out = callMethod(call, **params)
+
+    return out

--- a/src/toil/test/lib/singularityTest.py
+++ b/src/toil/test/lib/singularityTest.py
@@ -1,0 +1,123 @@
+import logging
+import signal
+import time
+import uuid
+from threading import Thread
+from subprocess import CalledProcessError
+
+import os
+from pwd import getpwuid
+from bd2k.util.files import mkdir_p
+from toil.job import Job
+from toil.leader import FailedJobsException
+from toil.lib.singularity import singularityCall, singularityCheckOutput
+from toil.test import ToilTest
+
+_log = logging.getLogger(__name__)
+
+
+class SingularityTest(ToilTest):
+    """
+    Tests singularityCall and ensures no containers are left around.
+
+
+    When running tests you may optionally set the TOIL_TEST_TEMP environment variable to the path
+    of a directory where you want temporary test files be placed. The directory will be created
+    if it doesn't exist. The path may be relative in which case it will be assumed to be relative
+    to the project root. If TOIL_TEST_TEMP is not defined, temporary files and directories will
+    be created in the system's default location for such files and any temporary files or
+    directories left over from tests will be removed automatically removed during tear down.
+    Otherwise, left-over files will not be removed.
+    """
+    def setUp(self):
+        self.tempDir = self._createTempDir(purpose='tempDir')
+
+
+    def testSingularityPipeChain(self, caching=True):
+        """
+        Test for piping API for singularityCall().  Using this API (activated when list of
+        argument lists is given as parameters), commands a piped together into a chain
+        ex:  parameters=[ ['printf', 'x\n y\n'], ['wc', '-l'] ] should execute:
+        printf 'x\n y\n' | wc -l
+        """
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
+        options.logLevel = 'INFO'
+        options.workDir = self.tempDir
+        options.clean = 'always'
+        if not caching:
+            options.disableCaching = True
+        A = Job.wrapJobFn(_testSingularityPipeChainFn)
+        rv = Job.Runner.startToil(A, options)
+        assert rv.strip() == '2'
+
+    def testSingularityPipeChainErrorDetection(self, caching=True):
+        """
+        By default, executing cmd1 | cmd2 | ... | cmdN, will only return an error
+        if cmdN fails.  This can lead to all manor of errors being silently missed.
+        This tests to make sure that the piping API for singularityCall() throws an exception
+        if non-last commands in the chain fail.
+        """
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
+        options.logLevel = 'INFO'
+        options.workDir = self.tempDir
+        options.clean = 'always'
+        if not caching:
+            options.disableCaching = True
+        A = Job.wrapJobFn(_testSingularityPipeChainErrorFn)
+        rv = Job.Runner.startToil(A, options)
+        assert rv == True
+
+    def testSingularityPermissions(self, caching=True):
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
+        options.logLevel = 'INFO'
+        options.workDir = self.tempDir
+        options.clean = 'always'
+        if not caching:
+            options.disableCaching = True
+        A = Job.wrapJobFn(_testSingularityPermissions)
+        Job.Runner.startToil(A, options)
+
+    def testSingularityPermissionsNonCaching(self):
+        self.testSingularityPermissions(caching=False)
+
+    def testNonCachingSingularityChain(self):
+        self.testSingularityPipeChain(caching=False)
+
+    def testNonCachingSingularityChainErrorDetection(self):
+        self.testSingularityPipeChainErrorDetection(caching=False)
+
+
+def _testSingularityPipeChainFn(job):
+    """
+    Return the result of simple pipe chain.  Should be 2
+    """
+    parameters = [ ['printf', 'x\n y\n'], ['wc', '-l'] ]
+    return singularityCheckOutput(job, tool='docker://quay.io/ucsc_cgl/spooky_test', parameters=parameters)
+
+def _testSingularityPipeChainErrorFn(job):
+    """
+    Return True if the command exit 1 | wc -l raises a CalledProcessError when run through 
+    the singularity interface
+    """
+    parameters = [ ['exit', '1'], ['wc', '-l'] ]
+    try:
+        return singularityCheckOutput(job, tool='docker://quay.io/ucsc_cgl/spooky_test', parameters=parameters)
+    except CalledProcessError:
+        return True
+    return False
+
+def _testSingularityPermissions(job):
+    testDir = job.fileStore.getLocalTempDir()
+    singularityCall(job, tool='docker://ubuntu', workDir=testDir, parameters=[['touch', '/data/test.txt']])
+    outFile = os.path.join(testDir, 'test.txt')
+    assert os.path.exists(outFile)
+    assert not ownerName(outFile) == "root"
+
+
+def ownerName(filename):
+    """
+    Determines a given file's owner
+    :param str filename: path to a file
+    :return: name of filename's owner
+    """
+    return getpwuid(os.stat(filename).st_uid).pw_name


### PR DESCRIPTION
I said back in #1768 that I'd PR [toil-vg](https://github.com/vgteam/toil-vg)'s singularity module into Toil, so here it is.  It seems to run okay for our purposes of calling command line tools in containers, except that the cache used to run Docker images on the fly gets easily overwhelmed.  This is worked around by converting the images a priori (we could probably automate this if necessary). If Singularity ever made the cache size tunable, that'd probably work too. 

There's still a lot of work to make this a drop-in replacement for docker.py:
* There's no interface to inspect or stop running containers. 
* The test won't run on Jenkins because singularity's not on the jenkins slave image. (even then, I'm not sure since I can't get any Toil tests to run locally from the command line any more) 
* I wouldn't be surprised if there are nesting issues that would arise when running these within the docker appliance (or vice versa)

I think would also require some thought for an abstract container interface.  In toil-vg we wrap everything (https://github.com/vgteam/toil-vg/blob/master/src/toil_vg/vg_common.py#L87-L244) so it's easy to flip between docker/singularity/no-container.  I think something similar is needed in Toil to make this useful.  On a related note, singularity.py shares about 99% of its code with docker.py, so there may be room to refactor that a bit better too. 
