### PR TITLE
Extend bdtKeys to support more ephemeral drives

### DIFF
--- a/src/toil/provisioners/aws/__init__.py
+++ b/src/toil/provisioners/aws/__init__.py
@@ -212,10 +212,9 @@ write_files:
         #!/bin/bash
         set -x
         ephemeral_count=0
-        possible_drives="/dev/xvdb /dev/xvdc /dev/xvdd /dev/xvde"
         drives=""
         directories="toil mesos docker"
-        for drive in $possible_drives; do
+        for drive in /dev/xvd{{b..z}}; do
             echo checking for $drive
             if [ -b $drive ]; then
                 echo found it

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -19,6 +19,7 @@ import logging
 import time
 
 import sys
+import string
 
 # Python 3 compatibility imports
 from _ssl import SSLError
@@ -703,7 +704,7 @@ class AWSProvisioner(AbstractProvisioner):
     @classmethod
     def _getBlockDeviceMapping(cls, instanceType, rootVolSize=50):
         # determine number of ephemeral drives via cgcloud-lib
-        bdtKeys = ['', '/dev/xvdb', '/dev/xvdc', '/dev/xvdd']
+        bdtKeys = [''] + ['/dev/xvd{}'.format(c) for c in string.lowercase[1:]]
         bdm = BlockDeviceMapping()
         # Change root volume size to allow for bigger Docker instances
         root_vol = BlockDeviceType(delete_on_termination=True)


### PR DESCRIPTION
This is a fix for #1814, where nodes with > 4 ephemeral drives, such as i2.8xlarge, are not supported.  

There is probably a more elegant/future-proof fix to be made here, but this at least works for the node type in question for the time being.  