### PR TITLE
Fix flaky JobService tests (resolves #1819)

### DIFF
--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -265,8 +265,6 @@ class Leader:
                         # itself was successful), and its subtree failed, it shouldn't be retried
                         # unless it has more than 1 try.
                         elif jobGraph.checkpoint is not None and jobGraph.remainingRetryCount > 1:
-                            jobGraph.setupJobAfterFailure(self.config)
-                            self.jobStore.update(jobGraph)
                             logger.warn('Job: %s is being restarted as a checkpoint after the total '
                                         'failure of jobs in its subtree.', jobGraph.jobStoreID)
                             self.issueJob(JobNode.fromJobGraph(jobGraph))

--- a/src/toil/test/src/checkpointTest.py
+++ b/src/toil/test/src/checkpointTest.py
@@ -20,7 +20,7 @@ from toil.jobStores.abstractJobStore import NoSuchFileException
 
 class CheckpointTest(ToilTest):
     def testCheckpointNotRetried(self):
-        """A checkpoint job with a retryCount of 0 should not be retried."""
+        """A checkpoint job should not be retried if the workflow has a retryCount of 0."""
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
         options.retryCount = 0
         # We set the workflow to *succeed* if the checkpointed job is
@@ -33,7 +33,7 @@ class CheckpointTest(ToilTest):
             Job.Runner.startToil(CheckRetryCount(numFailuresBeforeSuccess=1), options)
 
     def testCheckpointRetriedOnce(self):
-        """A checkpoint job with a retryCount of 1 should be retried exactly once."""
+        """A checkpoint job should be retried exactly once if the workflow has a retryCount of 1."""
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
         options.retryCount = 1
 

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -252,14 +252,18 @@ def main():
         # The job is a checkpoint, and is being restarted after previously completing
         if jobGraph.checkpoint != None:
             logger.debug("Job is a checkpoint")
+            # If the checkpoint still has extant jobs in its
+            # (flattened) stack and services, its subtree didn't
+            # complete properly. We handle the restart of the
+            # checkpoint here, removing its previous subtree.
             if len([i for l in jobGraph.stack for i in l]) > 0 or len(jobGraph.services) > 0:
                 logger.debug("Checkpoint has failed.")
                 # Reduce the retry count
                 assert jobGraph.remainingRetryCount >= 0
                 jobGraph.remainingRetryCount = max(0, jobGraph.remainingRetryCount - 1)
                 jobGraph.restartCheckpoint(jobStore)
-                # Otherwise, the job and successors are done, and we can cleanup stuff we couldn't clean
-                # because of the job being a checkpoint
+            # Otherwise, the job and successors are done, and we can cleanup stuff we couldn't clean
+            # because of the job being a checkpoint
             else:
                 logger.debug("The checkpoint jobs seems to have completed okay, removing any checkpoint files to delete.")
                 #Delete any remnant files


### PR DESCRIPTION
Hopefully this gives us some relief from the flaky tests.

This arose because of the recent checkpoint fixes. Unfortunately updating the state of the jobGraphs from the leader caused issues in some cases: for a job that launches services, the leader sets `jobGraph.services` to an empty list as a leader-specific signal that its services have been launched. This is out-of-sync with how it should appear in the jobStore. Crucially, this means that the job state can't ever be updated from the leader. If the jobGraph's services list gets cleared in the jobStore while the services are running, then those services will be orphaned and can't be cleared on checkpoint restart. If the orphaned services then become totally failed, and then the workflow ultimately completes (because a checkpointed subtree restarted successfully), the workflow will be marked as failed despite having completed (and despite the root job having been deleted).