### PR TITLE
Retry `docker push` 5 times (resolves #1821)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ obliterate_docker: clean_docker
 	-docker images -qf dangling=true | xargs docker rmi
 
 push_docker: docker check_docker_registry
-	docker push $(docker_image):$(docker_tag)
+	for i in $$(seq 1 5); do docker push $(docker_image):$(docker_tag) && break || sleep 60; done
 
 else
 


### PR DESCRIPTION
This retries the push 5 times, to avoid timeouts killing our integration tests.