### PR TITLE
Skip slow tests (resolves #1826).

### DIFF
--- a/docs/appendices/environment_vars.rst
+++ b/docs/appendices/environment_vars.rst
@@ -16,21 +16,6 @@ There are several environment variables that affect the way Toil runs.
 |                        | cases, the system's `standard temporary directory`_|
 |                        | is used.                                           |
 +------------------------+----------------------------------------------------+
-| TOIL_TEST_TEMP         | An absolute path to a directory where Toil tests   |
-|                        | will write their temporary files. Defaults to the  |
-|                        | system's `standard temporary directory`_.          |
-+------------------------+----------------------------------------------------+
-| TOIL_TEST_INTEGRATIVE  | If ``True``, this allows the integration tests to  |
-|                        | run. Only valid when running the tests from the    |
-|                        | source directory via ``make test`` or              |
-|                        | ``make test_parallel``.                            |
-+------------------------+----------------------------------------------------+
-| TOIL_TEST_EXPERIMENTAL | If ``True``, this allows tests on experimental     |
-|                        | features to run (such as the Google and Azure) job |
-|                        | stores. Only valid when running tests from the     |
-|                        | source directory via ``make test`` or              |
-|                        | ``make test_parallel``.                            |
-+------------------------+----------------------------------------------------+
 | TOIL_APPLIANCE_SELF    | The fully qualified reference for the Toil         |
 |                        | Appliance you wish to use, in the form             |
 |                        | ``REPO/IMAGE:TAG``.                                |

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -5,38 +5,24 @@
 Running tests
 -------------
 
-To invoke all unit tests use
+Test make targets, invoked as ``$ make <target>``, subject to which
+environment variables are set (see :ref:`test_env_vars`).
 
-::
-
-    $ make test
-
-To invoke all non-AWS integration tests use
-
-::
-
-    $ make integration_test
-
-To invoke all integration tests, including AWS tests, use
-
-::
-
-    $ export TOIL_AWS_KEYNAME=<aws_keyname>; make integration_test
-
-To skip building the Docker appliance and run tests that have no docker dependency use
-
-::
-
-    $ make test_offline
-
-To make integration tests easier to debug locally one can use
-
-::
-
-    $ make integration_test_local
-
-which runs the integration tests in serial and doesn't redirect output. This makes it appears on the terminal as
-expected.
++-------------------------+---------------------------------------------------+
+|     TARGET              |        DESCRIPTION                                |
++-------------------------+---------------------------------------------------+
+|  test                   | Invokes all tests.                                |
++-------------------------+---------------------------------------------------+
+| integration_test        | Invokes only the integration tests.               |
++-------------------------+---------------------------------------------------+
+| test_offline            | Skips building the Docker appliance and only      |
+|                         | invokes tests that have no docker dependencies.   |
++-------------------------+---------------------------------------------------+
+| integration_test_local  | Makes integration tests easier to debug locally   |
+|                         | by running the integration tests serially and     |
+|                         | doesn't redirect output. This makes it appears on |
+|                         | the terminal as expected.                         |
++-------------------------+---------------------------------------------------+
 
 Run an individual test with
 
@@ -84,6 +70,39 @@ For more information, see the `pytest documentation`_.
 
 .. _pytest documentation: https://docs.pytest.org/en/latest/
 
+
+
+.. _test_env_vars:
+
+Test environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++------------------------+----------------------------------------------------+
+| TOIL_TEST_TEMP         | An absolute path to a directory where Toil tests   |
+|                        | will write their temporary files. Defaults to the  |
+|                        | system's `standard temporary directory`_.          |
++------------------------+----------------------------------------------------+
+| TOIL_TEST_INTEGRATIVE  | If ``True``, this allows the integration tests to  |
+|                        | run. Only valid when running the tests from the    |
+|                        | source directory via ``make test`` or              |
+|                        | ``make test_parallel``.                            |
++------------------------+----------------------------------------------------+
+| TOIL_TEST_EXPERIMENTAL | If ``True``, this allows tests on experimental     |
+|                        | features to run (such as the Google and Azure) job |
+|                        | stores. Only valid when running tests from the     |
+|                        | source directory via ``make test`` or              |
+|                        | ``make test_parallel``.                            |
++------------------------+----------------------------------------------------+
+| TOIL_AWS_KEYNAME       | An AWS keyname (see :ref:`prepare_aws-ref`), which |
+|                        | is required to run the AWS tests.                  |
++------------------------+----------------------------------------------------+
+| TOIL_AZURE_KEYNAME     | An Azure keyname (see :ref:`prepare_azure-ref`),   |
+|                        | which is required to run the AWS tests.            |
++------------------------+----------------------------------------------------+
+| TOIL_TEST_QUICK        | If ``True``, long running tests are skipped.       |
++------------------------+----------------------------------------------------+
+
+.. _standard temporary directory: https://docs.python.org/2/library/tempfile.html#tempfile.gettempdir
 
 .. _quaySetup:
 

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -96,13 +96,24 @@ Test environment variables
 | TOIL_AWS_KEYNAME       | An AWS keyname (see :ref:`prepare_aws-ref`), which |
 |                        | is required to run the AWS tests.                  |
 +------------------------+----------------------------------------------------+
-| TOIL_AZURE_KEYNAME     | An Azure keyname (see :ref:`prepare_azure-ref`),   |
+| TOIL_AZURE_KEYNAME     | An Azure account keyname (see                      |
+|                        | :ref:`prepare_azure-ref`),                         |
 |                        | which is required to run the AWS tests.            |
++------------------------+----------------------------------------------------+
+| TOIL_GOOGLE_PROJECTID  | A Google Cloud account projectID                   |
+|                        | (see :ref:`runningGCE`), which is required to      |
+|                        | to run the Google Cloud tests.                     |
 +------------------------+----------------------------------------------------+
 | TOIL_TEST_QUICK        | If ``True``, long running tests are skipped.       |
 +------------------------+----------------------------------------------------+
 
 .. _standard temporary directory: https://docs.python.org/2/library/tempfile.html#tempfile.gettempdir
+
+.. admonition:: Partial install and failing tests.
+
+    Some tests may fail with an ImportError if the required extras are not installed
+    (:ref:`building_from_source-ref`). Install Toil with all of the extras
+    do prevent such errors.
 
 .. _quaySetup:
 

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -24,7 +24,19 @@ environment variables are set (see :ref:`test_env_vars`).
 |                         | the terminal as expected.                         |
 +-------------------------+---------------------------------------------------+
 
-Run an individual test with
+Run all tests (including slow tests):
+
+::
+
+    $ make test
+
+Run only quick tests (as of Sep 18, 2017, this was < 30 minutes):
+
+::
+
+    $ export TOIL_TEST_QUICK=True; make test
+
+Run an individual test with:
 
 ::
 
@@ -33,7 +45,7 @@ Run an individual test with
 The default value for ``tests`` is ``"src"`` which includes all tests in the
 ``src/`` subdirectory of the project root. Tests that require a particular
 feature will be skipped implicitly. If you want to explicitly skip tests that
-depend on a currently installed *feature*, use
+depend on a currently installed *feature*, use:
 
 ::
 
@@ -43,7 +55,9 @@ This will run only the tests that don't depend on the ``azure`` extra, even if
 that extra is currently installed. Note the distinction between the terms
 *feature* and *extra*. Every extra is a feature but there are features that are
 not extras, such as the ``gridengine`` and ``parasol`` features.  To skip tests
-involving both the Parasol feature and the Azure extra, use the following::
+involving both the Parasol feature and the Azure extra, use the following
+
+::
 
     $ make test tests="-m 'not azure and not parasol' src"
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -20,6 +20,7 @@ export LIBPROCESS_IP=127.0.0.1
 # Needed for integrative provisioner tests
 export CGCLOUD_ME=jenkins@jenkins-master
 export TOIL_AWS_KEYNAME=jenkins@jenkins-master
+export TOIL_AZURE_KEYNAME=toiltest
 
 TMPDIR=/mnt/ephemeral/tmp
 # Run rm "as root" so we can clean up files left over by rogue containers

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -315,6 +315,9 @@ def needs_google(test_item):
     Use as a decorator before test classes or methods to only run them if Google Storage usable.
     """
     test_item = _mark_test('google', test_item)
+    projectID = os.getenv('TOIL_GOOGLE_PROJECTID')
+    if not projectID or projectID is None:
+        return unittest.skip("Set TOIL_GOOGLE_PROJECTID to include this test.")(test_item)
     try:
         # noinspection PyUnresolvedReferences
         from boto import config

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -506,6 +506,17 @@ def integrative(test_item):
             'Set TOIL_TEST_INTEGRATIVE="True" to include this integration test, '
             'or run `make integration_test_local` to run all integration tests.')(test_item)
 
+def slow(test_item):
+    """
+    Use this decorator to identify tests that are slow and not critical.
+    Skip them if TOIL_TEST_QUICK is true.
+    """
+    test_item = _mark_test('slow', test_item)
+    if not less_strict_bool(os.getenv('TOIL_TEST_QUICK')):
+        return test_item
+    else:
+        return unittest.skip(
+            'Skipped because TOIL_TEST_QUICK is "True"')(test_item)
 
 methodNamePartRegex = re.compile('^[a-zA-Z_0-9]+$')
 

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -335,9 +335,9 @@ def needs_azure(test_item):
     Use as a decorator before test classes or methods to only run them if Azure is usable.
     """
     test_item = _mark_test('azure', test_item)
-    keyName = os.getenv('TOIL_AWS_KEYNAME')
+    keyName = os.getenv('TOIL_AZURE_KEYNAME')
     if not keyName or keyName is None:
-        return unittest.skip("Set TOIL_AWS_KEYNAME to include this test.")(test_item)
+        return unittest.skip("Set TOIL_AZURE_KEYNAME to include this test.")(test_item)
 
     try:
         # noinspection PyUnresolvedReferences

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -277,10 +277,8 @@ def needs_aws(test_item):
     """
     test_item = _mark_test('aws', test_item)
     keyName = os.getenv('TOIL_AWS_KEYNAME')
-    log.info('Checking keyname: %s', keyName)
     if not keyName or keyName is None:
         return unittest.skip("Set TOIL_AWS_KEYNAME to include this test.")(test_item)
-    log.info("NOPE %s" % keyName)
 
     try:
         # noinspection PyUnresolvedReferences
@@ -337,6 +335,10 @@ def needs_azure(test_item):
     Use as a decorator before test classes or methods to only run them if Azure is usable.
     """
     test_item = _mark_test('azure', test_item)
+    keyName = os.getenv('TOIL_AWS_KEYNAME')
+    if not keyName or keyName is None:
+        return unittest.skip("Set TOIL_AWS_KEYNAME to include this test.")(test_item)
+
     try:
         # noinspection PyUnresolvedReferences
         import azure.storage
@@ -383,6 +385,7 @@ def needs_mesos(test_item):
     try:
         # noinspection PyUnresolvedReferences
         import mesos.native
+        import psutil
     except ImportError:
         return unittest.skip(
             "Install Mesos (and Toil with the 'mesos' extra) to include this test.")(test_item)

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -326,7 +326,7 @@ class hidden(object):
             self.assertTrue(locator.startswith('file:'))
             self.assertEqual(locator[len('file:'):], filePath)
 
-
+@slow
 @needs_mesos
 class MesosBatchSystemTest(hidden.AbstractBatchSystemTest, MesosTestSupport):
     """
@@ -541,7 +541,7 @@ class Service(Job.Service):
     def stop(self, fileStore):
         subprocess.check_call(self.cmd + ' -1', shell=True)
 
-
+@slow
 @needs_parasol
 class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport):
     """
@@ -618,6 +618,7 @@ class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport)
         return [self._parseBatchString(line) for line in batchLines[1:] if line]
 
 
+@slow
 @needs_gridengine
 class GridEngineBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
     """
@@ -636,6 +637,7 @@ class GridEngineBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
         for f in glob('toil_job*.o*'):
             os.unlink(f)
 
+@slow
 @needs_slurm
 class SlurmBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
     """
@@ -654,6 +656,7 @@ class SlurmBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
         for f in glob('slurm-*.out'):
             os.unlink(f)
 
+@slow
 @needs_torque
 class TorqueBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
     """
@@ -802,6 +805,7 @@ def _resourceBlockTestAuxFn(outFile, sleepTime, writeVal):
     time.sleep(sleepTime)
 
 
+@slow
 @needs_mesos
 class MesosBatchSystemJobTest(hidden.AbstractBatchSystemJobTest, MesosTestSupport):
     """

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -689,6 +689,7 @@ class SingleMachineBatchSystemJobTest(hidden.AbstractBatchSystemJobTest):
     def getBatchSystemName(self):
         return "singleMachine"
 
+    @slow
     def testConcurrencyWithDisk(self):
         """
         Tests that the batch system is allocating disk resources properly

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -49,6 +49,7 @@ from toil.test import (ToilTest,
                        needs_gridengine,
                        needs_slurm,
                        needs_torque,
+                       slow,
                        tempFileContaining)
 from future.utils import with_metaclass
 
@@ -280,6 +281,7 @@ class hidden(object):
         def tearDown(self):
             super(hidden.AbstractBatchSystemJobTest, self).tearDown()
 
+        @slow
         def testJobConcurrency(self):
             """
             Tests that the batch system is allocating core resources properly for concurrent tasks.
@@ -365,7 +367,8 @@ class SingleMachineBatchSystemTest(hidden.AbstractBatchSystemTest):
     def createBatchSystem(self):
         return SingleMachineBatchSystem(config=self.config,
                                         maxCores=numCores, maxMemory=1e9, maxDisk=2001)
-        
+
+@slow
 class MaxCoresSingleMachineBatchSystemTest(ToilTest):
     """
     This test ensures that single machine batch system doesn't exceed the configured number of
@@ -712,6 +715,7 @@ class SingleMachineBatchSystemJobTest(hidden.AbstractBatchSystemJobTest):
         self.assertEqual(maxValue, 1)
 
     @skipIf(SingleMachineBatchSystem.numCores < 4, 'Need at least four cores to run this test')
+    @slow
     def testNestedResourcesDoNotBlock(self):
         """
         Resources are requested in the order Memory > Cpu > Disk.

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -28,7 +28,7 @@ import zipfile
 from six.moves import StringIO
 from six import u as str
 
-from toil.test import ToilTest, needs_cwl
+from toil.test import ToilTest, needs_cwl, slow
 
 @needs_cwl
 class CWLTest(ToilTest):
@@ -92,6 +92,7 @@ class CWLTest(ToilTest):
         except NoSuchJobStoreException:
             pass
 
+    @slow
     def test_run_conformance(self):
         rootDir = self._projectRootPath()
         cwlSpec = os.path.join(rootDir, 'src/toil/test/cwl/spec')

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -61,6 +61,7 @@ class CWLTest(ToilTest):
                 u'class': u'File',
                 u'checksum': u'sha1$b9214658cc453331b62c2282b772a5c063dbd284'}})
 
+    @slow
     def test_restart(self):
         """Enable restarts with CWLtoil -- run failing test, re-run correct test.
         """

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -876,7 +876,7 @@ class FileJobStoreTest(AbstractJobStoreTest.Test):
 @experimental
 @needs_google
 class GoogleJobStoreTest(AbstractJobStoreTest.Test):
-    projectID = 'cgc-05-0006'
+    projectID = os.getenv('TOIL_GOOGLE_PROJECTID')
     headers = {"x-goog-project-id": projectID}
 
     def _createJobStore(self):

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -64,6 +64,7 @@ from toil.test import (ToilTest,
                        needs_encryption,
                        make_tests,
                        needs_google,
+                       slow,
                        experimental)
 from future.utils import with_metaclass
 
@@ -534,6 +535,7 @@ class AbstractJobStoreTest(object):
             finally:
                 ftp.stop()
 
+        @slow
         def testFileDeletion(self):
             """
             Intended to cover the batch deletion of items in the AWSJobStore, but it doesn't hurt
@@ -549,6 +551,7 @@ class AbstractJobStoreTest(object):
                     # NB: the fooStream() methods return context managers
                     self.assertRaises(NoSuchFileException, master.readFileStream(fileID).__enter__)
 
+        @slow
         def testMultipartUploads(self):
             """
             This test is meant to cover multi-part uploads in the AWSJobStore but it doesn't hurt
@@ -645,6 +648,7 @@ class AbstractJobStoreTest(object):
                 self.assertEquals(f.read(), "")
             self.master.delete(job.jobStoreID)
 
+        @slow
         def testLargeFile(self):
             dirPath = self._createTempDir()
             filePath = os.path.join(dirPath, 'large')
@@ -677,6 +681,7 @@ class AbstractJobStoreTest(object):
                 except:
                     self.fail()
 
+        @slow
         def testCleanCache(self):
             # Make a bunch of jobs
             master = self.master
@@ -759,6 +764,7 @@ class AbstractJobStoreTest(object):
             """
             raise NotImplementedError()
 
+        @slow
         def testDestructionOfCorruptedJobStore(self):
             self._corruptJobStore()
             worker = self._createJobStore()
@@ -990,6 +996,7 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
                     with attempt:
                         s3.delete_bucket(bucket=bucket)
 
+    @slow
     def testInlinedFiles(self):
         from toil.jobStores.aws.jobStore import AWSJobStore
         master = self.master
@@ -1011,6 +1018,7 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
             args, kwargs = mock_log.warn.call_args
             self.assertTrue('Could not determine location' in args[0])
 
+    @slow
     def testMultiPartImportFailures(self):
         # This should be less than the number of threads in the pool used by the MP copy.
         num_parts = 10
@@ -1213,6 +1221,7 @@ class EncryptedFileJobStoreTest(FileJobStoreTest, AbstractEncryptedJobStoreTest.
 
 @needs_aws
 @needs_encryption
+@slow
 class EncryptedAWSJobStoreTest(AWSJobStoreTest, AbstractEncryptedJobStoreTest.Test):
     pass
 

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -1126,7 +1126,7 @@ class InvalidAWSJobStoreTest(ToilTest):
 
 @needs_azure
 class AzureJobStoreTest(AbstractJobStoreTest.Test):
-    accountName = 'toiltest'
+    accountName = os.getenv('TOIL_AZURE_KEYNAME')
 
     def _createJobStore(self):
         from toil.jobStores.azureJobStore import AzureJobStore

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -1228,6 +1228,7 @@ class EncryptedAWSJobStoreTest(AWSJobStoreTest, AbstractEncryptedJobStoreTest.Te
 
 @needs_azure
 @needs_encryption
+@slow
 class EncryptedAzureJobStoreTest(AzureJobStoreTest, AbstractEncryptedJobStoreTest.Test):
     pass
 

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -11,7 +11,7 @@ from bd2k.util.files import mkdir_p
 from toil.job import Job
 from toil.leader import FailedJobsException
 from toil.lib.docker import dockerCall, dockerCheckOutput, _containerIsRunning, _dockerKill, STOP, FORGO, RM
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 
 _log = logging.getLogger(__name__)
 
@@ -32,6 +32,7 @@ class DockerTest(ToilTest):
     def setUp(self):
         self.tempDir = self._createTempDir(purpose='tempDir')
 
+    @slow
     def testDockerClean(self, caching=True):
         """
         Run the test container that creates a file in the work dir, and sleeps for 5 minutes.  Ensure
@@ -144,6 +145,7 @@ class DockerTest(ToilTest):
     def testDockerPermissionsNonCaching(self):
         self.testDockerPermissions(caching=False)
 
+    @slow
     def testNonCachingDockerChain(self):
         self.testDockerPipeChain(caching=False)
 

--- a/src/toil/test/mesos/MesosDataStructuresTest.py
+++ b/src/toil/test/mesos/MesosDataStructuresTest.py
@@ -17,9 +17,10 @@ from builtins import range
 import uuid
 import random
 
-from toil.test import ToilTest, needs_mesos
+from toil.test import ToilTest, needs_mesos, slow
 
 
+@slow
 @needs_mesos
 class DataStructuresTest(ToilTest):
 

--- a/src/toil/test/mesos/mesosTest.py
+++ b/src/toil/test/mesos/mesosTest.py
@@ -22,7 +22,7 @@ import sys
 
 from toil.lib.bioio import getLogLevelString, system
 from toil.test.mesos.stress import main as stressMain
-from toil.test import ToilTest, needs_mesos
+from toil.test import ToilTest, needs_mesos, slow
 from toil.batchSystems.mesos.test import MesosTestSupport
 from toil.test.mesos import helloWorld
 
@@ -32,6 +32,7 @@ numCores = 2
 log = logging.getLogger(__name__)
 
 
+@slow
 @needs_mesos
 class MesosTest(ToilTest, MesosTestSupport):
     """

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -33,7 +33,7 @@ from toil.provisioners.aws.awsProvisioner import AWSProvisioner
 from uuid import uuid4
 
 
-from toil.test import needs_aws, integrative, ToilTest, needs_appliance, timeLimit
+from toil.test import needs_aws, integrative, ToilTest, needs_appliance, timeLimit, slow
 
 log = logging.getLogger(__name__)
 
@@ -41,6 +41,7 @@ log = logging.getLogger(__name__)
 @needs_aws
 @integrative
 @needs_appliance
+@slow
 class AbstractAWSAutoscaleTest(ToilTest):
 
     def sshUtil(self, command):

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -33,7 +33,7 @@ from bd2k.util.objects import InnerClass
 
 from toil.job import JobNode
 from toil.provisioners import Node
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 from toil.batchSystems.abstractBatchSystem import (AbstractScalableBatchSystem,
                                                    NodeInfo,
                                                    AbstractBatchSystem)
@@ -140,6 +140,7 @@ class ClusterScalerTest(ToilTest):
                          bs.totalWorkerTime,
                          old_div(bs.totalWorkerTime, bs.totalJobs) if bs.totalJobs > 0 else 0.0))
 
+    @slow
     def testClusterScaling(self):
         """
         Test scaling for a batch of non-preemptable jobs and no preemptable jobs (makes debugging
@@ -167,6 +168,7 @@ class ClusterScalerTest(ToilTest):
 
         self._testClusterScaling(config, numJobs=100, numPreemptableJobs=0)
 
+    @slow
     def testClusterScalingWithPreemptableJobs(self):
         """
         Test scaling simultaneously for a batch of preemptable and non-preemptable jobs.

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -330,7 +330,8 @@ class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
         return 'aws:%s:sort-test-%s' % (self.awsRegion(), uuid4())
 
     def _azureJobStore(self):
-        return "azure:toiltest:sort-test-%s" % uuid4()
+        accountName = os.getenv('TOIL_AZURE_KEYNAME')
+        return "azure:%s:sort-test-%s" % (accountName, uuid4())
 
     def _googleJobStore(self):
         return "google:cgc-05-0006:sort-test-%s" % uuid4()

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -42,6 +42,7 @@ from toil.test import (ToilTest,
                        needs_gridengine,
                        needs_torque,
                        needs_google,
+                       slow,
                        experimental)
 from toil.jobStores.abstractJobStore import NoSuchJobStoreException, JobStoreExistsException
 from toil.leader import FailedJobsException
@@ -69,6 +70,7 @@ def runMain(options):
             raise
 
 
+@slow
 class SortTest(ToilTest, MesosTestSupport, ParasolTestSupport):
     """
     Tests Toil by sorting a file in parallel on various combinations of job stores and batch

--- a/src/toil/test/src/checkpointTest.py
+++ b/src/toil/test/src/checkpointTest.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import
 from toil.job import Job
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 from toil.leader import FailedJobsException
 from toil.jobStores.abstractJobStore import NoSuchFileException
 
@@ -32,6 +32,7 @@ class CheckpointTest(ToilTest):
         with self.assertRaises(FailedJobsException):
             Job.Runner.startToil(CheckRetryCount(numFailuresBeforeSuccess=1), options)
 
+    @slow
     def testCheckpointRetriedOnce(self):
         """A checkpoint job should be retried exactly once if the workflow has a retryCount of 1."""
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
@@ -47,6 +48,7 @@ class CheckpointTest(ToilTest):
         with self.assertRaises(FailedJobsException):
             Job.Runner.startToil(CheckRetryCount(numFailuresBeforeSuccess=2), options)
 
+    @slow
     def testCheckpointedRestartSucceeds(self):
         """A checkpointed job should succeed on restart of a failed run if its child job succeeds."""
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())

--- a/src/toil/test/src/fileStoreTest.py
+++ b/src/toil/test/src/fileStoreTest.py
@@ -66,7 +66,8 @@ class hidden(object):
             elif self.jobStoreType == 'aws':
                 return 'aws:%s:cache-tests-%s' % (self.awsRegion(), uuid4())
             elif self.jobStoreType == 'azure':
-                return 'azure:toiltest:cache-tests-' + str(uuid4())
+                accountName = os.getenv('TOIL_AZURE_KEYNAME')
+                return 'azure:%s:cache-tests-%s' % (accountName, str(uuid4()))
             elif self.jobStoreType == 'google':
                 projectID = 'cgc-05-0006'
                 return 'google:' + projectID + ':cache-tests-' + str(uuid4())
@@ -254,6 +255,7 @@ class hidden(object):
             job.defer(lmd, files[0], nlf=files[1])
             return None
 
+        @slow
         def testDeferredFunctionRunsWithFailures(self):
             """
             Create 2 non local filesto use as flags.  Create a job that registers a function that
@@ -312,6 +314,7 @@ class hidden(object):
             if nlf is not None:
                 os.remove(nlf)
 
+        @slow
         def testNewJobsCanHandleOtherJobDeaths(self):
             """
             Create 2 non-local files and then create 2 jobs. The first job registers a deferred job
@@ -484,6 +487,7 @@ class hidden(object):
                     jobs[i].addChild(F)
                 Job.Runner.startToil(E, self.options)
 
+        @slow
         def testCacheLockRace(self):
             """
             Make 3 jobs compete for the same cache lock file.  If they have the lock at the same
@@ -1149,12 +1153,14 @@ class hidden(object):
                     fH.write(pack('d', cached))
                 os.kill(os.getpid(), signal.SIGKILL)
 
+        @slow
         def testRemoveLocalMutablyReadFile(self):
             """
             If a mutably read file is deleted by the user, it is ok.
             """
             self._deleteLocallyReadFilesFn(readAsMutable=True)
 
+        @slow
         def testRemoveLocalImmutablyReadFile(self):
             """
             If an immutably read file is deleted by the user, it is not ok.

--- a/src/toil/test/src/fileStoreTest.py
+++ b/src/toil/test/src/fileStoreTest.py
@@ -1307,6 +1307,7 @@ class NonCachingFileStoreTestWithAzureJobStore(hidden.AbstractNonCachingFileStor
     jobStoreType = 'azure'
 
 
+@slow
 @needs_azure
 @pytest.mark.timeout(1000)
 class CachingFileStoreTestWithAzureJobStore(hidden.AbstractCachingFileStoreTest):
@@ -1319,6 +1320,7 @@ class NonCachingFileStoreTestWithGoogleJobStore(hidden.AbstractNonCachingFileSto
     jobStoreType = 'google'
 
 
+@slow
 @experimental
 @needs_google
 @pytest.mark.timeout(1000)

--- a/src/toil/test/src/fileStoreTest.py
+++ b/src/toil/test/src/fileStoreTest.py
@@ -25,7 +25,7 @@ from uuid import uuid4
 
 from toil.job import Job
 from toil.fileStore import IllegalDeletionCacheError, CachingFileStore
-from toil.test import ToilTest, needs_aws, needs_azure, needs_google, experimental
+from toil.test import ToilTest, needs_aws, needs_azure, needs_google, experimental, slow
 from toil.leader import FailedJobsException
 from toil.jobStores.abstractJobStore import NoSuchFileException
 from toil.fileStore import CacheUnbalancedError
@@ -106,6 +106,7 @@ class hidden(object):
 
         # Test filestore operations.  This is a slightly less intense version of the cache specific
         # test `testReturnFileSizes`
+        @slow
         def testFileStoreOperations(self):
             """
             Write a couple of files to the jobstore.  Delete a couple of them.  Read back written
@@ -461,6 +462,7 @@ class hidden(object):
             super(hidden.AbstractCachingFileStoreTest, self).setUp()
             self.options.disableCaching = False
 
+        @slow
         def testExtremeCacheSetup(self):
             """
             Try to create the cache with bad worker active and then have 10 child jobs try to run in
@@ -540,6 +542,7 @@ class hidden(object):
                 assert cacheInfo.nlink == 0
                 assert cacheInfo.cached > 1
 
+        @slow
         def testCacheEvictionPartialEvict(self):
             """
             Ensure the cache eviction happens as expected.  Two files (20MB and 30MB) are written
@@ -555,6 +558,7 @@ class hidden(object):
 
             self._testCacheEviction(file1MB=20, file2MB=30, diskRequestMB=10)
 
+        @slow
         def testCacheEvictionTotalEvict(self):
             """
             Ensure the cache eviction happens as expected.  Two files (20MB and 30MB) are written
@@ -570,6 +574,7 @@ class hidden(object):
 
             self._testCacheEviction(file1MB=20, file2MB=30, diskRequestMB=30)
 
+        @slow
         def testCacheEvictionFailCase(self):
             """
             Ensure the cache eviction happens as expected.  Two files (20MB and 30MB) are written
@@ -707,6 +712,7 @@ class hidden(object):
                     assert cacheInfoMB == expectedMB, 'Testing %s: Expected ' % value + \
                                                       '%s but got %s.' % (expectedMB, cacheInfoMB)
 
+        @slow
         def testAsyncWriteWithCaching(self):
             """
             Ensure the Async Writing of files happens as expected.  The first Job forcefully
@@ -866,6 +872,7 @@ class hidden(object):
             A.addChild(B)
             Job.Runner.startToil(A, self.options)
 
+        @slow
         def testMultipleJobsReadSameCacheHitGlobalFile(self):
             """
             Write a local file to the job store (hence adding a copy to cache), then have 10 jobs
@@ -876,6 +883,7 @@ class hidden(object):
             """
             self._testMultipleJobsReadGlobalFileFunction(cacheHit=True)
 
+        @slow
         def testMultipleJobsReadSameCacheMissGlobalFile(self):
             """
             Write a non-local file to the job store(hence no cached copy), then have 10 jobs read
@@ -958,6 +966,7 @@ class hidden(object):
             job.fileStore.exportFile(job.fileStore.writeGlobalFile(fileName), 'File://' + outputFile)
             assert filecmp.cmp(fileName, outputFile)
 
+        @slow
         def testFileStoreExportFile(self):
             # Tests that files written to job store can be immediately exported
             # motivated by https://github.com/BD2KGenomics/toil/issues/1469
@@ -965,6 +974,7 @@ class hidden(object):
             Job.Runner.startToil(root, self.options)
 
         # Testing for the return of file sizes to the sigma job pool.
+        @slow
         def testReturnFileSizes(self):
             """
             Write a couple of files to the jobstore.  Delete a couple of them.  Read back written
@@ -979,6 +989,7 @@ class hidden(object):
                               disk='2G')
             Job.Runner.startToil(F, self.options)
 
+        @slow
         def testReturnFileSizesWithBadWorker(self):
             """
             Write a couple of files to the jobstore.  Delete a couple of them.  Read back written
@@ -1101,6 +1112,7 @@ class hidden(object):
             assert jobState['jobReqs'] == jobDisk
 
         # Testing the resumability of a failed worker
+        @slow
         def testControlledFailedWorkerRetry(self):
             """
             Conduct a couple of job store operations.  Then die.  Ensure that the restarted job is
@@ -1283,6 +1295,7 @@ class NonCachingFileStoreTestWithAwsJobStore(hidden.AbstractNonCachingFileStoreT
     jobStoreType = 'aws'
 
 
+@slow
 @needs_aws
 @pytest.mark.timeout(1000)
 class CachingFileStoreTestWithAwsJobStore(hidden.AbstractCachingFileStoreTest):

--- a/src/toil/test/src/hotDeploymentTest.py
+++ b/src/toil/test/src/hotDeploymentTest.py
@@ -7,13 +7,14 @@ from subprocess import CalledProcessError
 
 from bd2k.util.iterables import concat
 
-from toil.test import needs_mesos, ApplianceTestSupport, needs_appliance
+from toil.test import needs_mesos, ApplianceTestSupport, needs_appliance, slow
 
 log = logging.getLogger(__name__)
 
 
 @needs_mesos
 @needs_appliance
+@slow
 class HotDeploymentTest(ApplianceTestSupport):
     """
     Tests various hot-deployment scenarios. Using the appliance, i.e. a docker container,

--- a/src/toil/test/src/importExportFileTest.py
+++ b/src/toil/test/src/importExportFileTest.py
@@ -21,7 +21,7 @@ import os
 from toil.common import Toil
 from toil.job import Job
 from toil.leader import FailedJobsException
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 from toil.fileStore import FileID
 
 
@@ -72,6 +72,7 @@ class ImportExportFileTest(ToilTest):
 
         self._importExportFile(options, fail=False)
 
+    @slow
     def testImportExportRestartTrue(self):
         self._importExport(restart=True)
 

--- a/src/toil/test/src/jobFileStoreTest.py
+++ b/src/toil/test/src/jobFileStoreTest.py
@@ -51,7 +51,8 @@ class JobFileStoreTest(ToilTest):
         """
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
         options.linkImports = True
-        fileName = 'dummyFile.txt'
+        tempDir = self._createTempDir('testImportLinking')
+        fileName = os.path.join(tempDir, 'dummyFile.txt')
         with open(fileName, 'w') as fh:
             fh.write('Subtle literature reference.')
         with Toil(options) as workflow:

--- a/src/toil/test/src/jobFileStoreTest.py
+++ b/src/toil/test/src/jobFileStoreTest.py
@@ -22,7 +22,7 @@ from six.moves import xrange
 
 from toil.common import Toil
 from toil.job import Job
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 
 PREFIX_LENGTH=200
 
@@ -92,7 +92,8 @@ class JobFileStoreTest(ToilTest):
         Tests case that about half the files are cached
         """
         self._testJobFileStore(retryCount=0, badWorker=0.0,  stringNo=5, stringLength=1000000)
-    
+
+    @slow
     def testJobFileStoreWithBadWorker(self):
         """
         Tests case that about half the files are cached and the worker is randomly

--- a/src/toil/test/src/jobServiceTest.py
+++ b/src/toil/test/src/jobServiceTest.py
@@ -24,7 +24,7 @@ from six.moves import xrange
 
 from toil.lib.bioio import getTempFile
 from toil.job import Job
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 import time
 import sys
 from threading import Thread, Event
@@ -53,7 +53,8 @@ class JobServiceTest(ToilTest):
         # serialization on services is working correctly.
         
         self.runToil(job)
-        
+
+    @slow
     def testService(self, checkpoint=False):
         """
         Tests the creation of a Job.Service with random failures of the worker.
@@ -72,7 +73,8 @@ class JobServiceTest(ToilTest):
                 self.assertEquals(int(open(outFile, 'r').readline()), messageInt)
             finally:
                 os.remove(outFile)
-                
+
+    @slow
     def testServiceDeadlock(self):
         """
         Creates a job with more services than maxServices, checks that deadlock is detected.
@@ -109,6 +111,7 @@ class JobServiceTest(ToilTest):
         """
         self.testService(checkpoint=True)
 
+    @slow
     @skipIf(SingleMachineBatchSystem.numCores < 4, 'Need at least four cores to run this test')
     def testServiceRecursive(self, checkpoint=True):
         """
@@ -131,6 +134,7 @@ class JobServiceTest(ToilTest):
             finally:
                 os.remove(outFile)
 
+    @slow
     @skipIf(SingleMachineBatchSystem.numCores < 4, 'Need at least four cores to run this test')
     def testServiceParallelRecursive(self, checkpoint=True):
         """
@@ -331,7 +335,7 @@ def serviceAccessor(job, communicationFiles, outFile, randInt):
             return
 
     assert 0 # Job failed to get info from the service
-    
+
 class TestServiceSerialization(Job.Service):
     def __init__(self, messageInt, *args, **kwargs):
         """

--- a/src/toil/test/src/jobServiceTest.py
+++ b/src/toil/test/src/jobServiceTest.py
@@ -38,7 +38,8 @@ class JobServiceTest(ToilTest):
     """
     Tests testing the Job.Service class
     """
-    
+
+    @slow
     def testServiceSerialization(self):
         """
         Tests that a service can receive a promise without producing a serialization

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -30,7 +30,7 @@ from toil.common import Toil
 from toil.leader import FailedJobsException
 from toil.lib.bioio import getTempFile
 from toil.job import Job, JobGraphDeadlockException, JobFunctionWrappingJob
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 
 logger = logging.getLogger(__name__)
 
@@ -385,6 +385,7 @@ class JobTest(ToilTest):
             except expectedException as ex:
                 logger.info("The expected exception was thrown: %s", repr(ex))
 
+    @slow
     def testEvaluatingRandomDAG(self):
         """
         Randomly generate test input then check that the job graph can be 

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -56,6 +56,7 @@ class JobTest(ToilTest):
         with Toil(options) as toil:
             toil.start(Job.wrapJobFn(checkRequirements, memory='1000M'))
 
+    @slow
     def testStatic(self):
         """
         Create a DAG of jobs non-dynamically and run it. DAG is:
@@ -139,7 +140,8 @@ class JobTest(ToilTest):
             self.assertEquals(open(outFile, 'r').readline(), "ABCDE")
         finally:
             os.remove(outFile)
-            
+
+    @slow
     def testTrivialDAGConsistency(self):
         options = Job.Runner.getDefaultOptions(self._createTempDir() + '/jobStore')
         options.clean = 'always'
@@ -167,6 +169,7 @@ class JobTest(ToilTest):
             else:
                 self.fail()
 
+    @slow
     def testSiblingDAGConsistency(self):
         """
         Slightly more complex case. The stranded job's predecessors are siblings instead of
@@ -279,6 +282,7 @@ class JobTest(ToilTest):
                 and (fNode, tNode) not in childEdges and (fNode, tNode) not in followOnEdges):
                 checkFollowOnEdgeCycleDetection(fNode, tNode)
 
+    @slow
     def testNewCheckpointIsLeafVertexNonRootCase(self):
         """
         Test for issue #1465: Detection of checkpoint jobs that are not leaf vertices
@@ -300,6 +304,7 @@ class JobTest(ToilTest):
 
         self.runNewCheckpointIsLeafVertexTest(createWorkflow)
 
+    @slow
     def testNewCheckpointIsLeafVertexRootCase(self):
         """
         Test for issue #1466: Detection of checkpoint jobs that are not leaf vertices

--- a/src/toil/test/src/miscTests.py
+++ b/src/toil/test/src/miscTests.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import, print_function
 from builtins import range
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 from uuid import uuid4
 
 import math
@@ -34,6 +34,7 @@ class MiscTests(ToilTest):
         super(MiscTests, self).setUp()
         self.testDir = self._createTempDir()
 
+    @slow
     def testGetSizeOfDirectoryWorks(self):
         from toil.common import getDirSizeRecursively
         # os.stat lists the number of 512-byte blocks used, but really, the file system is using

--- a/src/toil/test/src/multipartTransferTest.py
+++ b/src/toil/test/src/multipartTransferTest.py
@@ -25,7 +25,7 @@ import boto.s3
 
 from toil.jobStores.aws.jobStore import copyKeyMultipart
 from toil.jobStores.aws.utils import region_to_bucket_location
-from toil.test import ToilTest, make_tests
+from toil.test import ToilTest, make_tests, slow
 
 partSize = 2 ** 20 * 5
 logger = logging.getLogger(__name__)
@@ -61,6 +61,7 @@ def openS3(keySize=None):
             bucket.delete()
 
 
+@slow
 class AWSMultipartCopyTest(ToilTest):
 
     @classmethod

--- a/src/toil/test/src/promisedRequirementTest.py
+++ b/src/toil/test/src/promisedRequirementTest.py
@@ -24,7 +24,7 @@ import toil.test.batchSystems.batchSystemTest as batchSystemTest
 
 from toil.job import Job
 from toil.job import PromisedRequirement
-from toil.test import needs_mesos
+from toil.test import needs_mesos, slow
 from toil.batchSystems.mesos.test import MesosTestSupport
 
 log = logging.getLogger(__name__)
@@ -42,6 +42,7 @@ class hidden(object):
         An abstract base class for testing Toil workflows with promised requirements.
         """
 
+        @slow
         def testConcurrencyDynamic(self):
             """
             Asserts that promised core resources are allocated properly using a dynamic Toil workflow
@@ -56,6 +57,7 @@ class hidden(object):
                 maxValue = max(values)
                 self.assertEqual(maxValue, old_div(self.cpuCount, coresPerJob))
 
+        @slow
         def testConcurrencyStatic(self):
             """
             Asserts that promised core resources are allocated properly using a static DAG

--- a/src/toil/test/src/promisedRequirementTest.py
+++ b/src/toil/test/src/promisedRequirementTest.py
@@ -128,6 +128,7 @@ class hidden(object):
         def testPromisesWithNonCachingFileStore(self):
             self.testPromisesWithJobStoreFileObjects(caching=False)
 
+        @slow
         def testPromiseRequirementRaceStatic(self):
             """
             Checks for a race condition when using promised requirements and child job functions.

--- a/src/toil/test/src/regularLogTest.py
+++ b/src/toil/test/src/regularLogTest.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import os
 
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 from toil.test.mesos import helloWorld
 
 
@@ -46,6 +46,7 @@ class RegularLogTest(ToilTest):
                     self.assertEqual(mime[1], encoding)
 
 
+    @slow
     def testLogToMaster(self):
         toilOutput = subprocess.check_output([sys.executable,
                                               '-m', helloWorld.__name__,
@@ -64,6 +65,7 @@ class RegularLogTest(ToilTest):
                                              stderr=subprocess.STDOUT)
         self._assertFileTypeExists(self.tempDir, '.log')
 
+    @slow
     def testWriteGzipLogs(self):
         toilOutput = subprocess.check_output([sys.executable,
                                               '-m', helloWorld.__name__,
@@ -74,6 +76,7 @@ class RegularLogTest(ToilTest):
                                               stderr=subprocess.STDOUT)
         self._assertFileTypeExists(self.tempDir, '.log.gz', 'gzip')
 
+    @slow
     def testMultipleLogToMaster(self):
         toilOutput = subprocess.check_output([sys.executable,
                                               '-m', helloWorld.__name__,

--- a/src/toil/test/src/restartDAGTest.py
+++ b/src/toil/test/src/restartDAGTest.py
@@ -19,7 +19,7 @@ import logging
 from toil.common import Toil
 from toil.job import Job
 from toil.leader import FailedJobsException
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 
 import inspect
 import os
@@ -44,9 +44,11 @@ class RestartDAGTest(ToilTest):
         super(RestartDAGTest, self).tearDown()
         shutil.rmtree(self.testJobStore)
 
+    @slow
     def testRestartedWorkflowSchedulesCorrectJobsOnFailedParent(self):
         self._testRestartedWorkflowSchedulesCorrectJobs('raise')
 
+    @slow
     def testRestartedWorkflowSchedulesCorrectJobsOnKilledParent(self):
         self._testRestartedWorkflowSchedulesCorrectJobs('kill')
 

--- a/src/toil/test/src/resumabilityTest.py
+++ b/src/toil/test/src/resumabilityTest.py
@@ -20,10 +20,11 @@ import os
 from six.moves import xrange
 
 from toil.job import Job
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 from toil.jobStores.abstractJobStore import NoSuchFileException
 from toil.leader import FailedJobsException
 
+@slow
 class ResumabilityTest(ToilTest):
     """
     https://github.com/BD2KGenomics/toil/issues/808

--- a/src/toil/test/src/toilContextManagerTest.py
+++ b/src/toil/test/src/toilContextManagerTest.py
@@ -15,9 +15,10 @@
 from __future__ import absolute_import
 from toil.common import Toil, ToilContextManagerException
 from toil.job import Job
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 
 
+@slow
 class ToilContextManagerTest(ToilTest):
     def testContextManger(self):
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())

--- a/src/toil/test/src/userDefinedJobArgTypeTest.py
+++ b/src/toil/test/src/userDefinedJobArgTypeTest.py
@@ -17,7 +17,7 @@ from builtins import object
 import sys
 from subprocess import check_call
 from toil.job import Job
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 
 
 class UserDefinedJobArgTypeTest(ToilTest):
@@ -39,6 +39,7 @@ class UserDefinedJobArgTypeTest(ToilTest):
         """Test with first job being a function"""
         Job.Runner.startToil(Job.wrapJobFn(jobFunction, 0, Foo()), self.options)
 
+    @slow
     def testJobClass(self):
         """Test with first job being an instance of a class"""
         Job.Runner.startToil(JobClass(0, Foo()), self.options)

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -257,6 +257,7 @@ class UtilsTest(ToilTest):
         # Check we can run 'toil clean'
         system(self.cleanCommand)
 
+    @slow
     def testUtilsStatsSort(self):
         """
         Tests the stats commands on a complete run of the stats test.
@@ -295,6 +296,7 @@ class UtilsTest(ToilTest):
         options.logLevel = 'debug'
         Job.Runner.startToil(Job.wrapFn(printUnicodeCharacter), options)
 
+    @slow
     def testMultipleJobsPerWorkerStats(self):
         """
         Tests case where multiple jobs are run on 1 worker to insure that all jobs report back their data

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -30,7 +30,7 @@ import toil.test.sort.sort
 from toil import resolveEntryPoint
 from toil.job import Job
 from toil.lib.bioio import getTempFile, system
-from toil.test import ToilTest, needs_aws, needs_rsync3, integrative
+from toil.test import ToilTest, needs_aws, needs_rsync3, integrative, slow
 from toil.test.sort.sortTest import makeFileToSort
 from toil.utils.toilStats import getStats, processData
 from toil.common import Toil, Config
@@ -87,6 +87,7 @@ class UtilsTest(ToilTest):
     @pytest.mark.timeout(1200)
     @needs_aws
     @integrative
+    @slow
     def testAWSProvisionerUtils(self):
         clusterName = 'cluster-utils-test' + str(uuid.uuid4())
         keyName = os.getenv('TOIL_AWS_KEYNAME')
@@ -185,6 +186,7 @@ class UtilsTest(ToilTest):
             except NameError:
                 pass
 
+    @slow
     def testUtilsSort(self):
         """
         Tests the status and stats commands of the toil command line utility using the


### PR DESCRIPTION
If TOIL_TEST_QUICK=True, all tests with the 'slow' decorator will be skipped. Quick, in this case, is 15 minutes on my laptop.

Any critical tests that are not too long could be added back in.