### PR TITLE
fix in NonCachingFileStore:open that may delete the parent directory of localTempDir (resolves #1825)

### DIFF
--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -106,7 +106,6 @@ class FileStore(object):
         self.jobStore = jobStore
         self.jobGraph = jobGraph
         self.localTempDir = os.path.abspath(localTempDir)
-        self.workFlowDir = os.path.dirname(self.localTempDir)
         self.jobName = self.jobGraph.command.split()[1]
         self.inputBlockFn = inputBlockFn
         self.loggingMessages = []
@@ -1605,8 +1604,8 @@ class NonCachingFileStore(FileStore):
     def open(self, job):
         jobReqs = job.disk
         startingDir = os.getcwd()
+        self.findAndHandleDeadJobs(self.localTempDir)
         self.localTempDir = makePublicDir(os.path.join(self.localTempDir, str(uuid.uuid4())))
-        self.findAndHandleDeadJobs(self.workFlowDir)
         self.jobStateFile = self._createJobStateFile()
         freeSpace, diskSize = getFileSystemSize(self.localTempDir)
         if freeSpace <= 0.1 * diskSize:


### PR DESCRIPTION
The fix remove workFlowDir from the base class FileStore, and call findAndHandleDeadJobs(localTempDir) in NonCachingFileStore:open, before localTempDir is changed to sub directory.