### PR TITLE
GridEngine not Gridengine

### DIFF
--- a/src/toil/batchSystems/registry.py
+++ b/src/toil/batchSystems/registry.py
@@ -13,8 +13,8 @@
 #
 
 def _gridengineBatchSystemFactory():
-    from toil.batchSystems.gridengine import GridengineBatchSystem
-    return GridengineBatchSystem
+    from toil.batchSystems.gridengine import GridEngineBatchSystem
+    return GridEngineBatchSystem
 
 def _parasolBatchSystemFactory():
     from toil.batchSystems.parasol import ParasolBatchSystem


### PR DESCRIPTION
There was a typo in the import statement that I corrected. Should be GridEngine not Gridengine.