### PR TITLE
Removed split

### DIFF
--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -60,7 +60,7 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
 
         def submitJob(self, subLine):
             process = subprocess.Popen(subLine, stdout=subprocess.PIPE)
-            result = int(process.stdout.readline().strip().split('.')[0])
+            result = int(process.stdout.readline().strip())
             return result
 
         def getJobExitCode(self, sgeJobID):


### PR DESCRIPTION
Split was causing white character to return such that casting to int was returning an error.