### PR TITLE
Update testing docs (resolves #1841, #1848)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ particular test, e.g.
 
 	make test tests=src/toil/test/sort/sortTest.py::SortTest::testSort
 
-The 'test_local' target is similar to 'test' but it skips the docker dependent tests and their
+The 'test_offline' target is similar to 'test' but it skips the docker dependent tests and their
 setup.
 
 The 'integration_test_local' target runs toil's integration tests. These are more thorough but also

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -61,6 +61,32 @@ involving both the Parasol feature and the Azure extra, use the following::
 
     $ make test tests="-m 'not azure and not parasol' src"
 
+Running tests with pytest
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Often it is simpler to use pytest directly, instead of calling the ``make`` wrapper.
+This usually works as expected, but some tests need some manual preparation.
+
+ - Running tests that make use of Docker (e.g. autoscaling tests and Docker tests)
+   require an appliance image to be hosted. This process first requires :ref:`quaySetup`.
+   Then to build and host the appliance image run the ``make`` targets ``docker``
+   and ``push_docker`` respectively.
+
+ - Running integration tests require setting the environment variable ::
+
+       export TOIL_TEST_INTEGRATIVE=True
+
+To run a specific test with pytest ::
+
+    python -m pytest src/toil/test/sort/sortTest.py::SortTest::testSort
+
+For more information, see the `pytest documentation`_.
+
+.. _pytest documentation: https://docs.pytest.org/en/latest/
+
+
+.. _quaySetup:
+
 Installing Docker with Quay
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `Docker`_ is needed for some of the tests. Follow the appropriate

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -114,9 +114,7 @@ as soon as a developer makes a commit or dirties the working copy they will no
 longer be able to rely on Toil to automatically detect the proper Toil Appliance
 image. Instead, developers wishing to test any appliance changes in autoscaling
 should build and push their own appliance image to a personal Docker registry.
-See :ref:`Autoscaling` and :func:`toil.applianceSelf` for information on how to
-configure Toil to pull the Toil Appliance image from your personal repo instead
-of the our official Quay account.
+This is described in the next section.
 
 General workflow for using Quay
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -38,29 +38,6 @@ To make integration tests easier to debug locally one can use
 which runs the integration tests in serial and doesn't redirect output. This makes it appears on the terminal as
 expected.
 
-
-Installing Docker with Quay
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-`Docker`_ is needed for some of the tests. Follow the appopriate
-installation instructions for your system on their website to get started.
-
-When running ``make test`` you might still get the following error::
-
-   $ make test
-   Please set TOIL_DOCKER_REGISTRY, e.g. to quay.io/USER.
-
-To solve, make an account with `Quay`_ and specify it like so::
-
-   $ TOIL_DOCKER_REGISTRY=quay.io/USER make test
-
-where ``USER`` is your Quay username.
-
-For convenience you may want to add this variable to your bashrc by running
-
-::
-
-   $ echo 'export TOIL_DOCKER_REGISTRY=quay.io/USER' >> $HOME/.bashrc
-
 Run an individual test with
 
 ::
@@ -83,6 +60,28 @@ not extras, such as the ``gridengine`` and ``parasol`` features.  To skip tests
 involving both the Parasol feature and the Azure extra, use the following::
 
     $ make test tests="-m 'not azure and not parasol' src"
+
+Installing Docker with Quay
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`Docker`_ is needed for some of the tests. Follow the appropriate
+installation instructions for your system on their website to get started.
+
+When running ``make test`` you might still get the following error::
+
+   $ make test
+   Please set TOIL_DOCKER_REGISTRY, e.g. to quay.io/USER.
+
+To solve, make an account with `Quay`_ and specify it like so::
+
+   $ TOIL_DOCKER_REGISTRY=quay.io/USER make test
+
+where ``USER`` is your Quay username.
+
+For convenience you may want to add this variable to your bashrc by running
+
+::
+
+   $ echo 'export TOIL_DOCKER_REGISTRY=quay.io/USER' >> $HOME/.bashrc
 
 Running Mesos tests
 ~~~~~~~~~~~~~~~~~~~

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -500,7 +500,8 @@ def integrative(test_item):
         return test_item
     else:
         return unittest.skip(
-            'Set TOIL_TEST_INTEGRATIVE="True" to include this integration test.')(test_item)
+            'Set TOIL_TEST_INTEGRATIVE="True" to include this integration test, '
+            'or run `make integration_test_local` to run all integration tests.')(test_item)
 
 
 methodNamePartRegex = re.compile('^[a-zA-Z_0-9]+$')


### PR DESCRIPTION
This adds a section describing what steps are necessary to run tests using pytest (this includes setting TEST_INTEGRATIVE for integration tests).

This also fixes the outdated reference to test_local (should be test_offline).

There are also miscellaneous fixes (minor reorganization, better error message, etc.)