### PR TITLE
Fix flaky AWS and cache tests

### DIFF
--- a/src/toil/jobStores/aws/utils.py
+++ b/src/toil/jobStores/aws/utils.py
@@ -392,12 +392,14 @@ def retry_sdb(delays=default_delays, timeout=default_timeout, predicate=retryabl
 
 
 def retryable_s3_errors(e):
-    return (isinstance(e, (S3CreateError, S3ResponseError))
-            and e.status == 409
-            and 'try again' in e.message
+    return ((isinstance(e, (S3CreateError, S3ResponseError))
+             and e.status == 409
+             and 'try again' in e.message)
             or connection_reset(e)
-            or isinstance(e, BotoServerError) and e.status == 500
-            or isinstance(e, S3CopyError) and 'try again' in e.message)
+            or (isinstance(e, BotoServerError) and e.status == 500)
+            # Throttling response sometimes received on bucket creation
+            or (isinstance(e, BotoServerError) and e.status == 503 and e.code == 'SlowDown')
+            or (isinstance(e, S3CopyError) and 'try again' in e.message))
 
 
 def retry_s3(delays=default_delays, timeout=default_timeout, predicate=retryable_s3_errors):

--- a/src/toil/test/src/fileStoreTest.py
+++ b/src/toil/test/src/fileStoreTest.py
@@ -33,7 +33,7 @@ import os
 import random
 import signal
 import time
-import unittest
+import pytest
 
 # Python 3 compatibility imports
 from six.moves import xrange
@@ -1272,7 +1272,7 @@ class _deleteMethods(object):
 class NonCachingFileStoreTestWithFileJobStore(hidden.AbstractNonCachingFileStoreTest):
     jobStoreType = 'file'
 
-
+@pytest.mark.timeout(1000)
 class CachingFileStoreTestWithFileJobStore(hidden.AbstractCachingFileStoreTest):
     jobStoreType = 'file'
 
@@ -1283,6 +1283,7 @@ class NonCachingFileStoreTestWithAwsJobStore(hidden.AbstractNonCachingFileStoreT
 
 
 @needs_aws
+@pytest.mark.timeout(1000)
 class CachingFileStoreTestWithAwsJobStore(hidden.AbstractCachingFileStoreTest):
     jobStoreType = 'aws'
 
@@ -1293,6 +1294,7 @@ class NonCachingFileStoreTestWithAzureJobStore(hidden.AbstractNonCachingFileStor
 
 
 @needs_azure
+@pytest.mark.timeout(1000)
 class CachingFileStoreTestWithAzureJobStore(hidden.AbstractCachingFileStoreTest):
     jobStoreType = 'azure'
 
@@ -1305,6 +1307,7 @@ class NonCachingFileStoreTestWithGoogleJobStore(hidden.AbstractNonCachingFileSto
 
 @experimental
 @needs_google
+@pytest.mark.timeout(1000)
 class CachingFileStoreTestWithGoogleJobStore(hidden.AbstractCachingFileStoreTest):
     jobStoreType = 'google'
 


### PR DESCRIPTION
This should address these two rare test failures:

- http://jenkins.cgcloud.info/job/toil-pull-requests/3214/testReport/junit/src.toil.test.jobStores.jobStoreTest/AWSJobStoreTest/testSDBDomainsDeletedOnFailedJobstoreBucketCreation/
- http://jenkins.cgcloud.info/job/toil-pull-requests/3213/testReport/junit/src.toil.test.src.fileStoreTest/CachingFileStoreTestWithAzureJobStore/testAsyncWriteWithCaching/