### PR TITLE
Use a socket to get the public-facing IP (resolves #1877, #1858)

### DIFF
--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -59,7 +59,7 @@ def _singleMachineOptions(addOptionFn):
 
 
 def _mesosOptions(addOptionFn):
-    addOptionFn("--mesosMaster", dest="mesosMasterAddress", default=getPublicIP(),
+    addOptionFn("--mesosMaster", dest="mesosMasterAddress", default=getPublicIP() + ':5050',
                 help=("The host and port of the Mesos master separated by colon. (default: %(default)s)"))
 
 # Built in batch systems that have options

--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -16,11 +16,27 @@ from __future__ import absolute_import
 from .registry import batchSystemFactoryFor, defaultBatchSystem, uniqueNames
 
 import socket
+from contextlib import closing
 
+def getPublicIP():
+    """Get the IP that this machine uses to contact the internet.
 
-def getLocalIP():
-    # may return localhost on some systems (not osx and coreos) https://stackoverflow.com/a/166520
-    return socket.gethostbyname(socket.gethostname())
+    If behind a NAT, this will still be this computer's IP, and not the router's."""
+    try:
+        # Try to get the internet-facing IP by attempting a connection
+        # to a non-existent server and reading what IP was used.
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as sock:
+            # 203.0.113.0/24 is reserved as TEST-NET-3 by RFC 5737, so
+            # there is guaranteed to be no one listening on the other
+            # end (and we won't accidentally DOS anyone).
+            sock.connect(('203.0.113.1', 1))
+            ip = sock.getsockname()[0]
+        return ip
+    except:
+        # Something went terribly wrong. Just give loopback rather
+        # than killing everything, because this is often called just
+        # to provide a default argument
+        return '127.0.0.1'
 
 def _parasolOptions(addOptionFn):
     addOptionFn("--parasolCommand", dest="parasolCommand", default=None,
@@ -43,8 +59,8 @@ def _singleMachineOptions(addOptionFn):
 
 
 def _mesosOptions(addOptionFn):
-    addOptionFn("--mesosMaster", dest="mesosMasterAddress", default=None,
-                help=("The host and port of the Mesos master separated by colon. default=%s" % 'localhost:5050'))
+    addOptionFn("--mesosMaster", dest="mesosMasterAddress", default=getPublicIP(),
+                help=("The host and port of the Mesos master separated by colon. (default: %(default)s)"))
 
 # Built in batch systems that have options
 _OPTIONS = [
@@ -96,7 +112,7 @@ def setDefaultOptions(config):
     config.linkImports = False
 
     # mesos
-    config.mesosMasterAddress = '%s:5050' % getLocalIP()
+    config.mesosMasterAddress = '%s:5050' % getPublicIP()
 
     # parasol
     config.parasolCommand = 'parasol'

--- a/src/toil/realtimeLogger.py
+++ b/src/toil/realtimeLogger.py
@@ -25,13 +25,14 @@ import os.path
 import json
 import logging
 import logging.handlers
-import socket
 import threading
 
 # Python 3 compatibility imports
 from six.moves import socketserver as SocketServer
 
 import toil.lib.bioio
+from toil.batchSystems.options import getPublicIP
+
 from future.utils import with_metaclass
 
 log = logging.getLogger(__name__)
@@ -145,16 +146,7 @@ class RealtimeLogger(with_metaclass(RealtimeLoggerMetaclass, object)):
                     cls.serverThread.start()
 
                     # Set options for logging in the environment so they get sent out to jobs
-                    fqdn = socket.getfqdn()
-                    try:
-                        ip = socket.gethostbyname(fqdn)
-                    except socket.gaierror:
-                        # FIXME: Does this only happen for me? Should we librarize the work-around?
-                        import platform
-                        if platform.system() == 'Darwin' and '.' not in fqdn:
-                            ip = socket.gethostbyname(fqdn + '.local')
-                        else:
-                            raise
+                    ip = getPublicIP()
                     port = cls.loggingServer.server_address[1]
 
                     def _setEnv(name, value):

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -960,7 +960,7 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
             testJobStoreUUID = str(uuid.uuid4())
             # Create the nucket at the external region
             s3 = S3Connection()
-            for attempt in retry_s3():
+            for attempt in retry_s3(delays=(2,5,10,30,60), timeout=600):
                 with attempt:
                     bucket = s3.create_bucket('domain-test-' + testJobStoreUUID + '--files',
                                               location=externalAWSLocation)


### PR DESCRIPTION
The old method (relying on the FQDN resolving correctly) crashed Toil
on some OSes (depending on your DNS server).

Fixes #1877, #1858.