### PR TITLE
Fix bugs in the Parasol batch system

### DIFF
--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -35,6 +35,7 @@ from bd2k.util.processes import which
 
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
 from toil.lib.bioio import getTempFile
+from toil.common import Toil
 
 logger = logging.getLogger(__name__)
 
@@ -63,9 +64,14 @@ class ParasolBatchSystem(BatchSystemSupport):
                 command = next(which(command))
             except StopIteration:
                 raise RuntimeError("Can't find %s on PATH." % command)
-        logger.debug('Using Parasol at %s', command)
+        logger.info('Using Parasol at %s', command)
         self.parasolCommand = command
-        self.parasolResultsDir = tempfile.mkdtemp(dir=config.jobStore)
+        jobStoreType, path = Toil.parseLocator(config.jobStore)
+        if jobStoreType != 'file':
+            raise RuntimeError("The parasol batch system doesn't currently work with any "
+                               "jobStore type except file jobStores.")
+        self.parasolResultsDir = tempfile.mkdtemp(dir=os.path.abspath(path))
+        logger.debug("Using parasol results dir: %s", self.parasolResultsDir)
 
         # In Parasol, each results file corresponds to a separate batch, and all jobs in a batch
         # have the same cpu and memory requirements. The keys to this dictionary are the (cpu,
@@ -175,7 +181,7 @@ class ParasolBatchSystem(BatchSystemSupport):
             if match is None:
                 # This is because parasol add job will return success, even if the job was not
                 # properly issued!
-                logger.debug('We failed to properly add the job, we will try again after a 5s.')
+                logger.info('We failed to properly add the job, we will try again after a 5s.')
                 time.sleep(5)
             else:
                 jobID = int(match.group(1))
@@ -190,7 +196,7 @@ class ParasolBatchSystem(BatchSystemSupport):
         return super(ParasolBatchSystem, self).setEnv(name, value)
 
     def __environment(self):
-        return (k + '=' + (os.environ[k] if v is None else v) for k, v in list(self.environment.items()))
+        return (k + '=' + (os.environ[k] if v is None else v) for k, v in self.environment.items())
 
     def killBatchJobs(self, jobIDs):
         """Kills the given jobs, represented as Job ids, then checks they are dead by checking
@@ -202,7 +208,7 @@ class ParasolBatchSystem(BatchSystemSupport):
                     self.runningJobs.remove(jobID)
                 exitValue = self._runParasol(['remove', 'job', str(jobID)],
                                              autoRetry=False)[0]
-                logger.debug("Tried to remove jobID: %i, with exit value: %i" % (jobID, exitValue))
+                logger.info("Tried to remove jobID: %i, with exit value: %i" % (jobID, exitValue))
             runningJobs = self.getIssuedBatchJobIDs()
             if set(jobIDs).difference(set(runningJobs)) == set(jobIDs):
                 break
@@ -222,15 +228,11 @@ class ParasolBatchSystem(BatchSystemSupport):
         Get all queued and running jobs for a results file.
         """
         jobIDs = []
-        for line in self._runParasol(['-results=' + resultsFile, 'pstat2'])[1]:
-            runningJobMatch = self.runningPattern.match(line)
-            queuedJobMatch = self.queuePattern.match(line)
-            if runningJobMatch:
-                jobID = runningJobMatch.group(1)
-            elif queuedJobMatch:
-                jobID = queuedJobMatch.group(1)
-            else:
+        for line in self._runParasol(['-extended', 'list', 'jobs'])[1]:
+            fields = line.strip().split()
+            if len(fields) == 0 or fields[-1] != resultsFile:
                 continue
+            jobID = fields[0]
             jobIDs.append(int(jobID))
         return set(jobIDs)
 

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -17,6 +17,7 @@ from __future__ import division
 from builtins import next
 from builtins import str
 from past.utils import old_div
+from future.utils import listitems
 import logging
 import os
 import re
@@ -196,7 +197,7 @@ class ParasolBatchSystem(BatchSystemSupport):
         return super(ParasolBatchSystem, self).setEnv(name, value)
 
     def __environment(self):
-        return (k + '=' + (os.environ[k] if v is None else v) for k, v in self.environment.items())
+        return (k + '=' + (os.environ[k] if v is None else v) for k, v in listitems(self.environment))
 
     def killBatchJobs(self, jobIDs):
         """Kills the given jobs, represented as Job ids, then checks they are dead by checking
@@ -220,7 +221,6 @@ class ParasolBatchSystem(BatchSystemSupport):
             if jobID in list(self.jobIDsToCpu.keys()):
                 self.usedCpus -= self.jobIDsToCpu.pop(jobID)
 
-    queuePattern = re.compile(r'q\s+([0-9]+)')
     runningPattern = re.compile(r'r\s+([0-9]+)\s+[\S]+\s+[\S]+\s+([0-9]+)\s+[\S]+')
 
     def getJobIDsForResultsFile(self, resultsFile):

--- a/src/toil/batchSystems/parasolTestSupport.py
+++ b/src/toil/batchSystems/parasolTestSupport.py
@@ -6,6 +6,7 @@ import threading
 import time
 import subprocess
 import multiprocessing
+import signal
 import os
 from bd2k.util.files import rm_f
 from bd2k.util.objects import InnerClass
@@ -60,7 +61,7 @@ class ParasolTestSupport(object):
             with self.lock:
                 self.popen = subprocess.Popen(command)
             status = self.popen.wait()
-            if status != 0:
+            if status != 0 and status != -signal.SIGKILL:
                 log.error("Command '%s' failed with %i.", command, status)
                 raise subprocess.CalledProcessError(status, command)
             log.info('Exiting %s', self.__class__.__name__)


### PR DESCRIPTION
This should hopefully make Parasol usable on the master branch, so that we don't have to keep up our toil fork on juggernaut/kolossus. I've tested it out, and the memory requirements seem to be enforced correctly, which I know was a worry before.

- Didn't parse jobStore path correctly: it now does, and fails early
if using anything but the FileJobStore
- The previous version attempted to remove jobs that it didn't launch.