### PR TITLE
Put jobName into the _toil_worker arguments (resolves #1884)

### DIFF
--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -532,7 +532,7 @@ class Leader(object):
         Add a job to the queue of jobs
         """
         jobNode.command = ' '.join((resolveEntryPoint('_toil_worker'),
-                                    self.jobStoreLocator, jobNode.jobStoreID))
+                                    jobNode.jobName, self.jobStoreLocator, jobNode.jobStoreID))
         jobBatchSystemID = self.batchSystem.issueBatchJob(jobNode)
         self.jobBatchSystemIDToIssuedJob[jobBatchSystemID] = jobNode
         if jobNode.preemptable:

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -47,8 +47,7 @@ from toil.jobStores.abstractJobStore import NoSuchJobException
 from toil.provisioners.clusterScaler import ClusterScaler
 from toil.serviceManager import ServiceManager
 from toil.statsAndLogging import StatsAndLogging
-from toil.jobGraph import JobNode
-from toil.job import ServiceJobNode
+from toil.job import JobNode, ServiceJobNode
 from toil.toilState import ToilState
 
 logger = logging.getLogger( __name__ )

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -98,11 +98,9 @@ def main():
     #Input args
     ##########################################
     
-    jobStoreLocator = sys.argv[1]
-    jobStoreID = sys.argv[2]
-    # we really want a list of job names but the ID will suffice if the job graph can't
-    # be loaded. If we can discover the name, we will replace this initial entry
-    listOfJobs = [jobStoreID]
+    listOfJobs = [sys.argv[1]]
+    jobStoreLocator = sys.argv[2]
+    jobStoreID = sys.argv[3]
     
     ##########################################
     #Load the jobStore/config file


### PR DESCRIPTION
This should make it easier to see what's happening on a node when using `ps` and similar tools. A typical `ps aux` line now looks like this:

```
joel     32119 60.5  0.4 566948 67128 pts/2    Sl+  19:20   0:43 /home/joel/toil-fresh/venv/bin/python /home/joel/toil-fresh/venv/bin/_toil_worker _forceModifyCacheLockFile file:/tmp/toil-test-toil.test.src.fileStoreTest.CachingFileStoreTestWithFileJobStore-testAsyncWriteWithCaching-jobstore-5zRacP H/L/jobLfK9ai
```

which is a little noisy, but the `_forceModifyCacheLockFile` is the name of the job being run.

This also tweaks leader.py to import JobNode from where it's defined, in job.py, rather than from jobGraph.py where it happens to be imported.