### PR TITLE
Batch: cache instead of block for statePollingWait

### DIFF
--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -67,18 +67,18 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
         """
         def getRunningJobIDs(self):
             times = {}
-
-            self.boss.sleepSeconds() 
             currentjobs = dict((str(self.batchJobIDs[x][0].strip()), x) for x in self.runningJobs)
             logger.debug("getRunningJobIDs current jobs are: " + str(currentjobs))
-            # Limit qstat to current username to avoid clogging the batch system on heavily loaded clusters
-            #job_user = os.environ.get('USER')
-            #process = subprocess.Popen(['qstat', '-u', job_user], stdout=subprocess.PIPE)
-            # -x shows exit status in PBSPro, not XML output like OSS PBS
+            # Skip running qstat if we don't have any current jobs
+            if not currentjobs:
+                return times
+            # Only query for job IDs to avoid clogging the batch system on heavily loaded clusters
+            # PBS plain qstat will return every running job on the system.
+            jobids = sorted(currentjobs.keys())
             if self._version == "pro":
-                process = subprocess.Popen(['qstat', '-x'], stdout=subprocess.PIPE)
+                process = subprocess.Popen(['qstat', '-x'] + jobids, stdout=subprocess.PIPE)
             elif self._version == "oss":
-                process = subprocess.Popen(['qstat'], stdout=subprocess.PIPE)
+                process = subprocess.Popen(['qstat'] + jobids, stdout=subprocess.PIPE)
 
 
             stdout, stderr = process.communicate()
@@ -107,7 +107,6 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
 
         def getUpdatedBatchJob(self, maxWait):
             try:
-                self.boss.sleepSeconds()
                 logger.debug("getUpdatedBatchJob: Job updates")
                 pbsJobID, retcode = self.updatedJobsQueue.get(timeout=maxWait)
                 self.updatedJobsQueue.task_done()

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -421,7 +421,8 @@ def _addOptions(addGroupFn, config):
     addOptionFn("--deadlockWait", dest="deadlockWait", default=None,
                 help=("The minimum number of seconds to observe the cluster stuck running only the same service jobs before throwing a deadlock exception. default=%s" % config.deadlockWait))
     addOptionFn("--statePollingWait", dest="statePollingWait", default=1,
-                help=("The minimum number of seconds to wait before retrieving the current job state, in seconds"))
+                help=("Time, in seconds, to wait before doing a scheduler query for job state. "
+                      "Return cached results if within the waiting period."))
 
     #
     #Resource requirements


### PR DESCRIPTION
Improves support for configuring interval to query schedulers. This
builds off #1769 which blocked to avoid extra queries. Unfortunately
this also blocks submissions of jobs, making it hard to scale up
analyses. This change uses caching instead of blocking, so Toil can
continue to submit and monitor jobs and will refresh queries to the
scheduler only within the `statePollingWait` period. The behavior when
`statePollingWait` is unset does not change.