### PR TITLE
Refactor binpacking algorithm

### DIFF
--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -93,8 +93,8 @@ class BinPackedFit(object):
     binPack method on a list of job shapes, and use getRequiredNodes
     to get how many nodes it thinks are required.
 
-    :param Shape nodeShapes: A list of possible types of nodes that can be launched.
-
+    :param list nodeShapes: A list of possible types of nodes that can be launched (as "Shape"s).
+    :param targetTime: The time before which all jobs should at least be started.
     """
     def __init__(self, nodeShapes, targetTime=3600):
         self.nodeShapes = nodeShapes
@@ -122,73 +122,28 @@ class BinPackedFit(object):
         """
         for nodeShape, nodeReservations in iteritems(self.nodeReservations):
             for nodeReservation in nodeReservations:
-                # Attempt to add the job to node reservation
+                if nodeReservation.attemptToAddJob(jobShape, nodeShape, self.targetTime):
+                    # We succeeded adding the job to this node reservation. Now we're done.
+                    return
 
-                # We work with "reservations": just slices
-                # of time and the amount of memory, cpu,
-                # etc. still unreserved during that time slice.
-
-                # starting slice of time that we can fit in so far
-                startingReservation = nodeReservation
-                # current end of the slices we can fit in so far
-                endingReservation = startingReservation
-                # the amount of runtime of the job currently covered by slices
-                t = 0
-                # total time from when the instance started up to startingReservation
-                startingReservationTime = 0
-
-                while True:
-                    # Considering a new ending reservation.
-                    if endingReservation.fits(jobShape):
-                        t += endingReservation.shape.wallTime
-
-                        if t >= jobShape.wallTime:
-                            # The job fits into all the slices between startingReservation and endingReservation.
-                            t = 0
-                            # Update all the slices, reserving the amount of resources that this job needs.
-                            while startingReservation != endingReservation:
-                                startingReservation.shape = subtract(startingReservation.shape, jobShape)
-                                t += startingReservation.shape.wallTime
-                                startingReservation = startingReservation.nReservation
-                            assert startingReservation == endingReservation
-                            assert jobShape.wallTime - t <= startingReservation.shape.wallTime
-                            adjustReservationForJob(startingReservation, jobShape, t)
-                            return
-
-                        # If the job would fit, but is longer than the total node allocation
-                        # extend the node allocation
-                        elif endingReservation.nReservation == None and startingReservation == nodeReservation:
-                            # Extend the node reservation to accommodate jobShape
-                            endingReservation.nReservation = NodeReservation(nodeShape)
-                    else:
-                        if startingReservationTime + t <= self.targetTime:
-                            startingReservation = endingReservation.nReservation
-                            startingReservationTime += t + endingReservation.shape.wallTime
-                            t = 0
-                        else:
-                            break
-
-                    endingReservation = endingReservation.nReservation
-                    if endingReservation is None:
-                        # Reached the end of the reservation without success so stop trying to
-                        # add to reservation
-                        break
-        # Case a new node reservation is required. Assign to the smallest node shape
-        # that will fit this job, prioritizing preemptable nodes
+        # If we get here, the job didn't fit into any existing node
+        # reservations. Assign to the smallest node shape that will
+        # fit this job, prioritizing preemptable nodes
         consideredNodes = [nodeShape for nodeShape in self.nodeShapes if nodeShape.cores >= jobShape.cores and nodeShape.memory >= jobShape.memory and nodeShape.disk >= jobShape.disk and (jobShape.preemptable or not nodeShape.preemptable)]
         if len(consideredNodes) == 0:
             return
         nodeShape = consideredNodes[0]
-        x = NodeReservation(nodeShape)
+        reservation = NodeReservation(nodeShape)
         t = nodeShape.wallTime
-        adjustReservationForJob(x, jobShape, 0)
-        self.nodeReservations[nodeShape].append(x)
+        adjustEndingReservationForJob(reservation, jobShape, 0)
+        self.nodeReservations[nodeShape].append(reservation)
 
+        # Extend the reservation if necessary to cover the job's entire runtime.
         while t < jobShape.wallTime:
-            y = NodeReservation(x.shape)
+            y = NodeReservation(reservation.shape)
             t += nodeShape.wallTime
-            x.nReservation = y
-            x = y
+            reservation.nReservation = y
+            reservation = y
 
     def getRequiredNodes(self):
         """
@@ -221,7 +176,69 @@ class NodeReservation(object):
             curRes = curRes.nReservation
         return shapes
 
-def adjustReservationForJob(reservation, jobShape, t):
+    def subtract(self, jobShape):
+        """
+        Adjust available resources of a node allocation as a job is scheduled within it.
+        """
+        self.shape = Shape(self.shape.wallTime, self.shape.memory - jobShape.memory, self.shape.cores - jobShape.cores, self.shape.disk - jobShape.disk, self.shape.preemptable)
+
+    def attemptToAddJob(self, jobShape, nodeShape, targetTime):
+        """Attempt to pack a job into this reservation timeslice and/or the reservations after it.
+
+        jobShape is the Shape of the job requirements, nodeShape is the Shape of the node this
+        is a reservation for, and targetTime is the maximum time to wait before starting this job.
+        """
+        # starting slice of time that we can fit in so far
+        startingReservation = self
+        # current end of the slices we can fit in so far
+        endingReservation = startingReservation
+        # the amount of runtime of the job currently covered by slices
+        jobTimeSoFar = 0
+        # total time from when the instance started up to startingReservation
+        startingReservationTime = 0
+
+        while True:
+            # Considering a new ending reservation.
+            if endingReservation.fits(jobShape):
+                jobTimeSoFar += endingReservation.shape.wallTime
+
+                if jobTimeSoFar >= jobShape.wallTime:
+                    # The job fits into all the slices between startingReservation and endingReservation.
+                    t = 0
+                    # Update all the slices, reserving the amount of resources that this job needs.
+                    while startingReservation != endingReservation:
+                        startingReservation.subtract(jobShape)
+                        t += startingReservation.shape.wallTime
+                        startingReservation = startingReservation.nReservation
+                    assert startingReservation == endingReservation
+                    assert jobShape.wallTime - t <= startingReservation.shape.wallTime
+                    adjustEndingReservationForJob(endingReservation, jobShape, t)
+                    # Packed the job.
+                    return True
+
+                # If the job would fit, but is longer than the total node allocation
+                # extend the node allocation
+                elif endingReservation.nReservation == None and startingReservation == self:
+                    # Extend the node reservation to accommodate jobShape
+                    endingReservation.nReservation = NodeReservation(nodeShape)
+            else:
+                if startingReservationTime + jobTimeSoFar <= targetTime:
+                    startingReservation = endingReservation.nReservation
+                    startingReservationTime += jobTimeSoFar + endingReservation.shape.wallTime
+                    jobTimeSoFar = 0
+                else:
+                    break
+
+            endingReservation = endingReservation.nReservation
+            if endingReservation is None:
+                # Reached the end of the reservation without success so stop trying to
+                # add to reservation
+                break
+        # Couldn't pack the job.
+        return False
+
+
+def adjustEndingReservationForJob(reservation, jobShape, t):
     if jobShape.wallTime - t < reservation.shape.wallTime:
         # This job only partially fills one of the slices. Create a new slice.
         reservation.shape, nS = split(reservation.shape, jobShape, jobShape.wallTime - t)
@@ -229,13 +246,7 @@ def adjustReservationForJob(reservation, jobShape, t):
         reservation.nReservation = nS
     else:
         # This job perfectly fits within the boundaries of the slices.
-        reservation.shape = subtract(reservation.shape, jobShape)
-
-def subtract(nodeShape, jobShape):
-    """
-    Adjust available resources of a node allocation as a job is scheduled within it.
-    """
-    return Shape(nodeShape.wallTime, nodeShape.memory - jobShape.memory, nodeShape.cores - jobShape.cores, nodeShape.disk - jobShape.disk, nodeShape.preemptable)
+        reservation.subtract(jobShape)
 
 def split(nodeShape, jobShape, t):
     """

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -33,6 +33,7 @@ from bd2k.util.retry import retry
 from bd2k.util.threading import ExceptionalThread
 from bd2k.util.throttle import throttle
 from itertools import islice
+from six import iteritems
 
 from toil.batchSystems.abstractBatchSystem import AbstractScalableBatchSystem, NodeInfo
 from toil.provisioners.abstractProvisioner import Shape
@@ -84,150 +85,159 @@ class RecentJobShapes(object):
         with self.lock:
             return list(self.jobShapes)
 
-
-def binPacking(jobShapes, nodeShapes):
+class BinPackedFit(object):
     """
-    Use a first fit decreasing (FFD) bin packing like algorithm to calculate an approximate
-    minimum number of nodes that will fit the given list of jobs.
-    :param Shape nodeShape: The properties of an atomic node allocation, in terms of wall-time,
-           memory, cores and local disk.
-    :param list[Shape] jobShapes: A list of shapes, each representing a job.
-    Let a *node reservation* be an interval of time that a node is reserved for, it is defined by
-    an integer number of node-allocations.
-    For a node reservation its *jobs* are the set of jobs that will be run within the node
-    reservation.
-    A minimal node reservation has time equal to one atomic node allocation, or the minimum
-    number node allocations to run the longest running job in its jobs.
-    :rtype: int
-    :returns: The minimum number of minimal node allocations estimated to be required to run all
-              the jobs in jobShapes.
+    Use a first fit decreasing (FFD) bin packing like algorithm to
+    calculate an approximate minimum number of nodes that will fit the
+    given list of jobs. To run the bin-packing algorithm, use the
+    binPack method on a list of job shapes, and use getRequiredNodes
+    to get how many nodes it thinks are required.
+
+    :param Shape nodeShapes: A list of possible types of nodes that can be launched.
+
     """
-    logger.debug('Running bin packing for node shapes %s and %s job(s).', nodeShapes, len(jobShapes))
-    # Sort in descending order from largest to smallest. The FFD like-strategy will pack the jobs in order from longest
-    # to shortest.
-    jobShapes.sort()
-    jobShapes.reverse()
+    def __init__(self, nodeShapes):
+        self.nodeShapes = nodeShapes
+        # Prioritize preemptable node shapes with the lowest memory
+        self.nodeShapes.sort(key=lambda nS: not nS.preemptable)
+        self.nodeShapes.sort(key=lambda nS: nS.memory)
+        self.nodeReservations = {nodeShape:[] for nodeShape in nodeShapes}  # The list of node reservations
 
+    def binPack(self, jobShapes):
+        """Pack a list of jobShapes into the fewest nodes reasonable. Can be run multiple times."""
+        logger.debug('Running bin packing for node shapes %s and %s job(s).', self.nodeShapes, len(jobShapes))
+        # Sort in descending order from largest to smallest. The FFD like-strategy will pack the jobs in order from longest
+        # to shortest.
+        jobShapes.sort()
+        jobShapes.reverse()
+        assert len(jobShapes) == 0 or jobShapes[0] >= jobShapes[-1]
+        for jS in jobShapes:
+            self.addJobShape(jS)
 
-    #Prioritize preemptable node shapes with the lowest memory
-    nodeShapes.sort(key=lambda nS: not nS.preemptable)
-    nodeShapes.sort(key=lambda nS: nS.memory)
-    
-    assert len(jobShapes) == 0 or jobShapes[0] >= jobShapes[-1]
-
-    class NodeReservation(object):
+    def addJobShape(self, jobShape):
         """
-        Represents a node reservation. To represent the resources available in a reservation a
-        node reservation is represented as a sequence of Shapes, each giving the resources free
-        within the given interval of time
+        Function adds the job to the first node reservation in which it will fit (this
+        is the bin-packing aspect)
         """
+        for nodeShape, nodeReservations in iteritems(self.nodeReservations):
+            for nodeReservation in nodeReservations:
+                # Attempt to add the job to node reservation
 
-        def __init__(self, shape):
-            # The wall-time and resource available
-            self.shape = shape
-            # The next portion of the reservation
-            self.nReservation = None
+                # We work with "reservations": just slices
+                # of time and the amount of memory, cpu,
+                # etc. still unreserved during that time slice.
 
-    nodeReservations = {nodeShape:[] for nodeShape in nodeShapes}  # The list of node reservations
+                # starting slice of time that we can fit in so far
+                startingReservation = nodeReservation
+                # current end of the slices we can fit in so far
+                endingReservation = startingReservation
+                # amount of the job covered by slices
+                t = 0
 
-    for jS in jobShapes:
-        def addToReservation():
-            """
-            Function adds the job, jS, to the first node reservation in which it will fit (this
-            is the bin-packing aspect)
-            """
+                while True:
+                    # Considering a new ending reservation.
+                    if endingReservation.fits(jobShape):
+                        t += endingReservation.shape.wallTime
 
-            def fits(nodeShape, jobShape):
-                """
-                Check if a job shape's resource requirements will fit within a given node allocation
-                """
-                return jobShape.memory <= nodeShape.memory and jobShape.cores <= nodeShape.cores and jobShape.disk <= nodeShape.disk and (jobShape.preemptable or not nodeShape.preemptable)
-
-            def subtract(nodeShape, jobShape):
-                """
-                Adjust available resources of a node allocation as a job is scheduled within it.
-                """
-                return Shape(nodeShape.wallTime, nodeShape.memory - jobShape.memory, nodeShape.cores - jobShape.cores, nodeShape.disk - jobShape.disk, nodeShape.preemptable)
-
-            def split(nodeShape, jobShape, t):
-                """
-                Partition a node allocation into two
-                """
-                return (Shape(t, nodeShape.memory - jobShape.memory, nodeShape.cores - jobShape.cores, nodeShape.disk - jobShape.disk, nodeShape.preemptable),
-                        NodeReservation(Shape(nodeShape.wallTime - t, nodeShape.memory, nodeShape.cores, nodeShape.disk, nodeShape.preemptable)))
-
-            for nodeShape in nodeShapes:
-                for nodeReservation in nodeReservations[nodeShape]:
-                    # Attempt to add the job to node reservation
-
-                    # We work with "reservations": just slices
-                    # of time and the amount of memory, cpu,
-                    # etc. still unreserved during that time slice.
-
-                    # starting slice of time that we can fit in so far
-                    startingReservation = nodeReservation
-                    # current end of the slices we can fit in so far
-                    endingReservation = startingReservation
-                    t = 0
-
-                    while True:
-                        if fits(endingReservation.shape, jS):
-                            t += endingReservation.shape.wallTime
-
-                            if t >= jS.wallTime:
-                                # The job fits into all the slices between startingReservation and endingReservation.
-                                t = 0
-                                # Update all the slices, reserving the amount of resources that this job needs.
-                                while startingReservation != endingReservation:
-                                    startingReservation.shape = subtract(startingReservation.shape, jS)
-                                    t += startingReservation.shape.wallTime
-                                    startingReservation = startingReservation.nReservation
-                                assert startingReservation == endingReservation
-                                assert jS.wallTime - t <= startingReservation.shape.wallTime
-
-                                if jS.wallTime - t < startingReservation.shape.wallTime:
-                                    # This job only partially fills one of the slices. Create a new slice.
-                                    startingReservation.shape, nS = split(startingReservation.shape, jS, jS.wallTime - t)
-                                    nS.nReservation = startingReservation.nReservation
-                                    startingReservation.nReservation = nS
-                                else:
-                                    # This job perfectly fits within the boundaries of the slices.
-                                    assert jS.wallTime - t == startingReservation.shape.wallTime
-                                    startingReservation.shape = subtract(startingReservation.shape, jS)
-                                return
-
-                            # If the job would fit, but is longer than the total node allocation
-                            # extend the node allocation
-                            elif endingReservation.nReservation == None and startingReservation == nodeReservation:
-                                # Extend the node reservation to accommodate jS
-                                endingReservation.nReservation = NodeReservation(nodeShape)
-                        else: # Does not fit, reset
-                            startingReservation = endingReservation.nReservation
+                        if t >= jobShape.wallTime:
+                            # The job fits into all the slices between startingReservation and endingReservation.
                             t = 0
+                            # Update all the slices, reserving the amount of resources that this job needs.
+                            while startingReservation != endingReservation:
+                                startingReservation.shape = subtract(startingReservation.shape, jobShape)
+                                t += startingReservation.shape.wallTime
+                                startingReservation = startingReservation.nReservation
+                            assert startingReservation == endingReservation
+                            assert jobShape.wallTime - t <= startingReservation.shape.wallTime
 
-                        endingReservation = endingReservation.nReservation
-                        if endingReservation is None:
-                            # Reached the end of the reservation without success so stop trying to
-                            # add to reservation
-                            break
-            # Case a new node reservation is required. Assign to the smallest node shape
-            # that will fit this job, prioritizing preemptable nodes
-            consideredNodes = [nodeShape for nodeShape in nodeShapes if nodeShape.cores >= jS.cores and nodeShape.memory >= jS.memory and nodeShape.disk >= jS.disk and (jS.preemptable or not nodeShape.preemptable)]
-            if len(consideredNodes) == 0:
-                return
-            nodeShape = consideredNodes[0]
-            x = NodeReservation(subtract(nodeShape, jS))
-            nodeReservations[nodeShape].append(x)
-            t = nodeShape.wallTime
-            while t < jS.wallTime:
-                y = NodeReservation(x.shape)
-                t += nodeShape.wallTime
-                x.nReservation = y
-                x = y
+                            if jobShape.wallTime - t < startingReservation.shape.wallTime:
+                                # This job only partially fills one of the slices. Create a new slice.
+                                startingReservation.shape, nS = split(startingReservation.shape, jobShape, jobShape.wallTime - t)
+                                nS.nReservation = startingReservation.nReservation
+                                startingReservation.nReservation = nS
+                            else:
+                                # This job perfectly fits within the boundaries of the slices.
+                                assert jobShape.wallTime - t == startingReservation.shape.wallTime
+                                startingReservation.shape = subtract(startingReservation.shape, jobShape)
+                            return
 
-        addToReservation()
-    return {nodeShape:len(nodeReservations[nodeShape]) for nodeShape in nodeShapes}
+                        # If the job would fit, but is longer than the total node allocation
+                        # extend the node allocation
+                        elif endingReservation.nReservation == None and startingReservation == nodeReservation:
+                            # Extend the node reservation to accommodate jobShape
+                            endingReservation.nReservation = NodeReservation(nodeShape)
+                    else: # Does not fit, reset
+                        startingReservation = endingReservation.nReservation
+                        t = 0
 
+                    endingReservation = endingReservation.nReservation
+                    if endingReservation is None:
+                        # Reached the end of the reservation without success so stop trying to
+                        # add to reservation
+                        break
+        # Case a new node reservation is required. Assign to the smallest node shape
+        # that will fit this job, prioritizing preemptable nodes
+        consideredNodes = [nodeShape for nodeShape in self.nodeShapes if nodeShape.cores >= jobShape.cores and nodeShape.memory >= jobShape.memory and nodeShape.disk >= jobShape.disk and (jobShape.preemptable or not nodeShape.preemptable)]
+        if len(consideredNodes) == 0:
+            return
+        nodeShape = consideredNodes[0]
+        x = NodeReservation(subtract(nodeShape, jobShape))
+        self.nodeReservations[nodeShape].append(x)
+        t = nodeShape.wallTime
+        while t < jobShape.wallTime:
+            y = NodeReservation(x.shape)
+            t += nodeShape.wallTime
+            x.nReservation = y
+            x = y
+
+    def getRequiredNodes(self):
+        """
+        Returns a dict from node shape to number of nodes required to run the packed jobs.
+        """
+        return {nodeShape:len(self.nodeReservations[nodeShape]) for nodeShape in self.nodeShapes}
+
+class NodeReservation(object):
+    """
+    Represents a node reservation. To represent the resources available in a reservation a
+    node reservation is represented as a sequence of Shapes, each giving the resources free
+    within the given interval of time
+    """
+    def __init__(self, shape):
+        # The wall-time and resource available
+        self.shape = shape
+        # The next portion of the reservation
+        self.nReservation = None
+
+    def fits(self, jobShape):
+        """Check if a job shape's resource requirements will fit within this allocation."""
+        return jobShape.memory <= self.shape.memory and jobShape.cores <= self.shape.cores and jobShape.disk <= self.shape.disk and (jobShape.preemptable or not self.shape.preemptable)
+
+    def shapes(self):
+        """Get all time-slice shapes, in order, from this reservation on."""
+        shapes = []
+        curRes = self
+        while curRes is not None:
+            shapes.append(curRes.shape)
+            curRes = curRes.nReservation
+        return shapes
+
+def subtract(nodeShape, jobShape):
+    """
+    Adjust available resources of a node allocation as a job is scheduled within it.
+    """
+    return Shape(nodeShape.wallTime, nodeShape.memory - jobShape.memory, nodeShape.cores - jobShape.cores, nodeShape.disk - jobShape.disk, nodeShape.preemptable)
+
+def split(nodeShape, jobShape, t):
+    """
+    Partition a node allocation into two
+    """
+    return (Shape(t, nodeShape.memory - jobShape.memory, nodeShape.cores - jobShape.cores, nodeShape.disk - jobShape.disk, nodeShape.preemptable),
+            NodeReservation(Shape(nodeShape.wallTime - t, nodeShape.memory, nodeShape.cores, nodeShape.disk, nodeShape.preemptable)))
+
+def binPacking(nodeShapes, jobShapes):
+    bpf = BinPackedFit(nodeShapes)
+    bpf.binPack(jobShapes)
+    return bpf.getRequiredNodes()
 
 class ClusterScaler(object):
     def __init__(self, provisioner, leader, config):
@@ -407,6 +417,9 @@ class ScalerThread(ExceptionalThread):
                 recentJobShapes = self.jobShapes.get()
                 queuedJobs = self.scaler.leader.getJobs()
                 logger.info("Detected %i queued jobs." % len(queuedJobs))
+                logger.info("avg runtime dict: %s" % repr(self.scaler.jobNameToAvgRuntime))
+                for jobName in set(job.jobName for job in queuedJobs):
+                    logger.info("Got avg runtime %s for job %s." % (self.scaler.getAverageRuntime(jobName), jobName))
                 queuedJobShapes = [Shape(wallTime=self.scaler.getAverageRuntime(jobName=job.jobName), memory=job.memory, cores=job.cores, disk=job.disk, preemptable=job.preemptable) for job in queuedJobs]
                 nodesToRunRecentJobs = binPacking(jobShapes=recentJobShapes, nodeShapes=self.nodeShapes)
                 nodesToRunQueuedJobs = binPacking(jobShapes=queuedJobShapes, nodeShapes=self.nodeShapes)

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -149,16 +149,7 @@ class BinPackedFit(object):
                                 startingReservation = startingReservation.nReservation
                             assert startingReservation == endingReservation
                             assert jobShape.wallTime - t <= startingReservation.shape.wallTime
-
-                            if jobShape.wallTime - t < startingReservation.shape.wallTime:
-                                # This job only partially fills one of the slices. Create a new slice.
-                                startingReservation.shape, nS = split(startingReservation.shape, jobShape, jobShape.wallTime - t)
-                                nS.nReservation = startingReservation.nReservation
-                                startingReservation.nReservation = nS
-                            else:
-                                # This job perfectly fits within the boundaries of the slices.
-                                assert jobShape.wallTime - t == startingReservation.shape.wallTime
-                                startingReservation.shape = subtract(startingReservation.shape, jobShape)
+                            adjustReservationForJob(startingReservation, jobShape, t)
                             return
 
                         # If the job would fit, but is longer than the total node allocation
@@ -181,9 +172,11 @@ class BinPackedFit(object):
         if len(consideredNodes) == 0:
             return
         nodeShape = consideredNodes[0]
-        x = NodeReservation(subtract(nodeShape, jobShape))
-        self.nodeReservations[nodeShape].append(x)
+        x = NodeReservation(nodeShape)
         t = nodeShape.wallTime
+        adjustReservationForJob(x, jobShape, 0)
+        self.nodeReservations[nodeShape].append(x)
+
         while t < jobShape.wallTime:
             y = NodeReservation(x.shape)
             t += nodeShape.wallTime
@@ -220,6 +213,16 @@ class NodeReservation(object):
             shapes.append(curRes.shape)
             curRes = curRes.nReservation
         return shapes
+
+def adjustReservationForJob(reservation, jobShape, t):
+    if jobShape.wallTime - t < reservation.shape.wallTime:
+        # This job only partially fills one of the slices. Create a new slice.
+        reservation.shape, nS = split(reservation.shape, jobShape, jobShape.wallTime - t)
+        nS.nReservation = reservation.nReservation
+        reservation.nReservation = nS
+    else:
+        # This job perfectly fits within the boundaries of the slices.
+        reservation.shape = subtract(reservation.shape, jobShape)
 
 def subtract(nodeShape, jobShape):
     """

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -96,8 +96,9 @@ class BinPackedFit(object):
     :param Shape nodeShapes: A list of possible types of nodes that can be launched.
 
     """
-    def __init__(self, nodeShapes):
+    def __init__(self, nodeShapes, targetTime=3600):
         self.nodeShapes = nodeShapes
+        self.targetTime = targetTime
         # Prioritize preemptable node shapes with the lowest memory
         self.nodeShapes.sort(key=lambda nS: not nS.preemptable)
         self.nodeShapes.sort(key=lambda nS: nS.memory)
@@ -131,8 +132,10 @@ class BinPackedFit(object):
                 startingReservation = nodeReservation
                 # current end of the slices we can fit in so far
                 endingReservation = startingReservation
-                # amount of the job covered by slices
+                # the amount of runtime of the job currently covered by slices
                 t = 0
+                # total time from when the instance started up to startingReservation
+                startingReservationTime = 0
 
                 while True:
                     # Considering a new ending reservation.
@@ -157,9 +160,13 @@ class BinPackedFit(object):
                         elif endingReservation.nReservation == None and startingReservation == nodeReservation:
                             # Extend the node reservation to accommodate jobShape
                             endingReservation.nReservation = NodeReservation(nodeShape)
-                    else: # Does not fit, reset
-                        startingReservation = endingReservation.nReservation
-                        t = 0
+                    else:
+                        if startingReservationTime + t <= self.targetTime:
+                            startingReservation = endingReservation.nReservation
+                            startingReservationTime += t + endingReservation.shape.wallTime
+                            t = 0
+                        else:
+                            break
 
                     endingReservation = endingReservation.nReservation
                     if endingReservation is None:

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -114,10 +114,9 @@ class ClusterScalerTest(ToilTest):
                                              cores=random.choice(list(range(1, x.cores + 1))),
                                              disk=random.choice(list(range(1, x.disk + 1))),
                                              preemptable=False)
-            randomJobShapes = []
-            for nodeShape in nodeShapes:
-                numberOfJobs = random.choice(list(range(1, 1000)))
-                randomJobShapes.extend([randomJobShape(nodeShape) for i in range(numberOfJobs)])
+
+            numberOfJobs = random.choice(list(range(1, 1000)))
+            randomJobShapes = [randomJobShape(random.choice(nodeShapes)) for i in range(numberOfJobs)]
             numberOfBins = binPacking(jobShapes=randomJobShapes, nodeShapes=nodeShapes)
             logger.info("Made the following node reservations: %s" % numberOfBins)
 


### PR DESCRIPTION
This PR refactors the notoriously unreadable bin-packing code into something a bit more sensible (though not at all perfect), adds actual unit tests for the bin-packing, and fixes a few bugs exposed by those tests. None of these bugs were introduced by the multiple-node-types PR, so I figured it wasn't worth holding up those necessary changes any longer. Specifically, this fixes:

- a bug where new node reservations (reservations are sort of like "time-slices" of resource usage at a node, so you can find the projected resource usage at each point in time) weren't split, meaning that a 5-minute job that uses 5 cores would be projected to use 5 cores for the entire 1-hour "wallTime" of the instance. This means in certain situations, more nodes would be created than would be optimal.
- a bug where a long-running job, which "extends" a node reservation for a very long time, can end up causing other jobs to be packed into its extended reservations, even though they may be projected to start several hours in the future. This ends up underprovisioning nodes if you have a few long-running jobs and many more short jobs. (I've noticed the old pre-multiple-node-types scaler underestimating the number of needed nodes with Cactus, though I don't know whether that's caused by this particular bug or not.)

I also want to use this to discuss a few other autoscaler parameters/behaviors that aren't directly related to the bin-packer. Basically, I think it's worth having a discussion on a few topics:
- Do we still need to pack based on recent jobs as well as queued jobs? I'd argue the queued jobs are enough, and packing recent jobs is a bit confusing.
- The beta parameter has always annoyed me a bit: I like the basic idea, but I think the current behavior is less useful than it could be. Right now it is basically used to ignore small fluctuations, which is fine. But the problem I usually have with the scaler isn't with small fluctuations, it's with fluctuations that are too large, too fast. Usually this happens when thousands of small jobs are being dumped all at once, right after a series of long jobs, causing the autoscaler to freak out and hit its max -- then it rapidly figures out the jobs are pretty short and adjusts to something smaller than the max within 5 minutes, wasting some money. So I'd prefer the inertia parameter to be something much more like a moving average, which could give the autoscaler a chance to adjust, while still being able to hit the max in a reasonable time. (The moving average could still have some minor fluctuations, so maybe the existing beta parameter behavior would still be needed.)
- How should we order the "preference" of nodes to launch? Currently a sort is used which will do the "right" thing in the vast, vast majority of cases--but not all. Should we use the ordering provided by the user, and trust them to do it right? Or should we sort to prioritize the cheapest instances first, which is probably what the user wants?