### PR TITLE
dockerCall function changed to use docker API. (resolves #1851)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,3 +299,4 @@ check_cpickle:
 		check_running_on_jenkins \
 		check_build_reqs \
 		docker clean_docker push_docker
+

--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -91,7 +91,7 @@ print(heredoc('''
         && ln -s /home/s3am/bin/s3am /usr/local/bin/
 
     # Install statically linked version of docker client
-    RUN curl https://get.docker.com/builds/Linux/x86_64/docker-1.12.3.tgz \
+    RUN curl https://get.docker.com/builds/Linux/x86_64/docker-1.13.1.tgz \
          | tar -xvzf - --transform='s,[^/]*/,,g' -C /usr/local/bin/ \
          && chmod u+x /usr/local/bin/docker
 

--- a/docs/developingWorkflows/developing.rst
+++ b/docs/developingWorkflows/developing.rst
@@ -714,10 +714,12 @@ each node of the cluster.
 
 When invoking docker containers from within a Toil workflow, it is strongly
 recommended that you use :func:`dockerCall`, a toil job function provided in
-``toil.lib.docker``. ``dockerCall`` provides a layer of abstraction over using the
-``subprocess`` module to call Docker directly, and provides container cleanup on
-job failure. When docker containers are run without this feature, failed jobs can
-result in resource leaks.
+``toil.lib.docker``. ``dockerCall`` leverages docker's own python API, 
+and provides container cleanup on job failure. When docker containers are 
+run without this feature, failed jobs can result in resource leaks.  Docker's
+API can be found at this _website.
+
+.. _website: https://docker-py.readthedocs.io/en/stable/
 
 In order to use ``dockerCall``, your installation of Docker must be set up to run
 without ``sudo``. Instructions for setting this up can be found here_.
@@ -728,7 +730,7 @@ An example of a basic ``dockerCall`` is below:
 
     dockerCall(job=job,
                 tool='quay.io/ucsc_cgl/bwa',
-                work_dir=job.fileStore.getLocalTempDir(),
+                workDir=job.fileStore.getLocalTempDir(),
                 parameters=['index', '/data/reference.fa'])
 
 ``dockerCall`` can also be added to workflows like any other job function:
@@ -737,7 +739,7 @@ An example of a basic ``dockerCall`` is below:
  
      align = Job.wrapJobFn(dockerCall,
                            tool='quay.io/ucsc_cgl/bwa',
-                           work_dir=job.fileStore.getLocalTempDir(),
+                           workDir=job.fileStore.getLocalTempDir(),
                            parameters=['index', '/data/reference.fa']))
 
      if __name__=="__main__":
@@ -753,22 +755,15 @@ commonly used in bioinformatics analysis.
 The documentation provides guidelines for developing your own Docker containers
 that can be used with Toil and ``dockerCall``. In order for a container to be
 compatible with ``dockerCall``, it must have an ``ENTRYPOINT`` set to a wrapper
-script, as described in cgl-docker-lib containerization standards. Alternately,
-the entrypoint to the container can be set using the docker option
-``--entrypoint``. The container should be runnable directly with Docker as:
+script, as described in cgl-docker-lib containerization standards.  This can be
+set by passing in the optional keyword argument, 'entrypoint'.  Example: 
 
-.. code-block:: console
+     entrypoint=["/bin/bash","-c"]
 
-    $ docker run <docker parameters> <tool name> <tool parameters>
+dockerCall supports currently the 75 keyword arguments found in the python
+Docker API at this _website, under the 'run' command.
 
-For example:
-
-.. code-block:: console
-
-    $ docker run -d quay.io/ucsc-cgl/bwa -s -o /data/aligned /data/ref.fa
-
-
-.. _service-dev-ref:
+.. _website: https://docker-py.readthedocs.io/en/stable/containers.html
 
 Services
 --------

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ def runSetup():
             'bd2k-python-lib>=1.14a1.dev35',
             'dill==0.2.5',
             'six>=1.10.0',
-            'future'],
+            'future',
+            'docker==2.5.1'],
         extras_require={
             'mesos': [
                 'psutil==3.0.1'],

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -188,7 +188,7 @@ def dockerCall(job,
     # practice:
     # http://docker-py.readthedocs.io/en/stable/containers.html
     elif len(parameters) > 0 and type(parameters) is list:
-        command = [' '.join(p) for p in parameters]
+        command = ' '.join(parameters)
         _logger.debug("Calling docker with: " + repr(command))
 
     # If the 'parameters' lists are empty, they are respecified as None, which

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -11,7 +11,7 @@ from docker.errors import ContainerError
 from bd2k.util.files import mkdir_p
 from toil.job import Job
 from toil.leader import FailedJobsException
-from toil.test import ToilTest
+from toil.test import ToilTest, slow
 from toil.lib import FORGO, STOP, RM
 from toil.lib.docker import dockerCall, dockerCheckOutput, \
                             _containerIsRunning, _dockerKill
@@ -131,82 +131,102 @@ class DockerTest(ToilTest):
         self.testDockerClean(disableCaching=True, detached=False, rm=True,
                              deferParam=None)
 
+    @slow
     def testDockerClean_CxD_FORGO(self):
         self.testDockerClean(disableCaching=True, detached=True, rm=False,
                              deferParam=FORGO)
 
+    @slow
     def testDockerClean_CxD_STOP(self):
         self.testDockerClean(disableCaching=True, detached=True, rm=False,
                              deferParam=STOP)
 
+    @slow
     def testDockerClean_CxD_RM(self):
         self.testDockerClean(disableCaching=True, detached=True, rm=False,
                              deferParam=RM)
 
+    @slow
     def testDockerClean_CxD_None(self):
         self.testDockerClean(disableCaching=True, detached=True, rm=False,
                              deferParam=None)
 
+    @slow
     def testDockerClean_Cxx_FORGO(self):
         self.testDockerClean(disableCaching=True, detached=False, rm=False,
                              deferParam=FORGO)
 
+    @slow
     def testDockerClean_Cxx_STOP(self):
         self.testDockerClean(disableCaching=True, detached=False, rm=False,
                              deferParam=STOP)
 
+    @slow
     def testDockerClean_Cxx_RM(self):
         self.testDockerClean(disableCaching=True, detached=False, rm=False,
                              deferParam=RM)
 
+    @slow
     def testDockerClean_Cxx_None(self):
         self.testDockerClean(disableCaching=True, detached=False, rm=False,
                              deferParam=None)
 
+    @slow
     def testDockerClean_xRx_FORGO(self):
         self.testDockerClean(disableCaching=False, detached=False, rm=True,
                              deferParam=FORGO)
 
+    @slow
     def testDockerClean_xRx_STOP(self):
         self.testDockerClean(disableCaching=False, detached=False, rm=True,
                              deferParam=STOP)
 
+    @slow
     def testDockerClean_xRx_RM(self):
         self.testDockerClean(disableCaching=False, detached=False, rm=True,
                              deferParam=RM)
 
+    @slow
     def testDockerClean_xRx_None(self):
         self.testDockerClean(disableCaching=False, detached=False, rm=True,
                              deferParam=None)
 
+    @slow
     def testDockerClean_xxD_FORGO(self):
         self.testDockerClean(disableCaching=False, detached=True, rm=False,
                              deferParam=FORGO)
 
+    @slow
     def testDockerClean_xxD_STOP(self):
         self.testDockerClean(disableCaching=False, detached=True, rm=False,
                              deferParam=STOP)
 
+    @slow
     def testDockerClean_xxD_RM(self):
         self.testDockerClean(disableCaching=False, detached=True, rm=False,
                              deferParam=RM)
 
+    @slow
     def testDockerClean_xxD_None(self):
         self.testDockerClean(disableCaching=False, detached=True, rm=False,
                              deferParam=None)
 
+    @slow
     def testDockerClean_xxx_FORGO(self):
         self.testDockerClean(disableCaching=False, detached=False, rm=False,
                              deferParam=FORGO)
 
+    @slow
     def testDockerClean_xxx_STOP(self):
         self.testDockerClean(disableCaching=False, detached=False, rm=False,
                              deferParam=STOP)
 
+    @slow
     def testDockerClean_xxx_RM(self):
         self.testDockerClean(disableCaching=False, detached=False, rm=False,
                              deferParam=RM)
 
+    @slow
     def testDockerClean_xxx_None(self):
         self.testDockerClean(disableCaching=False, detached=False, rm=False,
                              deferParam=None)
@@ -246,9 +266,11 @@ class DockerTest(ToilTest):
         rv = Job.Runner.startToil(A, options)
         assert rv == True
 
+    @slow
     def testNonCachingDockerChain(self):
         self.testDockerPipeChain(disableCaching=False)
 
+    @slow
     def testNonCachingDockerChainErrorDetection(self):
         self.testDockerPipeChainErrorDetection(disableCaching=False)
 
@@ -288,14 +310,16 @@ def _testDockerCleanFn(job,
                deferParam=deferParam,
                containerName=containerName,
                detach=detached,
-               removeOnExit=rm)
+               removeOnExit=rm,
+               privileged=True)
 
 def _testDockerPipeChainFn(job):
     """Return the result of a simple pipe chain.  Should be 2."""
     parameters = [ ['printf', 'x\n y\n'], ['wc', '-l'] ]
     return dockerCheckOutput(job,
                              tool='quay.io/ucsc_cgl/spooky_test',
-                             parameters=parameters)
+                             parameters=parameters,
+                             privileged=True)
 
 def _testDockerPipeChainErrorFn(job):
     """Return True if the command exit 1 | wc -l raises a ContainerError."""

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -1,226 +1,309 @@
+from __future__ import absolute_import
 import logging
 import signal
 import time
-import uuid
-from threading import Thread
-from subprocess import CalledProcessError
-
 import os
-from pwd import getpwuid
+import uuid
+import docker
+from threading import Thread
+from docker.errors import ContainerError
+
 from bd2k.util.files import mkdir_p
 from toil.job import Job
 from toil.leader import FailedJobsException
-from toil.lib.docker import dockerCall, dockerCheckOutput, _containerIsRunning, _dockerKill, STOP, FORGO, RM
-from toil.test import ToilTest, slow
+from toil.test import ToilTest
+from toil.lib import FORGO, STOP, RM
+from toil.lib.docker import dockerCall, dockerCheckOutput, \
+                            _containerIsRunning, _dockerKill
 
-_log = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class DockerTest(ToilTest):
     """
     Tests dockerCall and ensures no containers are left around.
 
-
-    When running tests you may optionally set the TOIL_TEST_TEMP environment variable to the path
-    of a directory where you want temporary test files be placed. The directory will be created
-    if it doesn't exist. The path may be relative in which case it will be assumed to be relative
-    to the project root. If TOIL_TEST_TEMP is not defined, temporary files and directories will
-    be created in the system's default location for such files and any temporary files or
-    directories left over from tests will be removed automatically removed during tear down.
+    When running tests you may optionally set the TOIL_TEST_TEMP environment
+    variable to the path of a directory where you want temporary test files be
+    placed. The directory will be created if it doesn't exist. The path may be
+    relative in which case it will be assumed to be relative to the project
+    root. If TOIL_TEST_TEMP is not defined, temporary files and directories will
+    be created in the system's default location for such files and any temporary
+    files or directories left over from tests will be removed automatically
+    removed during tear down.
     Otherwise, left-over files will not be removed.
     """
     def setUp(self):
         self.tempDir = self._createTempDir(purpose='tempDir')
+        self.dockerTestLogLevel = 'INFO'
 
-    @slow
-    def testDockerClean(self, caching=True):
+    def testDockerClean(self,
+                        disableCaching=True,
+                        detached=True,
+                        rm=True,
+                        deferParam=None):
         """
-        Run the test container that creates a file in the work dir, and sleeps for 5 minutes.  Ensure
-        that the calling job gets SIGKILLed after a minute, leaving behind the spooky/ghost/zombie
-        container. Ensure that the container is killed on batch system shutdown (through the defer
-        mechanism).
-        This inherently also tests _docker
-        :returns: None
+        Run the test container that creates a file in the work dir, and sleeps
+        for 5 minutes.
+
+        Ensure that the calling job gets SIGKILLed after a minute, leaving
+        behind the spooky/ghost/zombie container. Ensure that the container is
+        killed on batch system shutdown (through the deferParam mechanism).
         """
-        # We need to test the behaviour of `defer` with `rm` and `detached`. We do not look at the case
-        # where `rm` and `detached` are both True.  This is the truth table for the different
-        # combinations at the end of the test. R = Running, X = Does not exist, E = Exists but not
-        # running.
+
+        # We need to test the behaviour of `deferParam` with `rm` and
+        # `detached`. We do not look at the case where `rm` and `detached` are
+        # both True.  This is the truth table for the different combinations at
+        # the end of the test. R = Running, X = Does not exist, E = Exists but
+        # not running.
         #              None     FORGO     STOP    RM
         #    rm        X         R         X      X
         # detached     R         R         E      X
         #  Neither     R         R         E      X
-        assert os.getuid() != 0, "Cannot test this if the user is root."
+
         data_dir = os.path.join(self.tempDir, 'data')
         work_dir = os.path.join(self.tempDir, 'working')
-        test_file = os.path.join(data_dir, 'test.txt')
+        test_file = os.path.join(work_dir, 'test.txt')
+
         mkdir_p(data_dir)
         mkdir_p(work_dir)
-        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
-        options.logLevel = 'INFO'
+
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir,
+                                                            'jobstore'))
+        options.logLevel = self.dockerTestLogLevel
         options.workDir = work_dir
         options.clean = 'always'
-        if not caching:
-            options.disableCaching = True
-        for rm in (True, False):
-            for detached in (True, False):
-                if detached and rm:
-                    continue
-                for defer in (FORGO, STOP, RM, None):
-                    # Not using base64 logic here since it might create a name starting with a `-`.
-                    container_name = uuid.uuid4().hex
-                    A = Job.wrapJobFn(_testDockerCleanFn, data_dir, detached, rm, defer,
-                                      container_name)
-                    try:
-                        Job.Runner.startToil(A, options)
-                    except FailedJobsException:
-                        # The file created by spooky_container would remain in the directory, and since
-                        # it was created inside the container, it would have had uid and gid == 0 (root)
-                        # upon creation. If the defer mechanism worked, it should now be non-zero and we
-                        # check for that.
-                        file_stats = os.stat(test_file)
-                        assert file_stats.st_gid != 0
-                        assert file_stats.st_uid != 0
-                        if (rm and defer != FORGO) or defer == RM:
-                            # These containers should not exist
-                            assert _containerIsRunning(container_name) is None, \
-                                'Container was not removed.'
-                        elif defer == STOP:
-                            # These containers should exist but be non-running
-                            assert _containerIsRunning(container_name) == False, \
-                                'Container was not stopped.'
-                        else:
-                            # These containers will be running
-                            assert _containerIsRunning(container_name) == True, \
-                                'Container was not running.'
-                    finally:
-                        # Prepare for the next test.
-                        _dockerKill(container_name, RM)
-                        os.remove(test_file)
+        options.disableCaching = disableCaching
 
-    def testDockerPipeChain(self, caching=True):
+        # No base64 logic since it might create a name starting with a `-`.
+        container_name = uuid.uuid4().hex
+        A = Job.wrapJobFn(_testDockerCleanFn,
+                          work_dir,
+                          detached,
+                          rm,
+                          deferParam,
+                          container_name)
+        try:
+            Job.Runner.startToil(A, options)
+        except FailedJobsException:
+            # The file created by spooky_container would remain in the directory
+            # and since it was created inside the container, it would have had
+            # uid and gid == 0 (root) which may cause problems when docker
+            # attempts to clean up the jobstore.
+            file_stats = os.stat(test_file)
+            assert file_stats.st_gid != 0
+            assert file_stats.st_uid != 0
+
+            if (rm and (deferParam != FORGO)) or deferParam == RM:
+                # These containers should not exist
+                assert _containerIsRunning(container_name) is None, \
+                    'Container was not removed.'
+
+            elif deferParam == STOP:
+                # These containers should exist but be non-running
+                assert _containerIsRunning(container_name) == False, \
+                    'Container was not stopped.'
+
+            else:
+                # These containers will be running
+                assert _containerIsRunning(container_name) == True, \
+                    'Container was not running.'
+        client = docker.from_env(version='auto')
+        _dockerKill(container_name, client)
+        try:
+            os.remove(test_file)
+        except:
+            pass
+
+    def testDockerClean_CRx_FORGO(self):
+        self.testDockerClean(disableCaching=True, detached=False, rm=True,
+                             deferParam=FORGO)
+
+    def testDockerClean_CRx_STOP(self):
+        self.testDockerClean(disableCaching=True, detached=False, rm=True,
+                             deferParam=STOP)
+
+    def testDockerClean_CRx_RM(self):
+        self.testDockerClean(disableCaching=True, detached=False, rm=True,
+                             deferParam=RM)
+
+    def testDockerClean_CRx_None(self):
+        self.testDockerClean(disableCaching=True, detached=False, rm=True,
+                             deferParam=None)
+
+    def testDockerClean_CxD_FORGO(self):
+        self.testDockerClean(disableCaching=True, detached=True, rm=False,
+                             deferParam=FORGO)
+
+    def testDockerClean_CxD_STOP(self):
+        self.testDockerClean(disableCaching=True, detached=True, rm=False,
+                             deferParam=STOP)
+
+    def testDockerClean_CxD_RM(self):
+        self.testDockerClean(disableCaching=True, detached=True, rm=False,
+                             deferParam=RM)
+
+    def testDockerClean_CxD_None(self):
+        self.testDockerClean(disableCaching=True, detached=True, rm=False,
+                             deferParam=None)
+
+    def testDockerClean_Cxx_FORGO(self):
+        self.testDockerClean(disableCaching=True, detached=False, rm=False,
+                             deferParam=FORGO)
+
+    def testDockerClean_Cxx_STOP(self):
+        self.testDockerClean(disableCaching=True, detached=False, rm=False,
+                             deferParam=STOP)
+
+    def testDockerClean_Cxx_RM(self):
+        self.testDockerClean(disableCaching=True, detached=False, rm=False,
+                             deferParam=RM)
+
+    def testDockerClean_Cxx_None(self):
+        self.testDockerClean(disableCaching=True, detached=False, rm=False,
+                             deferParam=None)
+
+    def testDockerClean_xRx_FORGO(self):
+        self.testDockerClean(disableCaching=False, detached=False, rm=True,
+                             deferParam=FORGO)
+
+    def testDockerClean_xRx_STOP(self):
+        self.testDockerClean(disableCaching=False, detached=False, rm=True,
+                             deferParam=STOP)
+
+    def testDockerClean_xRx_RM(self):
+        self.testDockerClean(disableCaching=False, detached=False, rm=True,
+                             deferParam=RM)
+
+    def testDockerClean_xRx_None(self):
+        self.testDockerClean(disableCaching=False, detached=False, rm=True,
+                             deferParam=None)
+
+    def testDockerClean_xxD_FORGO(self):
+        self.testDockerClean(disableCaching=False, detached=True, rm=False,
+                             deferParam=FORGO)
+
+    def testDockerClean_xxD_STOP(self):
+        self.testDockerClean(disableCaching=False, detached=True, rm=False,
+                             deferParam=STOP)
+
+    def testDockerClean_xxD_RM(self):
+        self.testDockerClean(disableCaching=False, detached=True, rm=False,
+                             deferParam=RM)
+
+    def testDockerClean_xxD_None(self):
+        self.testDockerClean(disableCaching=False, detached=True, rm=False,
+                             deferParam=None)
+
+    def testDockerClean_xxx_FORGO(self):
+        self.testDockerClean(disableCaching=False, detached=False, rm=False,
+                             deferParam=FORGO)
+
+    def testDockerClean_xxx_STOP(self):
+        self.testDockerClean(disableCaching=False, detached=False, rm=False,
+                             deferParam=STOP)
+
+    def testDockerClean_xxx_RM(self):
+        self.testDockerClean(disableCaching=False, detached=False, rm=False,
+                             deferParam=RM)
+
+    def testDockerClean_xxx_None(self):
+        self.testDockerClean(disableCaching=False, detached=False, rm=False,
+                             deferParam=None)
+
+    def testDockerPipeChain(self, disableCaching=True):
         """
-        Test for piping API for dockerCall().  Using this API (activated when list of
-        argument lists is given as parameters), commands a piped together into a chain
+        Test for piping API for dockerCall().  Using this API (activated when
+        list of argument lists is given as parameters), commands a piped
+        together into a chain.
         ex:  parameters=[ ['printf', 'x\n y\n'], ['wc', '-l'] ] should execute:
         printf 'x\n y\n' | wc -l
         """
-        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
-        options.logLevel = 'INFO'
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir,
+                                                            'jobstore'))
+        options.logLevel = self.dockerTestLogLevel
         options.workDir = self.tempDir
         options.clean = 'always'
-        if not caching:
-            options.disableCaching = True
+        options.caching = disableCaching
         A = Job.wrapJobFn(_testDockerPipeChainFn)
         rv = Job.Runner.startToil(A, options)
         assert rv.strip() == '2'
 
-    def testDockerPipeChainErrorDetection(self, caching=True):
+    def testDockerPipeChainErrorDetection(self, disableCaching=True):
         """
-        By default, executing cmd1 | cmd2 | ... | cmdN, will only return an error
-        if cmdN fails.  This can lead to all manor of errors being silently missed.
-        This tests to make sure that the piping API for dockerCall() throws an exception
-        if non-last commands in the chain fail.
+        By default, executing cmd1 | cmd2 | ... | cmdN, will only return an
+        error if cmdN fails.  This can lead to all manor of errors being
+        silently missed.  This tests to make sure that the piping API for
+        dockerCall() throws an exception if non-last commands in the chain fail.
         """
-        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
-        options.logLevel = 'INFO'
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir,
+                                                            'jobstore'))
+        options.logLevel = self.dockerTestLogLevel
         options.workDir = self.tempDir
         options.clean = 'always'
-        if not caching:
-            options.disableCaching = True
+        options.caching = disableCaching
         A = Job.wrapJobFn(_testDockerPipeChainErrorFn)
         rv = Job.Runner.startToil(A, options)
         assert rv == True
 
-    def testDockerPermissions(self, caching=True):
-        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
-        options.logLevel = 'INFO'
-        options.workDir = self.tempDir
-        options.clean = 'always'
-        if not caching:
-            options.disableCaching = True
-        A = Job.wrapJobFn(_testDockerPermissions)
-        Job.Runner.startToil(A, options)
-
-    def testDockerPermissionsNonCaching(self):
-        self.testDockerPermissions(caching=False)
-
-    @slow
     def testNonCachingDockerChain(self):
-        self.testDockerPipeChain(caching=False)
+        self.testDockerPipeChain(disableCaching=False)
 
     def testNonCachingDockerChainErrorDetection(self):
-        self.testDockerPipeChainErrorDetection(caching=False)
+        self.testDockerPipeChainErrorDetection(disableCaching=False)
 
-    def testNonCachingDockerClean(self):
-        self.testDockerClean(caching=False)
-
-
-def _testDockerCleanFn(job, workDir, detached=None, rm=None, defer=None, containerName=None):
+def _testDockerCleanFn(job,
+                       workDir,
+                       detached=None,
+                       rm=None,
+                       deferParam=None,
+                       containerName=None):
     """
-    Test function for test docker_clean.  Runs a container with given flags and then dies leaving
-    behind a zombie container
+    Test function for test docker_clean.  Runs a container with given flags and
+    then dies leaving behind a zombie container.
     :param toil.job.Job job: job
     :param workDir: See `work_dir=` in :func:`dockerCall`
     :param bool rm: See `rm=` in :func:`dockerCall`
     :param bool detached: See `detached=` in :func:`dockerCall`
-    :param int defer: See `defer=` in :func:`dockerCall`
+    :param int deferParam: See `deferParam=` in :func:`dockerCall`
     :param str containerName: See `container_name=` in :func:`dockerCall`
-    :return:
     """
-    dockerParameters = ['--log-driver=none', '-v', os.path.abspath(workDir) + ':/data',
-                        '--name', containerName]
-    if detached:
-        dockerParameters.append('-d')
-    if rm:
-        dockerParameters.append('--rm')
-
     def killSelf():
         test_file = os.path.join(workDir, 'test.txt')
-        # This will kill the worker once we are sure the docker container started
+        # Kill the worker once we are sure the docker container is started
         while not os.path.exists(test_file):
-            _log.debug('Waiting on the file created by spooky_container.')
+            _logger.debug('Waiting on the file created by spooky_container.')
             time.sleep(1)
         # By the time we reach here, we are sure the container is running.
-        os.kill(os.getpid(), signal.SIGKILL)  # signal.SIGINT)
+        time.sleep(1)
+        os.kill(os.getpid(), signal.SIGKILL)
+
     t = Thread(target=killSelf)
     # Make it a daemon thread so that thread failure doesn't hang tests.
     t.daemon = True
     t.start()
-    dockerCall(job, tool='quay.io/ucsc_cgl/spooky_test', workDir=workDir, defer=defer, dockerParameters=dockerParameters)
-
+    dockerCall(job,
+               tool='quay.io/ucsc_cgl/spooky_test',
+               workDir=workDir,
+               deferParam=deferParam,
+               containerName=containerName,
+               detach=detached,
+               removeOnExit=rm)
 
 def _testDockerPipeChainFn(job):
-    """
-    Return the result of simple pipe chain.  Should be 2
-    """
+    """Return the result of a simple pipe chain.  Should be 2."""
     parameters = [ ['printf', 'x\n y\n'], ['wc', '-l'] ]
-    return dockerCheckOutput(job, tool='quay.io/ucsc_cgl/spooky_test', parameters=parameters)
+    return dockerCheckOutput(job,
+                             tool='quay.io/ucsc_cgl/spooky_test',
+                             parameters=parameters)
 
 def _testDockerPipeChainErrorFn(job):
-    """
-    Return True if the command exit 1 | wc -l raises a CalledProcessError when run through 
-    the docker interface
-    """
+    """Return True if the command exit 1 | wc -l raises a ContainerError."""
     parameters = [ ['exit', '1'], ['wc', '-l'] ]
     try:
-        return dockerCheckOutput(job, tool='quay.io/ucsc_cgl/spooky_test', parameters=parameters)
-    except CalledProcessError:
+        dockerCheckOutput(job,
+                          tool='quay.io/ucsc_cgl/spooky_test',
+                          parameters=parameters)
+    except ContainerError:
         return True
     return False
-
-def _testDockerPermissions(job):
-    testDir = job.fileStore.getLocalTempDir()
-    dockerCall(job, tool='ubuntu', workDir=testDir, parameters=[['touch', '/data/test.txt']])
-    outFile = os.path.join(testDir, 'test.txt')
-    assert os.path.exists(outFile)
-    assert not ownerName(outFile) == "root"
-
-
-def ownerName(filename):
-    """
-    Determines a given file's owner
-    :param str filename: path to a file
-    :return: name of filename's owner
-    """
-    return getpwuid(os.stat(filename).st_uid).pw_name


### PR DESCRIPTION
Addresses #1851

Hopefully this addresses the backwards compatibility issues with previous dockerCall usage.  I reworked a few things, and wanted to ask about the old bash command structure.  The name too, docker.py, was changed because it conflicts with "import docker" from the python docker API.  I also changed the "defer" variable because it interfered with the defer() function within toil.

This PR makes use of docker's powerful python API (including an exception that detects if a docker image exists) and the documentation they've cheerfully provided here: http://docker-py.readthedocs.io/en/stable/containers.html

This PR is also a necessary step towards increasing our docker functionality in preparation for running WDL workflows using docker.