### PR TITLE
Fix workflow effort being wasted if a single export fails (fixes #1319)

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -77,7 +77,10 @@ print(heredoc('''
     RUN chmod 777 /usr/bin/waitForKey.sh
 
     # The stock pip is too old and can't install from sdist with extras
-    RUN pip install --upgrade pip==8.1.2
+    RUN pip install --upgrade pip==9.0.1
+
+    # Default setuptools is too old
+    RUN pip install --upgrade setuptools==36.5.0
 
     # Include virtualenv, as it is still the recommended way to deploy pipelines
     RUN pip install --upgrade virtualenv==15.0.3

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -208,6 +208,16 @@ class AbstractJobStore(with_metaclass(ABCMeta, object)):
         self.setRootJob(rootJob.jobStoreID)
         return rootJob
 
+    def getRootJobReturnValue(self):
+        """
+        Parse the return value from the root job.
+
+        Raises an exception if the root job hasn't fulfilled its promise yet.
+        """
+        # Parse out the return value from the root job
+        with self.readSharedFileStream('rootJobReturnValue') as fH:
+            return pickle.load(fH)
+
     @property
     @memoize
     def _jobStoreClasses(self):

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -208,13 +208,8 @@ class Leader(object):
         if len(self.toilState.totalFailedJobs) > 0:
             raise FailedJobsException(self.config.jobStore, self.toilState.totalFailedJobs, self.jobStore)
 
-        # Parse out the return value from the root job
-        with self.jobStore.readSharedFileStream('rootJobReturnValue') as fH:
-            try:
-                return pickle.load(fH)
-            except EOFError:
-                logger.exception('Failed to unpickle root job return value')
-                raise FailedJobsException(self.config.jobStore, self.toilState.totalFailedJobs, self.jobStore)
+
+        return self.jobStore.getRootJobReturnValue()
 
     def innerLoop(self):
         """

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -251,9 +251,6 @@ class UtilsTest(ToilTest):
         # Delete output file before next step
         os.remove(self.outputFile)
 
-        # Check if we try to launch after its finished that we get a JobException
-        self.assertRaises(CalledProcessError, system, toilCommand + ['--restart'])
-
         # Check we can run 'toil clean'
         system(self.cleanCommand)
 


### PR DESCRIPTION
Previously, if your workflow completed successfully but a single `toil.exportFile` call failed, the entire effort would be wasted, because there was no way of running the export steps again (the workflow would crash if restarted).

This PR allows a "restart" if the workflow is nominally completed and the jobStore hasn't been deleted. No Job work will be done on this type of "restart", just export steps and other main-method work.