### PR TITLE
Define fileStore semantics (resolves #1887, #1903)

### DIFF
--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -54,7 +54,7 @@ def _singleMachineOptions(addOptionFn):
                       "Used in singleMachine batch system. default=%s" % 1))
     addOptionFn("--linkImports", dest="linkImports", default=False, action='store_true',
                 help=("When using Toil's importFile function for staging, input files are copied to the job store. "
-                      "Specifying this option saves space by hard-linking imported files. As long as caching is "
+                      "Specifying this option saves space by sym-linking imported files. As long as caching is "
                       "enabled Toil will protect the file automatically by changing the permissions to read-only."))
 
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -452,12 +452,6 @@ def _addOptions(addGroupFn, config):
                      bytes2human( config.defaultDisk, symbols='iec' ))
     assert not config.defaultPreemptable, 'User would be unable to reset config.defaultPreemptable'
     addOptionFn('--defaultPreemptable', dest='defaultPreemptable', action='store_true')
-    addOptionFn("--readGlobalFileMutableByDefault", dest="readGlobalFileMutableByDefault",
-                action='store_true', default=None, help='Toil disallows modification of read '
-                                                        'global files. Setting this flag causes '
-                                                        'them to be mutable. Unfortunately, this '
-                                                        'prevents saving space by caching files '
-                                                        'with hardlinks.')
     addOptionFn('--maxCores', dest='maxCores', default=None, metavar='INT',
                 help='The maximum number of CPU cores to request from the batch system at any one '
                      'time. Standard suffixes like K, Ki, M, Mi, G or Gi are supported. Default '

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -117,7 +117,7 @@ class Config(object):
         self.rescueJobsFrequency = 3600
 
         #Misc
-        self.disableCaching = False
+        self.disableCaching = True
         self.maxLogFileSize = 64000
         self.writeLogs = None
         self.writeLogsGzip = None
@@ -487,7 +487,7 @@ def _addOptions(addGroupFn, config):
     #Misc options
     #
     addOptionFn = addGroupFn("toil miscellaneous options", "Miscellaneous options")
-    addOptionFn('--disableCaching', dest='disableCaching', action='store_true', default=False,
+    addOptionFn('--disableCaching', dest='disableCaching', action='store_true', default=True,
                 help='Disables caching in the file store. This flag must be set to use '
                      'a batch system that does not support caching such as Grid Engine, Parasol, '
                      'LSF, or Slurm')

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -203,7 +203,10 @@ class FileStore(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def readGlobalFile(self, fileStoreID, userPath=None, cache=True, mutable=None):
         """
-        Downloads a file described by fileStoreID from the file store to the local directory.
+        Makes the file associated with fileStoreID available locally. If mutable is True,
+        then a copy of the file will be created locally so that the original is not modified
+        and does not change the file for other jobs. If mutable is False, then a link can
+        be created to the file, saving disk resources.
 
         If a user path is specified, it is used as the destination. If a user path isn't
         specified, the file is stored in the local temp directory with an encoded name.

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -183,13 +183,7 @@ class FileJobStore(AbstractJobStore):
         # linking is not done be default because of issue #1755
         srcPath = self._extractPathFromUrl(srcURL)
         if self.linkImports:
-            try:
-                os.link(os.path.realpath(srcPath), destPath)
-            except OSError:
-                shutil.copyfile(srcPath, destPath)
-            else:
-                # make imported files read-only if they're linked for protection
-                os.chmod(destPath, 0o444)
+            os.symlink(os.path.realpath(srcPath), destPath)
         else:
             shutil.copyfile(srcPath, destPath)
 

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -193,6 +193,9 @@ class FileJobStore(AbstractJobStore):
                 fd, absPath = self._getTempFile()  # use this to get a valid path to write to in job store
                 os.close(fd)
                 os.unlink(absPath)
+                # remove the .tmp extension and add the original file name
+                (noExt,ext) = os.path.splitext(absPath)
+                absPath = noExt + '-' + os.path.basename(url.path)
                 self._copyOrLink(url, absPath)
                 return FileID(self._getRelativePath(absPath), os.stat(absPath).st_size)
             else:

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -872,6 +872,17 @@ class FileJobStoreTest(AbstractJobStoreTest.Test):
     def _cleanUpExternalStore(self, dirPath):
         shutil.rmtree(dirPath)
 
+    def testPreserveFileName(self):
+        "Check that the fileID ends with the given file name."
+        fh, path = tempfile.mkstemp()
+        try:
+            os.close(fh)
+            job = self.master.create(self.arbitraryJob)
+            fileID = self.master.writeFile(path, job.jobStoreID)
+            self.assertTrue(fileID.endswith(os.path.basename(path)))
+        finally:
+            os.unlink(path)
+
 
 @experimental
 @needs_google

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -60,6 +60,8 @@ if False:
 
 
 class ClusterScalerTest(ToilTest):
+
+    @slow
     def testBinPacking(self):
         """
         Tests the bin-packing method used by the cluster scaler.


### PR DESCRIPTION
- [x] Define the semantics of of readGlobalFile.
- [x] Disable caching by default.
- [x] Mutable false by default. -- Oct 6th
- [x] Symlink instead of hard link files when possible (because sym links are more versatile and work across different filesystems)
- [ ] Ensure that caching still correctly tracks links.
- [x] Preserve file names (optional in this PR), see #1883.
- [ ] Better document role of fileStore vs jobStore.


RULE: If Toil did not create the file, Toil will not change permissions.
