### PR TITLE
Fixed dockerCall backwards compatibility issues.

### DIFF
--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -27,39 +27,175 @@ from toil.lib import STOP
 from toil.lib import RM
 from toil.test import timeLimit
 
-_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def dockerCheckOutput(job, *args, **kwargs):
     """
-    Runs dockerCall().
+    Deprecated.  Runs subprocessDockerCall() using 'subprocess.check_output()'.
 
     Provided for backwards compatibility with a previous implementation that
-    used 'subprocess.check_call()' and 'subprocess.check_output()'.  This has
-    since been supplanted and all dockerCall() runs now return the same output
-    so there is no need for a separate dockerCheckOutput() function that calls
-    'subprocess.check_output()'.
-
-    See dockerCall().
+    used 'subprocess.check_output()'.  This has since been supplanted and
+    apiDockerCall() is recommended.
     """
-    return dockerCall(job=job, *args, **kwargs)
+    logger.warn("WARNING: dockerCheckOutput() using subprocess.check_output() "
+                "is deprecated, please switch to apiDockerCall().")
+    return subprocessDockerCall(job=job, *args, **kwargs)
 
-def dockerCall(job,
-               tool,
-               parameters=None,
-               workDir=None,
-               dockerParameters=None,
-               deferParam=None,
-               containerName=None,
-               entrypoint=['/bin/bash', '-c'],
-               detach=False,
-               stderr=None,
-               dataDir='/data',
-               logDriver=None,
-               removeOnExit=False,
-               userPrivilege=None,
-               environment=None,
-               **kwargs):
+def dockerCall(job, *args, **kwargs):
+    """
+    Deprecated.  Runs subprocessDockerCall() using 'subprocess.check_output()'.
+
+    Provided for backwards compatibility with a previous implementation that
+    used 'subprocess.check_call()'.  This has since been supplanted and
+    apiDockerCall() is recommended.
+    """
+    logger.warn("WARNING: dockerCall() using subprocess.check_output() "
+                "is deprecated, please switch to apiDockerCall().")
+    return subprocessDockerCall(job=job, *args, **kwargs)
+
+def subprocessDockerCall(job,
+                         tool,
+                         parameters=None,
+                         workDir=None,
+                         dockerParameters=None,
+                         outfile=None,
+                         defer=None):
+    """
+    Deprecated.  Calls Docker using subprocess.check_output().
+
+    Assumes `docker` is on the PATH.  Uses Toil's defer functionality to ensure
+    containers are shutdown even in case of job or pipeline failure
+
+    Example of using dockerCall in toil to index a FASTA file with SAMtools:
+        def toil_job(job):
+            work_dir = job.fileStore.getLocalTempDir()
+            path = job.fileStore.readGlobalFile(ref_id, os.path.join(
+                                                          work_dir, 'ref.fasta')
+            parameters = ['faidx', path]
+            dockerCall(job, tool='quay.io/ucgc_cgl/samtools:latest',
+                       work_dir=work_dir, parameters=parameters)
+
+    :param toil.Job.job job: The Job instance for the calling function.
+    :param str tool: Name of the Docker image to be used
+                     (e.g. quay.io/ucsc_cgl/samtools).
+    :param list[str] parameters: Command line arguments to be passed.
+           If list of lists: list[list[str]], then treat as successive commands
+           chained with pipe.
+    :param str workDir: Directory to mount into the container via `-v`.
+                        Destination convention is '/data'.
+    :param list[str] dockerParameters: Parameters to pass to Docker.
+             Default parameters are `--rm`, `--log-driver none`, and the
+             mountpoint `-v work_dir:/data` where /data is the destination
+             convention.
+             These defaults are removed if docker_parmaters is passed,
+             so be sure to pass them if they are desired.
+    :param file outfile: Pipe output of Docker call to file handle
+    :param int defer: What action should be taken on the container upon job
+                      completion?
+           FORGO (0) will leave the container untouched.
+           STOP (1) will attempt to stop the container with `docker stop`
+           (useful for debugging).
+           RM (2) will stop the container and then forcefully remove it from the
+           system using `docker rm -f`. This is the default behavior if defer is
+           set to None.
+    """
+    if parameters is None:
+        parameters = []
+    if workDir is None:
+        workDir = os.getcwd()
+
+    # Setup the outgoing subprocess call for docker
+    baseDockerCall = ['docker', 'run']
+    if dockerParameters:
+        baseDockerCall += dockerParameters
+    else:
+        baseDockerCall += ['--rm', '--log-driver', 'none', '-v',
+                           os.path.abspath(workDir) + ':/data']
+
+    # Ensure the user has passed a valid value for defer
+    assert defer in (None, FORGO, STOP, RM)
+
+    # Get container name which is needed for _dockerKill
+    try:
+        if any('--name' in x for x in baseDockerCall):
+            if any('--name=' in x for x in baseDockerCall):
+                containerName = [x.split('=')[1]
+                                 for x in baseDockerCall if '--name' in x][0]
+            else:
+                containerName = baseDockerCall[
+                    baseDockerCall.index('--name') + 1]
+        else:
+            containerName = getContainerName(job)
+            baseDockerCall.extend(['--name', containerName])
+    except ValueError:
+        containerName = getContainerName(job)
+        baseDockerCall.extend(['--name', containerName])
+    except IndexError:
+        raise RuntimeError(
+            "Couldn't parse Docker's `--name=` option, check parameters: " +
+            str(dockerParameters))
+
+    # Defer the container on-exit action
+    if '--rm' in baseDockerCall and defer is None:
+        defer = RM
+    if '--rm' in baseDockerCall and defer is not RM:
+        logger.warn('--rm being passed to docker call but defer not set to '
+                    'dockerCall.RM, defer set to: ' + str(defer))
+    job.defer(_dockerKill, containerName, action=defer)
+    # Defer the permission fixing function which will run after this job.
+    # We call this explicitly later on in this function,
+    # but we defer it as well to handle unexpected job failure.
+    job.defer(_fixPermissions, tool, workDir)
+
+    # Make subprocess call
+
+    # If parameters is list of lists, treat each list as
+    # separate command and chain with pipes
+    if len(parameters) > 0 and type(parameters[0]) is list:
+        # When piping, all arguments now get merged into a single string to
+        # bash -c.
+        # We try to support spaces in paths by wrapping them all in quotes
+        # first.
+        chain_params = [' '.join(p) for p in [list(map(pipes.quote, q))
+                                              for q in parameters]]
+        # Use bash's set -eo pipefail to detect and abort on a failure in any
+        # command in the chain
+        call = baseDockerCall + ['--entrypoint', '/bin/bash',  tool, '-c',
+                                 'set -eo pipefail && {}'.format(' | '
+                                                         .join(chain_params))]
+    else:
+        call = baseDockerCall + [tool] + parameters
+    logger.info("Calling docker with " + repr(call))
+
+    params = {}
+    if outfile:
+        params['stdout'] = outfile
+
+    for attempt in retry(predicate=dockerPredicate):
+        with attempt:
+            out = subprocess.check_output(call, **params)
+
+    _fixPermissions(tool=tool, workDir=workDir)
+    return out
+
+def apiDockerCall(job,
+                  image,
+                  parameters=None,
+                  dockerParameters=None,
+                  deferParam=None,
+                  volumes=None,
+                  working_dir=None,
+                  containerName=None,
+                  entrypoint=None,
+                  detach=False,
+                  stderr=None,
+                  log_config=None,
+                  auto_remove=None,
+                  remove=False,
+                  user=None,
+                  environment=None,
+                  **kwargs):
     """
     A toil wrapper for the python docker API.
 
@@ -71,19 +207,18 @@ def dockerCall(job,
     appropriately.
 
     Example of using dockerCall in toil to index a FASTA file with SAMtools:
-
     def toil_job(job):
-        workDir = job.fileStore.getLocalTempDir()
+        working_dir = job.fileStore.getLocalTempDir()
         path = job.fileStore.readGlobalFile(ref_id,
-                                            os.path.join(work_dir, 'ref.fasta')
+                                          os.path.join(working_dir, 'ref.fasta')
         parameters = ['faidx', path]
         dockerCall(job,
-                   tool='quay.io/ucgc_cgl/samtools:latest',
-                   workDir=workDir,
+                   image='quay.io/ucgc_cgl/samtools:latest',
+                   working_dir=working_dir,
                    parameters=parameters)
 
     :param toil.Job.job job: The Job instance for the calling function.
-    :param str tool: Name of the Docker image to be used.
+    :param str image: Name of the Docker image to be used.
                      (e.g. 'quay.io/ucsc_cgl/samtools:latest')
     :param list[str] parameters: A list of string elements.  If there are
                                  multiple elements, these will be joined with
@@ -93,28 +228,21 @@ def dockerCall(job,
                                  subprocess.check_call().
                                  **If list of lists: list[list[str]], then treat
                                  as successive commands chained with pipe.
-    :param str workDir: The working directory where output files are deposited.
-    :param list[str] dockerParameters: Deprecated.  These parameters are bash
-                                       options supplied through check_call such
-                                       as '--rm' and '-d', and are no longer
-                                       used.  This is currently handled for a
-                                       limited number of options with a function
-                                       that converts to the docker API format.
+    :param str working_dir: The working directory.
     :param int deferParam: Action to take on the container upon job completion.
            FORGO (0) leaves the container untouched and running.
            STOP (1) Sends SIGTERM, then SIGKILL if necessary to the container.
            RM (2) Immediately send SIGKILL to the container. This is the default
            behavior if defer is set to None.
-    :param str containerName: The name of the container.
+    :param str name: The name/ID of the container.
     :param str entrypoint: Prepends commands sent to the container.  See:
                       https://docker-py.readthedocs.io/en/stable/containers.html
     :param bool detach: Run the container in detached mode. (equivalent to '-d')
     :param bool stderr: Return stderr after running the container or not.
-    :param str dataDir: The path in the container where the data is held.
-    :param str logDriver: Specify the logs to return from the container.  See:
+    :param str log_config: Specify the logs to return from the container.  See:
                       https://docker-py.readthedocs.io/en/stable/containers.html
-    :param bool removeOnExit: Remove the container on exit or not.
-    :param str userPrivilege: The container will be run with the privileges of
+    :param bool remove: Remove the container on exit or not.
+    :param str user: The container will be run with the privileges of
                               the user specified.  Can be an actual name, such
                               as 'root' or 'lifeisaboutfishtacos', or it can be
                               the uid or gid of the user ('0' is root; '1000' is
@@ -127,45 +255,23 @@ def dockerCall(job,
     :param kwargs: Additional keyword arguments supplied to the docker API's
                    run command.  The list is 75 keywords total, for examples
                    and full documentation see:
-
                    https://docker-py.readthedocs.io/en/stable/containers.html
-
-                   * NOTE: A number of the above are redundant with kwargs,
-                           mostly due to wanting to supply nonstandard defaults
-                           for toil's dockerCall method in order to maintain
-                           backwards compatibility with existing toil workflows.
-                           Try to use the params provided before using kwargs.
-                           For example, don't use 'tool=XXX' AND 'image=XXX', or
-                           the image used will be submitted twice.
     """
-    dockerApiKeywords = [containerName,
-                         workDir,
-                         dataDir,
-                         removeOnExit,
-                         detach,
-                         environment,
-                         logDriver]
-    # dockerParameters is deprecated, but if used will use some of the
-    # commandline inputs to define variables.  This is limited to a small subset
-    # of supported commandline inputs only intended for backwards compatibility.
-    if dockerParameters:
-        apiParameters = getDeprecatedCmdlineParams(dockerParameters)
-        for k, v in apiParameters:
-            for keyword in dockerApiKeywords:
-                if k == str(keyword):
-                    keyword = v
 
     # make certain that files have the correct permissions
     thisUser = os.getuid()
     thisGroup = os.getgid()
-    if userPrivilege is None:
-        userPrivilege = str(thisUser) + ":" + str(thisGroup)
+    if user is None:
+        user = str(thisUser) + ":" + str(thisGroup)
 
     if containerName is None:
-        containerName = _getContainerName(job)
+        containerName = getContainerName(job)
 
-    if workDir is None:
-        workDir = os.getcwd()
+    if working_dir is None:
+        working_dir = os.getcwd()
+
+    if volumes is None:
+        volumes = {working_dir: {'bind': '/data', 'mode': 'rw'}}
 
     if parameters is None:
         parameters = []
@@ -173,13 +279,15 @@ def dockerCall(job,
     # If 'parameters' is a list of lists, treat each list as a separate command
     # and chain with pipes.
     if len(parameters) > 0 and type(parameters[0]) is list:
+        if entrypoint is None:
+            entrypoint = ['/bin/bash', '-c']
         chain_params = \
             [' '.join((pipes.quote(arg) for arg in command)) \
              for command in parameters]
         command = ' | '.join(chain_params)
         pipe_prefix = "set -eo pipefail && "
         command = [pipe_prefix + command]
-        _logger.debug("Calling docker with: " + repr(command))
+        logger.debug("Calling docker with: " + repr(command))
 
     # If 'parameters' is a normal list, join all elements into a single string
     # element.
@@ -189,7 +297,7 @@ def dockerCall(job,
     # http://docker-py.readthedocs.io/en/stable/containers.html
     elif len(parameters) > 0 and type(parameters) is list:
         command = ' '.join(parameters)
-        _logger.debug("Calling docker with: " + repr(command))
+        logger.debug("Calling docker with: " + repr(command))
 
     # If the 'parameters' lists are empty, they are respecified as None, which
     # tells the API to simply create and run the container
@@ -197,7 +305,7 @@ def dockerCall(job,
         entrypoint = None
         command = None
 
-    workDir = os.path.abspath(workDir)
+    working_dir = os.path.abspath(working_dir)
 
     # Ensure the user has passed a valid value for deferParam
     assert deferParam in (None, FORGO, STOP, RM), \
@@ -206,51 +314,52 @@ def dockerCall(job,
     client = docker.from_env(version='auto')
 
     if deferParam == STOP:
-        job.defer(_dockerStop, containerName, client)
+        job.defer(dockerStop, containerName, client)
 
     if deferParam == FORGO:
-        removeOnExit = False
+        remove = False
     elif deferParam == RM:
-        removeOnExit = True
-        job.defer(_dockerKill, containerName, client)
-    elif removeOnExit is True:
-        job.defer(_dockerKill, containerName, client)
+        remove = True
+        job.defer(dockerKill, containerName, client)
+    elif remove is True:
+        job.defer(dockerKill, containerName, client)
+
+    if auto_remove is None:
+        auto_remove = remove
 
     try:
-        out = client.containers.run(image=tool,
+        out = client.containers.run(image=image,
                                     command=command,
-                                    working_dir=workDir,
+                                    working_dir=working_dir,
                                     entrypoint=entrypoint,
                                     name=containerName,
                                     detach=detach,
-                                    volumes=
-                                     {workDir: {'bind': dataDir, 'mode': 'rw'}},
-                                    auto_remove=removeOnExit,
-                                    remove=removeOnExit,
-                                    log_config=logDriver,
-                                    user=userPrivilege,
+                                    volumes=volumes,
+                                    auto_remove=auto_remove,
+                                    remove=remove,
+                                    log_config=log_config,
+                                    user=user,
                                     environment=environment,
                                     **kwargs)
         return out
     # If the container exits with a non-zero exit code and detach is False.
     except ContainerError:
-        _logger.error("Docker had non-zero exit.  Check your command: " + \
+        logger.error("Docker had non-zero exit.  Check your command: " + \
                       repr(command))
         raise
     except ImageNotFound:
-        _logger.error("Docker image not found.")
+        logger.error("Docker image not found.")
         raise
     except requests.exceptions.HTTPError as e:
-        _logger.error("The server returned an error.")
+        logger.error("The server returned an error.")
         raise create_api_error_from_http_exception(e)
     except:
         raise
 
-def _dockerKill(container_name, client, gentleKill=False):
+def dockerKill(container_name, client, gentleKill=False):
     """
     Immediately kills a container.  Equivalent to "docker kill":
     https://docs.docker.com/engine/reference/commandline/kill/
-
     :param container_name: Name of the container being killed.
     :param client: The docker API client object to call.
     """
@@ -263,27 +372,25 @@ def _dockerKill(container_name, client, gentleKill=False):
                 client.containers.get(container_name).stop()
             this_container = client.containers.get(container_name)
     except NotFound:
-        _logger.debug("Attempted to stop container, but container != exist: ",
+        logger.debug("Attempted to stop container, but container != exist: ",
                       container_name)
     except requests.exceptions.HTTPError as e:
-        _logger.debug("Attempted to stop container, but server gave an error: ",
+        logger.debug("Attempted to stop container, but server gave an error: ",
                       container_name)
         raise create_api_error_from_http_exception(e)
 
-def _dockerStop(container_name, client):
+def dockerStop(container_name, client):
     """
     Gracefully kills a container.  Equivalent to "docker stop":
     https://docs.docker.com/engine/reference/commandline/stop/
-
     :param container_name: Name of the container being stopped.
     :param client: The docker API client object to call.
     """
-    _dockerKill(container_name, client, gentleKill=True)
+    dockerKill(container_name, client, gentleKill=True)
 
-def _containerIsRunning(container_name):
+def containerIsRunning(container_name):
     """
     Checks whether the container is running or not.
-
     :param container_name: Name of the container being checked.
     :returns: True if status is 'running', False if status is anything else,
     and None if the container does not exist.
@@ -299,63 +406,85 @@ def _containerIsRunning(container_name):
     except NotFound:
         return None
     except requests.exceptions.HTTPError as e:
-        _logger.debug("Server error attempting to call container: ",
+        logger.debug("Server error attempting to call container: ",
                       container_name)
         raise create_api_error_from_http_exception(e)
 
-def _getContainerName(job):
+def getContainerName(job):
     """Create a random string including the job name, and return it."""
     return '--'.join([str(job),
                       base64.b64encode(os.urandom(9), '-_')])\
                       .replace("'", '').replace('"', '').replace('_', '')
 
-def getDeprecatedCmdlineParams(cmdline_params):
+
+def _dockerKill(containerName, action):
     """
-    Supports a minimal number of key terms for backwards compatibility with the
-    arguments formerly supplied to check_call as a commandline array of strings.
-    This is not intended to be maintained or developed beyond those needs, as
-    the dockerCall use of the python docker API keywords is strongly encouraged.
-
-    :param cmdline_params: An array of strings intended for use by check_call.
-                           e.g. ['--rm', '-d']
-    :returns: A dictionary of terms compatible with the python docker API.
+    Deprecated.  Kills the specified container.
+    :param str containerName: The name of the container created by docker_call
+    :param int action: What action should be taken on the container?
     """
-    cmdline_dict = {}
-    skip_to_name = 0
-    skip_to_volume = 0
-    for term in cmdline_params:
-        if term == '--rm':
-            cmdline_dict['removeOnExit'] = True
+    running = containerIsRunning(containerName)
+    if running is None:
+        # This means that the container doesn't exist.  We will see this if the
+        # container was run with --rm and has already exited before this call.
+        logger.info('The container with name "%s" appears to have already been '
+                    'removed.  Nothing to '
+                  'do.', containerName)
+    else:
+        if action in (None, FORGO):
+            logger.info('The container with name %s continues to exist as we '
+                        'were asked to forgo a '
+                      'post-job action on it.', containerName)
+        else:
+            logger.info('The container with name %s exists. Running '
+                        'user-specified defer functions.',
+                         containerName)
+            if running and action >= STOP:
+                logger.info('Stopping container "%s".', containerName)
+                for attempt in retry(predicate=dockerPredicate):
+                    with attempt:
+                        subprocess.check_call(['docker', 'stop', containerName])
+            else:
+                logger.info('The container "%s" was not found to be running.',
+                            containerName)
+            if action >= RM:
+                # If the container was run with --rm, then stop will most likely
+                # remove the container.  We first check if it is running then
+                # remove it.
+                running = containerIsRunning(containerName)
+                if running is not None:
+                    logger.info('Removing container "%s".', containerName)
+                    for attempt in retry(predicate=dockerPredicate):
+                        with attempt:
+                            subprocess.check_call(['docker', 'rm', '-f',
+                                                   containerName])
+                else:
+                    logger.info('Container "%s" was not found on the system.'
+                                'Nothing to remove.',
+                                 containerName)
 
-        if term == '-d':
-            cmdline_dict['detach'] = True
+def _fixPermissions(tool, workDir):
+    """
+    Deprecated.
 
-        if term.beginswith('--logdriver'):
-            log_config = term.split('=')[-1]
-            cmdline_dict['log_config'] = log_config
+    Fix permission of a mounted Docker directory by reusing the tool to change
+    ownership.  Docker natively runs as a root inside the container, and files
+    written to the mounted directory are implicitly owned by root.
+    :param list baseDockerCall: Docker run parameters
+    :param str tool: Name of tool
+    :param str workDir: Path of work directory to recursively chown
+    """
+    if os.geteuid() == 0:
+        # we're running as root so this chown is redundant
+        return
 
-        if skip_to_name == 1:
-            skip_to_name = 0
-            cmdline_dict['name'] = term
-
-        if term == '--name':
-            skip_to_name = 1
-
-        if skip_to_volume == 1:
-            skip_to_volume = 0
-            workDir = term.split(':')[0]
-            dataDir = term.split(':')[-1]
-            cmdline_dict['workDir'] = workDir
-            cmdline_dict['dataDir'] = dataDir
-
-        if term == '-v':
-            skip_to_volume = 1
-
-        if skip_to_envar == 1:
-            skip_to_envar = 0
-            cmdline_dict['environment'] = [term]
-
-        if term == '--env':
-            skip_to_envar = 1
-
-    return cmdline_dict
+    baseDockerCall = ['docker', 'run', '--log-driver=none',
+                      '-v', os.path.abspath(workDir) + ':/data', '--rm',
+                      '--entrypoint=chown']
+    stat = os.stat(workDir)
+    command = baseDockerCall + [tool] + ['-R', '{}:{}'.format(stat.st_uid,
+                                                              stat.st_gid),
+                                         '/data']
+    for attempt in retry(predicate=dockerPredicate):
+        with attempt:
+            subprocess.check_call(command)

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -13,8 +13,7 @@ from toil.job import Job
 from toil.leader import FailedJobsException
 from toil.test import ToilTest, slow
 from toil.lib import FORGO, STOP, RM
-from toil.lib.docker import dockerCall, dockerCheckOutput, \
-                            _containerIsRunning, _dockerKill
+from toil.lib.docker import apiDockerCall, containerIsRunning, dockerKill
 
 _logger = logging.getLogger(__name__)
 
@@ -22,7 +21,6 @@ _logger = logging.getLogger(__name__)
 class DockerTest(ToilTest):
     """
     Tests dockerCall and ensures no containers are left around.
-
     When running tests you may optionally set the TOIL_TEST_TEMP environment
     variable to the path of a directory where you want temporary test files be
     placed. The directory will be created if it doesn't exist. The path may be
@@ -45,7 +43,6 @@ class DockerTest(ToilTest):
         """
         Run the test container that creates a file in the work dir, and sleeps
         for 5 minutes.
-
         Ensure that the calling job gets SIGKILLed after a minute, leaving
         behind the spooky/ghost/zombie container. Ensure that the container is
         killed on batch system shutdown (through the deferParam mechanism).
@@ -62,23 +59,23 @@ class DockerTest(ToilTest):
         #  Neither     R         R         E      X
 
         data_dir = os.path.join(self.tempDir, 'data')
-        work_dir = os.path.join(self.tempDir, 'working')
-        test_file = os.path.join(work_dir, 'test.txt')
+        working_dir = os.path.join(self.tempDir, 'working')
+        test_file = os.path.join(working_dir, 'test.txt')
 
         mkdir_p(data_dir)
-        mkdir_p(work_dir)
+        mkdir_p(working_dir)
 
         options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir,
                                                             'jobstore'))
         options.logLevel = self.dockerTestLogLevel
-        options.workDir = work_dir
+        options.workDir = working_dir
         options.clean = 'always'
         options.disableCaching = disableCaching
 
         # No base64 logic since it might create a name starting with a `-`.
         container_name = uuid.uuid4().hex
         A = Job.wrapJobFn(_testDockerCleanFn,
-                          work_dir,
+                          working_dir,
                           detached,
                           rm,
                           deferParam,
@@ -96,20 +93,20 @@ class DockerTest(ToilTest):
 
             if (rm and (deferParam != FORGO)) or deferParam == RM:
                 # These containers should not exist
-                assert _containerIsRunning(container_name) is None, \
+                assert containerIsRunning(container_name) is None, \
                     'Container was not removed.'
 
             elif deferParam == STOP:
                 # These containers should exist but be non-running
-                assert _containerIsRunning(container_name) == False, \
+                assert containerIsRunning(container_name) == False, \
                     'Container was not stopped.'
 
             else:
                 # These containers will be running
-                assert _containerIsRunning(container_name) == True, \
+                assert containerIsRunning(container_name) == True, \
                     'Container was not running.'
         client = docker.from_env(version='auto')
-        _dockerKill(container_name, client)
+        dockerKill(container_name, client)
         try:
             os.remove(test_file)
         except:
@@ -275,7 +272,7 @@ class DockerTest(ToilTest):
         self.testDockerPipeChainErrorDetection(disableCaching=False)
 
 def _testDockerCleanFn(job,
-                       workDir,
+                       working_dir,
                        detached=None,
                        rm=None,
                        deferParam=None,
@@ -284,14 +281,14 @@ def _testDockerCleanFn(job,
     Test function for test docker_clean.  Runs a container with given flags and
     then dies leaving behind a zombie container.
     :param toil.job.Job job: job
-    :param workDir: See `work_dir=` in :func:`dockerCall`
+    :param working_dir: See `work_dir=` in :func:`dockerCall`
     :param bool rm: See `rm=` in :func:`dockerCall`
     :param bool detached: See `detached=` in :func:`dockerCall`
     :param int deferParam: See `deferParam=` in :func:`dockerCall`
     :param str containerName: See `container_name=` in :func:`dockerCall`
     """
     def killSelf():
-        test_file = os.path.join(workDir, 'test.txt')
+        test_file = os.path.join(working_dir, 'test.txt')
         # Kill the worker once we are sure the docker container is started
         while not os.path.exists(test_file):
             _logger.debug('Waiting on the file created by spooky_container.')
@@ -304,30 +301,30 @@ def _testDockerCleanFn(job,
     # Make it a daemon thread so that thread failure doesn't hang tests.
     t.daemon = True
     t.start()
-    dockerCall(job,
-               tool='quay.io/ucsc_cgl/spooky_test',
-               workDir=workDir,
-               deferParam=deferParam,
-               containerName=containerName,
-               detach=detached,
-               removeOnExit=rm,
-               privileged=True)
+    apiDockerCall(job,
+                  image='quay.io/ucsc_cgl/spooky_test',
+                  working_dir=working_dir,
+                  deferParam=deferParam,
+                  containerName=containerName,
+                  detach=detached,
+                  remove=rm,
+                  privileged=True)
 
 def _testDockerPipeChainFn(job):
     """Return the result of a simple pipe chain.  Should be 2."""
     parameters = [ ['printf', 'x\n y\n'], ['wc', '-l'] ]
-    return dockerCheckOutput(job,
-                             tool='quay.io/ucsc_cgl/spooky_test',
-                             parameters=parameters,
-                             privileged=True)
+    return apiDockerCall(job,
+                         image='quay.io/ucsc_cgl/spooky_test',
+                         parameters=parameters,
+                         privileged=True)
 
 def _testDockerPipeChainErrorFn(job):
     """Return True if the command exit 1 | wc -l raises a ContainerError."""
     parameters = [ ['exit', '1'], ['wc', '-l'] ]
     try:
-        dockerCheckOutput(job,
-                          tool='quay.io/ucsc_cgl/spooky_test',
-                          parameters=parameters)
+        apiDockerCall(job,
+                      image='quay.io/ucsc_cgl/spooky_test',
+                      parameters=parameters)
     except ContainerError:
         return True
     return False


### PR DESCRIPTION
dockerCall() and dockerCheckOutput() now default to using subprocess.check_output() under the old functionality.  This should enable full backwards compatibility.  To use the new docker API wrapper, use apiDockerCall().