### PR TITLE
Modify subprocessDockerCall to address 1959.

### DIFF
--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -30,7 +30,7 @@ from toil.test import timeLimit
 logger = logging.getLogger(__name__)
 
 
-def dockerCheckOutput(job, *args, **kwargs):
+def dockerCheckOutput(*args, **kwargs):
     """
     Deprecated.  Runs subprocessDockerCall() using 'subprocess.check_output()'.
 
@@ -40,9 +40,9 @@ def dockerCheckOutput(job, *args, **kwargs):
     """
     logger.warn("WARNING: dockerCheckOutput() using subprocess.check_output() "
                 "is deprecated, please switch to apiDockerCall().")
-    return subprocessDockerCall(job=job, *args, **kwargs)
+    return subprocessDockerCall(*args, **kwargs)
 
-def dockerCall(job, *args, **kwargs):
+def dockerCall(*args, **kwargs):
     """
     Deprecated.  Runs subprocessDockerCall() using 'subprocess.check_output()'.
 
@@ -52,7 +52,7 @@ def dockerCall(job, *args, **kwargs):
     """
     logger.warn("WARNING: dockerCall() using subprocess.check_output() "
                 "is deprecated, please switch to apiDockerCall().")
-    return subprocessDockerCall(job=job, *args, **kwargs)
+    return subprocessDockerCall(*args, **kwargs)
 
 def subprocessDockerCall(job,
                          tool,

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -160,7 +160,7 @@ def subprocessDockerCall(job,
                                  'set -eo pipefail && {}'.format(' | '.join(chain_params))]
     else:
         call = baseDockerCall + [tool] + parameters
-    _logger.info("Calling docker with " + repr(call))
+    logger.info("Calling docker with " + repr(call))
 
     params = {}
     if outfile:

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -193,6 +193,7 @@ def apiDockerCall(job,
                   remove=False,
                   user=None,
                   environment=None,
+                  outfile=None,
                   **kwargs):
     """
     A toil wrapper for the python docker API.
@@ -339,6 +340,11 @@ def apiDockerCall(job,
                                     user=user,
                                     environment=environment,
                                     **kwargs)
+        if outfile:
+            file = open(outfile, "w")
+            file.write(out)
+            file.close()
+
         return out
     # If the container exits with a non-zero exit code and detach is False.
     except ContainerError:

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -59,6 +59,7 @@ def subprocessDockerCall(job,
                          parameters=None,
                          workDir=None,
                          dockerParameters=None,
+                         checkOutput=True,
                          outfile=None,
                          defer=None):
     """

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -193,7 +193,6 @@ def apiDockerCall(job,
                   remove=False,
                   user=None,
                   environment=None,
-                  outfile=None,
                   **kwargs):
     """
     A toil wrapper for the python docker API.
@@ -340,10 +339,6 @@ def apiDockerCall(job,
                                     user=user,
                                     environment=environment,
                                     **kwargs)
-        if outfile:
-            file = open(outfile, "w")
-            file.write(out)
-            file.close()
 
         return out
     # If the container exits with a non-zero exit code and detach is False.

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -13,9 +13,13 @@ from toil.job import Job
 from toil.leader import FailedJobsException
 from toil.test import ToilTest, slow, needs_appliance
 from toil.lib import FORGO, STOP, RM
-from toil.lib.docker import apiDockerCall, containerIsRunning, dockerKill
+from toil.lib.docker import dockerCall, dockerCheckOutput, apiDockerCall, containerIsRunning, dockerKill
 
-_logger = logging.getLogger(__name__)
+# only needed for subprocessDockerCall tests
+from subprocess import CalledProcessError
+from pwd import getpwuid
+
+logger = logging.getLogger(__name__)
 
 
 @needs_appliance
@@ -272,6 +276,130 @@ class DockerTest(ToilTest):
     def testNonCachingDockerChainErrorDetection(self):
         self.testDockerPipeChainErrorDetection(disableCaching=False)
 
+    # everything below this point tests subprocessDockerCall
+    @slow
+    def testSubprocessDockerClean(self, caching=True):
+        """
+        Run the test container that creates a file in the work dir, and sleeps for 5 minutes.  Ensure
+        that the calling job gets SIGKILLed after a minute, leaving behind the spooky/ghost/zombie
+        container. Ensure that the container is killed on batch system shutdown (through the defer
+        mechanism).
+        This inherently also tests _docker
+        :returns: None
+        """
+        # We need to test the behaviour of `defer` with `rm` and `detached`. We do not look at the case
+        # where `rm` and `detached` are both True.  This is the truth table for the different
+        # combinations at the end of the test. R = Running, X = Does not exist, E = Exists but not
+        # running.
+        #              None     FORGO     STOP    RM
+        #    rm        X         R         X      X
+        # detached     R         R         E      X
+        #  Neither     R         R         E      X
+        assert os.getuid() != 0, "Cannot test this if the user is root."
+        data_dir = os.path.join(self.tempDir, 'data')
+        work_dir = os.path.join(self.tempDir, 'working')
+        test_file = os.path.join(data_dir, 'test.txt')
+        mkdir_p(data_dir)
+        mkdir_p(work_dir)
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
+        options.logLevel = 'INFO'
+        options.workDir = work_dir
+        options.clean = 'always'
+        if not caching:
+            options.disableCaching = True
+        for rm in (True, False):
+            for detached in (True, False):
+                if detached and rm:
+                    continue
+                for defer in (FORGO, STOP, RM, None):
+                    # Not using base64 logic here since it might create a name starting with a `-`.
+                    container_name = uuid.uuid4().hex
+                    A = Job.wrapJobFn(_testSubprocessDockerCleanFn, data_dir, detached, rm, defer,
+                                      container_name)
+                    try:
+                        Job.Runner.startToil(A, options)
+                    except FailedJobsException:
+                        # The file created by spooky_container would remain in the directory, and since
+                        # it was created inside the container, it would have had uid and gid == 0 (root)
+                        # upon creation. If the defer mechanism worked, it should now be non-zero and we
+                        # check for that.
+                        file_stats = os.stat(test_file)
+                        assert file_stats.st_gid != 0
+                        assert file_stats.st_uid != 0
+                        if (rm and defer != FORGO) or defer == RM:
+                            # These containers should not exist
+                            assert containerIsRunning(container_name) is None, \
+                                'Container was not removed.'
+                        elif defer == STOP:
+                            # These containers should exist but be non-running
+                            assert containerIsRunning(container_name) == False, \
+                                'Container was not stopped.'
+                        else:
+                            # These containers will be running
+                            assert containerIsRunning(container_name) == True, \
+                                'Container was not running.'
+                    finally:
+                        # Prepare for the next test.
+                        dockerKill(container_name, RM)
+                        os.remove(test_file)
+
+    def testSubprocessDockerPipeChain(self, caching=True):
+        """
+        Test for piping API for dockerCall().  Using this API (activated when list of
+        argument lists is given as parameters), commands a piped together into a chain
+        ex:  parameters=[ ['printf', 'x\n y\n'], ['wc', '-l'] ] should execute:
+        printf 'x\n y\n' | wc -l
+        """
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
+        options.logLevel = 'INFO'
+        options.workDir = self.tempDir
+        options.clean = 'always'
+        if not caching:
+            options.disableCaching = True
+        A = Job.wrapJobFn(_testSubprocessDockerPipeChainFn)
+        rv = Job.Runner.startToil(A, options)
+        assert rv.strip() == '2'
+
+    def testSubprocessDockerPipeChainErrorDetection(self, caching=True):
+        """
+        By default, executing cmd1 | cmd2 | ... | cmdN, will only return an error
+        if cmdN fails.  This can lead to all manor of errors being silently missed.
+        This tests to make sure that the piping API for dockerCall() throws an exception
+        if non-last commands in the chain fail.
+        """
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
+        options.logLevel = 'INFO'
+        options.workDir = self.tempDir
+        options.clean = 'always'
+        if not caching:
+            options.disableCaching = True
+        A = Job.wrapJobFn(_testSubprocessDockerPipeChainErrorFn)
+        rv = Job.Runner.startToil(A, options)
+        assert rv == True
+
+    def testSubprocessDockerPermissions(self, caching=True):
+        options = Job.Runner.getDefaultOptions(os.path.join(self.tempDir, 'jobstore'))
+        options.logLevel = 'INFO'
+        options.workDir = self.tempDir
+        options.clean = 'always'
+        if not caching:
+            options.disableCaching = True
+        A = Job.wrapJobFn(_testSubprocessDockerPermissions)
+        Job.Runner.startToil(A, options)
+
+    def testSubprocessDockerPermissionsNonCaching(self):
+        self.testSubprocessDockerPermissions(caching=False)
+
+    @slow
+    def testSubprocessNonCachingDockerChain(self):
+        self.testSubprocessDockerPipeChain(caching=False)
+
+    def testSubprocessNonCachingDockerChainErrorDetection(self):
+        self.testSubprocessDockerPipeChainErrorDetection(caching=False)
+
+    def testSubprocessNonCachingDockerClean(self):
+        self.testSubprocessDockerClean(caching=False)
+
 def _testDockerCleanFn(job,
                        working_dir,
                        detached=None,
@@ -292,7 +420,7 @@ def _testDockerCleanFn(job,
         test_file = os.path.join(working_dir, 'test.txt')
         # Kill the worker once we are sure the docker container is started
         while not os.path.exists(test_file):
-            _logger.debug('Waiting on the file created by spooky_container.')
+            logger.debug('Waiting on the file created by spooky_container.')
             time.sleep(1)
         # By the time we reach here, we are sure the container is running.
         time.sleep(1)
@@ -329,3 +457,74 @@ def _testDockerPipeChainErrorFn(job):
     except ContainerError:
         return True
     return False
+
+###########################################################################
+
+
+def _testSubprocessDockerCleanFn(job, workDir, detached=None, rm=None, defer=None, containerName=None):
+    """
+    Test function for test docker_clean.  Runs a container with given flags and then dies leaving
+    behind a zombie container
+    :param toil.job.Job job: job
+    :param workDir: See `work_dir=` in :func:`dockerCall`
+    :param bool rm: See `rm=` in :func:`dockerCall`
+    :param bool detached: See `detached=` in :func:`dockerCall`
+    :param int defer: See `defer=` in :func:`dockerCall`
+    :param str containerName: See `container_name=` in :func:`dockerCall`
+    :return:
+    """
+    dockerParameters = ['--log-driver=none', '-v', os.path.abspath(workDir) + ':/data',
+                        '--name', containerName]
+    if detached:
+        dockerParameters.append('-d')
+    if rm:
+        dockerParameters.append('--rm')
+
+    def killSelf():
+        test_file = os.path.join(workDir, 'test.txt')
+        # This will kill the worker once we are sure the docker container started
+        while not os.path.exists(test_file):
+            logger.debug('Waiting on the file created by spooky_container.')
+            time.sleep(1)
+        # By the time we reach here, we are sure the container is running.
+        os.kill(os.getpid(), signal.SIGKILL)  # signal.SIGINT)
+    t = Thread(target=killSelf)
+    # Make it a daemon thread so that thread failure doesn't hang tests.
+    t.daemon = True
+    t.start()
+    dockerCall(job, tool='quay.io/ucsc_cgl/spooky_test', workDir=workDir, defer=defer, dockerParameters=dockerParameters)
+
+def _testSubprocessDockerPipeChainFn(job):
+    """
+    Return the result of simple pipe chain.  Should be 2
+    """
+    parameters = [ ['printf', 'x\n y\n'], ['wc', '-l'] ]
+    return dockerCheckOutput(job, tool='quay.io/ucsc_cgl/spooky_test', parameters=parameters)
+
+def _testSubprocessDockerPipeChainErrorFn(job):
+    """
+    Return True if the command exit 1 | wc -l raises a CalledProcessError when run through 
+    the docker interface
+    """
+    parameters = [ ['exit', '1'], ['wc', '-l'] ]
+    try:
+        return dockerCheckOutput(job, tool='quay.io/ucsc_cgl/spooky_test', parameters=parameters)
+    except CalledProcessError:
+        return True
+    return False
+
+def _testSubprocessDockerPermissions(job):
+    testDir = job.fileStore.getLocalTempDir()
+    dockerCall(job, tool='ubuntu', workDir=testDir, parameters=[['touch', '/data/test.txt']])
+    outFile = os.path.join(testDir, 'test.txt')
+    assert os.path.exists(outFile)
+    assert not ownerName(outFile) == "root"
+
+
+def ownerName(filename):
+    """
+    Determines a given file's owner
+    :param str filename: path to a file
+    :return: name of filename's owner
+    """
+    return getpwuid(os.stat(filename).st_uid).pw_name


### PR DESCRIPTION
Just allow "job" to be accepted as an *arg.  Addresses an issue with the subprocessDockerCall() that toil-vg uses.