### PR TITLE
Fix launch-cluster breaking if your terminal window isn't extra-wide

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -575,7 +575,7 @@ class AWSProvisioner(AbstractProvisioner):
     def _waitForDockerDaemon(cls, ip_address):
         logger.info('Waiting for docker on %s to start...', ip_address)
         while True:
-            output = cls._sshInstance(ip_address, '/usr/bin/ps', 'aux')
+            output = cls._sshInstance(ip_address, '/usr/bin/ps', 'auxww')
             time.sleep(5)
             if 'dockerd' in output:
                 # docker daemon has started


### PR DESCRIPTION
The Toil provisioner uses `ssh -t` to issue commands, which forces the allocation of a
TTY. When checking that dockerd is running, it issues a `ps aux` and
searches for dockerd in the output. But when run inside a TTY, ps
truncates the output to the width of the terminal. If you used the
default terminal width, 80, and were particularly unlucky with what
date/PID/RSS you had, you could get an output line for the dockerd process
that looks like this:

```
root      1002  8.3  1.8 816052 73688 ?        Ssl  18:37   0:30 /run/torcx/bin
```

which actually doesn't contain the string "dockerd" at all.

This patch just forces ps to never truncate.