### PR TITLE
get latest fixes from cwltool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def runSetup():
                 'gcs_oauth2_boto_plugin==1.14',
                 botoRequirement],
             'cwl': [
-                'cwltool==1.0.20171107133715',
+                'cwltool==1.0.20171227212058',
                 'schema-salad >= 2.6, < 3',
                 'galaxy-lib==17.9.3',
                 'cwltest>=1.0.20170214185319']},

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -896,12 +896,9 @@ def main(args=None, stdout=sys.stdout):
             options.job_order = options.cwljob
             options.tool_help = None
             options.debug = options.logLevel == "DEBUG"
-            job = cwltool.main.load_job_order(options, t, sys.stdin)
-
-            if type(job) == int:
-                return job
-
-            job, options.basedir = job
+            job, options.basedir, loader = cwltool.main.load_job_order(
+                options, sys.stdin, None, [], options.job_order)
+            job = cwltool.main.init_job_order(job, options, t, loader=loader)
 
             fillInDefaults(t.tool["inputs"], job)
 


### PR DESCRIPTION
* Run "#main" resolved object by default
* sort globs according to POSIX
* reduce loading time for packed documents