### PR TITLE
show default values in --help

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -36,7 +36,7 @@ except ImportError:
     import pickle
 
 from abc import ABCMeta, abstractmethod
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from contextlib import contextmanager
 from io import BytesIO
 
@@ -726,7 +726,7 @@ class Job(JobLikeObject):
             :returns: The argument parser used by a toil workflow with added Toil options.
             :rtype: :class:`argparse.ArgumentParser`
             """
-            parser = ArgumentParser()
+            parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
             Job.Runner.addToilOptions(parser)
             return parser
 


### PR DESCRIPTION
When using `Job.Runner.getDefaultArgumentParser` method, default values aren't displayed with `--help`.

This pull request adds  [ArgumentDefaultsHelpFormatter](https://docs.python.org/3/library/argparse.html#formatter-class) as `formatter_class` in `Job.Runner.getDefaultArgumentParser`.

See https://stackoverflow.com/questions/12151306.
  