### PR TITLE
move local job queue up into BatchSystemLocalSupport

### DIFF
--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -181,14 +181,6 @@ class AbstractBatchSystem(with_metaclass(ABCMeta, object)):
         raise NotImplementedError()
 
     @classmethod
-    def getRescueBatchJobFrequency(cls):
-        """
-        Gets the period of time to wait (floating point, in seconds) between checking for
-        missing/overlong jobs.
-        """
-        raise NotImplementedError()
-
-    @classmethod
     def setOptions(cls, setOption):
         """
         Process command line or configuration options relevant to this batch system.
@@ -287,17 +279,6 @@ class BatchSystemSupport(AbstractBatchSystem):
             except KeyError:
                 raise RuntimeError("%s does not exist in current environment", name)
         self.environment[name] = value
-
-    @classmethod
-    def getRescueBatchJobFrequency(cls):
-        """
-        Gets the period of time to wait (floating point, in seconds) between checking for
-        missing/overlong jobs.
-
-        :return: time in seconds to wait in between checking for lost jobs
-        :rtype: float
-        """
-        raise NotImplementedError()
 
     def _getResultsFileName(self, toilPath):
         """

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -368,7 +368,7 @@ class BatchSystemLocalSupport(BatchSystemSupport):
     def getUpdatedLocalJob(self, maxWait):
 	# type: (int) -> Optional[Tuple[int, int, int]]
 	"""To be called by getUpdatedBatchJob()"""
-	return self.localBatch.getUpdateBatchJob()
+	return self.localBatch.getUpdatedBatchJob()
 
     def getNextJobID(self):  # type: () -> int
         """
@@ -471,7 +471,7 @@ class AbstractScalableBatchSystem(AbstractBatchSystem):
     def ignoreNode(self, nodeAddress):
         """
         Stop sending jobs to this node. Used in autoscaling
-        when the autoscaler is ready to terminate a node, but 
+        when the autoscaler is ready to terminate a node, but
         jobs are still running. This allows the node to be terminated
         after the current jobs have finished.
 
@@ -488,6 +488,7 @@ class AbstractScalableBatchSystem(AbstractBatchSystem):
         possibility of a new node having the same address as a terminated one.
         """
         raise NotImplementedError()
+
 
 class InsufficientSystemResources(Exception):
     """

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -333,7 +333,7 @@ class BatchSystemLocalSupport(BatchSystemSupport):
     """
 
     def __init__(self, config, maxCores, maxMemory, maxDisk):
-        super(BatchSystemLocalSupport, self).__init__()
+        super(BatchSystemLocalSupport, self).__init__(config, maxCores, maxMemory, maxDisk)
         self.localBatch = registry.batchSystemFactoryFor(
             registry.defaultBatchSystem())()(
                 config, maxCores, maxMemory, maxDisk)

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -351,8 +351,8 @@ class BatchSystemLocalSupport(BatchSystemSupport):
             return None
 
     def killLocalJobs(self, jobIDs):
-	"""
-	To be called by killBatchJobs. Will kill all local jobs that match the
+        """
+        To be called by killBatchJobs. Will kill all local jobs that match the
         provided jobIDs.
         """
         self.localBatch.killBatchJobs(jobIDs)
@@ -362,27 +362,27 @@ class BatchSystemLocalSupport(BatchSystemSupport):
         return self.localBatch.getIssuedBatchJobIDs()
 
     def getRunningLocalJobIDs(self):
-	"""To be called by getRunningBatchJobIDs()."""
-	return self.localBatch.getRunningBatchJobIDs()
+        """To be called by getRunningBatchJobIDs()."""
+        return self.localBatch.getRunningBatchJobIDs()
 
     def getUpdatedLocalJob(self, maxWait):
-	# type: (int) -> Optional[Tuple[int, int, int]]
-	"""To be called by getUpdatedBatchJob()"""
-	return self.localBatch.getUpdatedBatchJob()
+        # type: (int) -> Optional[Tuple[int, int, int]]
+        """To be called by getUpdatedBatchJob()"""
+        return self.localBatch.getUpdatedBatchJob(maxWait)
 
     def getNextJobID(self):  # type: () -> int
         """
         Must be used to get job IDs so that the local and batch jobs do not
         conflict.
         """
-	with self.localBatch.jobIndexLock:
-		jobID = self.localBatch.jobIndex
-		self.localBatch.jobIndex += 1
-	return jobID
+        with self.localBatch.jobIndexLock:
+            jobID = self.localBatch.jobIndex
+            self.localBatch.jobIndex += 1
+        return jobID
 
     def shutdownLocal(self):  # type: () -> None
-	"""To be called from shutdown()"""
-	self.localBatch.shutdown()
+        """To be called from shutdown()"""
+        self.localBatch.shutdown()
 
 
 class NodeInfo(object):

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import
 
 from builtins import str
 from datetime import datetime
-import os
-import shutil
 import logging
 import time
 from threading import Thread
@@ -29,17 +27,12 @@ from future.utils import with_metaclass
 
 from bd2k.util.objects import abstractclassmethod
 
-from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
-from toil.batchSystems import registry
-try:
-    from toil.cwl.cwltoil import CWL_INTERNAL_JOBS
-except ImportError:
-    # CWL extra not installed
-    CWL_INTERNAL_JOBS = ()
+from toil.batchSystems.abstractBatchSystem import BatchSystemLocalSupport
 
 logger = logging.getLogger(__name__)
 
-class AbstractGridEngineBatchSystem(BatchSystemSupport):
+
+class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
     """
     A partial implementation of BatchSystemSupport for batch systems run on a
     standard HPC cluster. By default worker cleanup and hot deployment are not
@@ -82,7 +75,7 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
 
             :param: string jobID: toil job ID
             """
-            if not jobID in self.batchJobIDs:
+            if jobID not in self.batchJobIDs:
                 RuntimeError("Unknown jobID, could not be converted")
 
             (job, task) = self.batchJobIDs[jobID]
@@ -283,7 +276,6 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
             """
             raise NotImplementedError()
 
-
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         super(AbstractGridEngineBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
 
@@ -307,8 +299,6 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
         self.worker = self.Worker(self.newJobsQueue, self.updatedJobsQueue, self.killQueue,
                               self.killedJobsQueue, self)
         self.worker.start()
-        self.localBatch = registry.batchSystemFactoryFor(registry.defaultBatchSystem())()(config, maxCores,
-                                                                                          maxMemory, maxDisk)
         self._getRunningBatchJobIDsTimestamp = None
         self._getRunningBatchJobIDsCache = {}
 
@@ -326,13 +316,12 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
 
     def issueBatchJob(self, jobNode):
         # Avoid submitting internal jobs to the batch queue, handle locally
-        if jobNode.jobName.startswith(CWL_INTERNAL_JOBS):
-            jobID = self.localBatch.issueBatchJob(jobNode)
+        localID = self.handleLocalJob(jobNode)
+        if localID:
+            return localID
         else:
             self.checkResourceRequest(jobNode.memory, jobNode.cores, jobNode.disk)
-            with self.localBatch.jobIndexLock:
-                jobID = self.localBatch.jobIndex
-                self.localBatch.jobIndex += 1
+            jobID = self.getNextJobID()
             self.currentJobs.add(jobID)
             self.newJobsQueue.put((jobID, jobNode.cores, jobNode.memory, jobNode.command))
             logger.debug("Issued the job command: %s with job id: %s ", jobNode.command, str(jobID))
@@ -343,7 +332,7 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
         Kills the given jobs, represented as Job ids, then checks they are dead by checking
         they are not in the list of issued jobs.
         """
-        self.localBatch.killBatchJobs(jobIDs)
+        self.killLocalJobs(jobIDs)
         jobIDs = set(jobIDs)
         logger.debug('Jobs to be killed: %r', jobIDs)
         for jobID in jobIDs:
@@ -363,7 +352,7 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
         """
         Gets the list of issued jobs
         """
-        return list(self.localBatch.getIssuedBatchJobIDs()) + list(self.currentJobs)
+        return list(self.getIssuedLocalJobIDs()) + list(self.currentJobs)
 
     def getRunningBatchJobIDs(self):
         """Retrieve running job IDs from local and batch scheduler.
@@ -371,7 +360,6 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
         Respects statePollingWait and will return cached results if not within
         time period to talk with the scheduler.
         """
-        localIds = self.localBatch.getRunningBatchJobIDs()
         if (self._getRunningBatchJobIDsTimestamp and
              (datetime.now() - self._getRunningBatchJobIDsTimestamp).total_seconds() < self.config.statePollingWait):
             batchIds = self._getRunningBatchJobIDsCache
@@ -379,11 +367,11 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
             batchIds = self.worker.getRunningJobIDs()
             self._getRunningBatchJobIDsCache = batchIds
             self._getRunningBatchJobIDsTimestamp = datetime.now()
-        batchIds.update(localIds)
+        batchIds.update(self.getRunningLocalJobIDs())
         return batchIds
 
     def getUpdatedBatchJob(self, maxWait):
-        local_tuple = self.localBatch.getUpdatedBatchJob(0)
+        local_tuple = self.getUpdatedLocalJob(0)
         if local_tuple:
             return local_tuple
         else:
@@ -400,7 +388,7 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
         """
         Signals worker to shutdown (via sentinel) then cleanly joins the thread
         """
-        self.localBatch.shutdown()
+        self.shutdownLocal()
         newJobsQueue = self.newJobsQueue
         self.newJobsQueue = None
 
@@ -418,7 +406,7 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
 
     @classmethod
     def getRescueBatchJobFrequency(cls):
-        return 30 * 60 # Half an hour
+        return 30 * 60  # Half an hour
 
     def sleepSeconds(self, sleeptime=1):
         """ Helper function to drop on all state-querying functions to avoid over-querying.

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -404,10 +404,6 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
     def getWaitDuration(self):
         return 5
 
-    @classmethod
-    def getRescueBatchJobFrequency(cls):
-        return 30 * 60  # Half an hour
-
     def sleepSeconds(self, sleeptime=1):
         """ Helper function to drop on all state-querying functions to avoid over-querying.
         """

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -33,7 +33,7 @@ import os
 from six.moves.queue import Empty, Queue
 
 from toil.batchSystems import MemoryString
-from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
+from toil.batchSystems.abstractBatchSystem import BatchSystemLocalSupport
 from toil.batchSystems.lsfHelper import parse_memory, per_core_reservation
 
 logger = logging.getLogger( __name__ )
@@ -149,7 +149,7 @@ class Worker(Thread):
 
             time.sleep(10)
 
-class LSFBatchSystem(BatchSystemSupport):
+class LSFBatchSystem(BatchSystemLocalSupport):
     """
     The interface for running jobs on lsf, runs all the jobs you give it as they come in,
     but in parallel.

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -1,22 +1,22 @@
-#Copyright (C) 2013 by Thomas Keane (tk2@sanger.ac.uk)
+# Copyright (C) 2013 by Thomas Keane (tk2@sanger.ac.uk)
 #
-#Permission is hereby granted, free of charge, to any person obtaining a copy
-#of this software and associated documentation files (the "Software"), to deal
-#in the Software without restriction, including without limitation the rights
-#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-#copies of the Software, and to permit persons to whom the Software is
-#furnished to do so, subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-#The above copyright notice and this permission notice shall be included in
-#all copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
-#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-#THE SOFTWARE.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 from __future__ import absolute_import
 from __future__ import division
 from builtins import str
@@ -37,7 +37,6 @@ from toil.batchSystems.abstractBatchSystem import BatchSystemLocalSupport
 from toil.batchSystems.lsfHelper import parse_memory, per_core_reservation
 
 logger = logging.getLogger( __name__ )
-
 
 
 def prepareBsub(cpu, mem):
@@ -65,6 +64,7 @@ def prepareBsub(cpu, mem):
         bsubline.extend(lsfArgs.split())
     return bsubline
 
+
 def bsub(bsubline):
     process = subprocess.Popen(" ".join(bsubline), shell=True, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
     liney = process.stdout.readline()
@@ -73,10 +73,11 @@ def bsub(bsubline):
     logger.debug("Got the job id: %s" % (str(result)))
     return result
 
+
 def getjobexitcode(lsfJobID):
         job, task = lsfJobID
 
-        #first try bjobs to find out job state
+        # first try bjobs to find out job state
         args = ["bjobs", "-l", str(job)]
         logger.debug("Checking job exit code for job via bjobs: " + str(job))
         process = subprocess.Popen(" ".join(args), shell=True, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
@@ -101,7 +102,7 @@ def getjobexitcode(lsfJobID):
             logger.debug("bjobs detected job started but not completed: " + str(job))
             return None
 
-        #if not found in bjobs, then try bacct (slower than bjobs)
+        # if not found in bjobs, then try bacct (slower than bjobs)
         logger.debug("bjobs failed to detect job - trying bacct: " + str(job))
 
         args = ["bacct", "-l", str(job)]
@@ -116,6 +117,7 @@ def getjobexitcode(lsfJobID):
                 return 1
         logger.debug("Cant determine exit code for job or job still running: " + str(job))
         return None
+
 
 class Worker(Thread):
     def __init__(self, newJobsQueue, updatedJobsQueue, boss):
@@ -149,6 +151,7 @@ class Worker(Thread):
 
             time.sleep(10)
 
+
 class LSFBatchSystem(BatchSystemLocalSupport):
     """
     The interface for running jobs on lsf, runs all the jobs you give it as they come in,
@@ -168,9 +171,9 @@ class LSFBatchSystem(BatchSystemLocalSupport):
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         super(LSFBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
         self.lsfResultsFile = self._getResultsFileName(config.jobStore)
-        #Reset the job queue and results (initially, we do this again once we've killed the jobs)
+        # Reset the job queue and results (initially, we do this again once we've killed the jobs)
         self.lsfResultsFileHandle = open(self.lsfResultsFile, 'w')
-        self.lsfResultsFileHandle.close() #We lose any previous state in this file, and ensure the files existence
+        self.lsfResultsFileHandle.close()  # We lose any previous state in this file, and ensure the files existence
         self.currentjobs = set()
         self.obtainSystemConstants()
         self.jobIDs = dict()
@@ -183,8 +186,8 @@ class LSFBatchSystem(BatchSystemLocalSupport):
         self.worker.start()
 
     def __des__(self):
-        #Closes the file handle associated with the results file.
-        self.lsfResultsFileHandle.close() #Close the results file, cos were done.
+        # Closes the file handle associated with the results file.
+        self.lsfResultsFileHandle.close() # Close the results file, cos were done.
 
     def issueBatchJob(self, jobNode):
         localID = self.handleLocalJob(jobNode)
@@ -198,14 +201,14 @@ class LSFBatchSystem(BatchSystemLocalSupport):
         return jobID
 
     def getLsfID(self, jobID):
-        if not jobID in self.lsfJobIDs:
-             RuntimeError("Unknown jobID, could not be converted")
+        if jobID not in self.lsfJobIDs:
+            RuntimeError("Unknown jobID, could not be converted")
 
         (job,task) = self.lsfJobIDs[jobID]
         if task is None:
-             return str(job)
+            return str(job)
         else:
-             return str(job) + "." + str(task)
+            return str(job) + "." + str(task)
 
     def killBatchJobs(self, jobIDs):
         self.killLocalJobs(jobIDs)
@@ -214,9 +217,9 @@ class LSFBatchSystem(BatchSystemLocalSupport):
         for jobID in jobIDs:
             try:
                 lsfID = self.getLsfID(jobID)
-                logger.debug("DEL: " + str(self.getLsfID(jobID)))
+                logger.debug("DEL: " + str(lsfID))
                 self.currentjobs.remove(jobID)
-                process = subprocess.Popen(["bkill", self.getLsfID(jobID)])
+                subprocess.Popen(["bkill", lsfID])
                 del self.jobIDs[self.lsfJobIDs[jobID]]
                 del self.lsfJobIDs[jobID]
             except RuntimeError:
@@ -237,7 +240,7 @@ class LSFBatchSystem(BatchSystemLocalSupport):
         """A list of jobs (as jobIDs) currently issued (may be running, or maybe 
         just waiting).
         """
-        return list(self.getIssuedLocalJobIDs()) + list(self.currentJobs)
+        return list(self.getIssuedLocalJobIDs()) + list(self.currentjobs)
 
     def getRunningBatchJobIDs(self):
         """Gets a map of jobs (as jobIDs) currently running (not just waiting) 
@@ -249,7 +252,7 @@ class LSFBatchSystem(BatchSystemLocalSupport):
             if x in self.lsfJobIDs:
                 currentjobs.add(self.lsfJobIDs[x])
             else:
-                #not yet started
+                # not yet started
                 pass
         process = subprocess.Popen(["bjobs"], stdout = subprocess.PIPE)
 

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -269,17 +269,9 @@ class LSFBatchSystem(BatchSystemLocalSupport):
             return jobID, retcode, None
 
     def getWaitDuration(self):
-        """We give parasol a second to catch its breath (in seconds)
+        """We give LSF a second to catch its breath (in seconds)
         """
-        #return 0.0
         return 15
-
-    @classmethod
-    def getRescueBatchJobFrequency(cls):
-        """Parasol leaks jobs, but rescuing jobs involves calls to parasol list jobs and pstat2,
-        making it expensive. We allow this every 10 minutes..
-        """
-        return 1800
 
     def obtainSystemConstants(self):
         p = subprocess.Popen(["lshosts"], stdout = subprocess.PIPE, stderr = subprocess.STDOUT)

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -267,10 +267,6 @@ class MesosBatchSystem(BatchSystemLocalSupport,
         """
         return self.reconciliationPeriod
 
-    @classmethod
-    def getRescueBatchJobFrequency(cls):
-        return 30 * 60  # Half an hour
-
     def _buildExecutor(self):
         """
         Creates and returns an ExecutorInfo instance representing our executor implementation.

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-from builtins import next
 from builtins import filter
 from builtins import str
 from builtins import object
@@ -33,7 +32,6 @@ try:
 except ImportError:
     import pickle
 
-import itertools
 
 # Python 3 compatibility imports
 from six.moves.queue import Empty, Queue
@@ -46,14 +44,14 @@ from mesos.interface import mesos_pb2
 
 from toil import resolveEntryPoint
 from toil.batchSystems.abstractBatchSystem import (AbstractScalableBatchSystem,
-                                                   BatchSystemSupport,
+                                                   BatchSystemLocalSupport,
                                                    NodeInfo)
 from toil.batchSystems.mesos import ToilJob, ResourceRequirement, TaskData, JobQueue
 
 log = logging.getLogger(__name__)
 
 
-class MesosBatchSystem(BatchSystemSupport,
+class MesosBatchSystem(BatchSystemLocalSupport,
                        AbstractScalableBatchSystem,
                        mesos.interface.Scheduler):
     """
@@ -147,7 +145,6 @@ class MesosBatchSystem(BatchSystemSupport,
 
         self.executor = self._buildExecutor()
 
-        self.unusedJobID = itertools.count()
         self.lastReconciliation = time.time()
         self.reconciliationPeriod = 120
 
@@ -176,8 +173,11 @@ class MesosBatchSystem(BatchSystemSupport,
         is an int giving the number of bytes the job needs to run in and cores is the number of cpus
         needed for the job and error-file is the path of the file to place any std-err/std-out in.
         """
+        localID = self.handleLocalJob(jobNode)
+        if localID:
+            return localID
         self.checkResourceRequest(jobNode.memory, jobNode.cores, jobNode.disk)
-        jobID = next(self.unusedJobID)
+        jobID = self.getNextJobID()
         job = ToilJob(jobID=jobID,
                       name=str(jobNode),
                       resources=ResourceRequirement(**jobNode._requirements),
@@ -196,6 +196,7 @@ class MesosBatchSystem(BatchSystemSupport,
         return jobID
 
     def killBatchJobs(self, jobIDs):
+        self.killLocalJobs(jobIDs)
         # FIXME: probably still racy
         assert self.driver is not None
         localSet = set()
@@ -222,15 +223,19 @@ class MesosBatchSystem(BatchSystemSupport,
     def getIssuedBatchJobIDs(self):
         jobIds = set(self.jobQueues.jobIDs())
         jobIds.update(list(self.runningJobMap.keys()))
-        return list(jobIds)
+        return list(jobIds) + list(self.getIssuedLocalJobIDs())
 
     def getRunningBatchJobIDs(self):
         currentTime = dict()
         for jobID, data in list(self.runningJobMap.items()):
             currentTime[jobID] = time.time() - data.startTime
+        currentTime.update(self.getRunningLocalJobIDs())
         return currentTime
 
     def getUpdatedBatchJob(self, maxWait):
+        local_tuple = self.getUpdatedLocalJob(0)
+        if local_tuple:
+            return local_tuple
         while True:
             try:
                 item = self.updatedJobsQueue.get(timeout=maxWait)
@@ -315,6 +320,7 @@ class MesosBatchSystem(BatchSystemSupport,
         return ':'.join(address)
 
     def shutdown(self):
+        self.shutdownLocal()
         log.debug("Stopping Mesos driver")
         self.driver.stop()
         log.debug("Joining Mesos driver")
@@ -635,11 +641,10 @@ class MesosBatchSystem(BatchSystemSupport,
         """
         log.warning("Executor '%s' lost.", executorId)
 
-
     @classmethod
     def setOptions(cl, setOption):
         setOption("mesosMasterAddress", None, None, 'localhost:5050')
-        
+
 
 def toMiB(n):
     return n / 1024 / 1024

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -280,14 +280,6 @@ class ParasolBatchSystem(BatchSystemSupport):
             else:
                 return jobID, status, wallTime
 
-    @classmethod
-    def getRescueBatchJobFrequency(cls):
-        """
-        Parasol leaks jobs, but rescuing jobs involves calls to parasol list jobs and pstat2,
-        making it expensive.
-        """
-        return 5400  # Once every 90 minutes
-
     def updatedJobWorker(self):
         """
         We use the parasol results to update the status of jobs, adding them

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -291,16 +291,9 @@ class SingleMachineBatchSystem(BatchSystemSupport):
         return jobID, exitValue, wallTime
 
     @classmethod
-    def getRescueBatchJobFrequency(cls):
-        """
-        This should not really occur, wihtout an error. To exercise the system we allow it every 90 minutes.
-        """
-        return 5400
-
-    @classmethod
     def setOptions(cls, setOption):
         setOption("scale", default=1)
-        
+
 class Info(object):
     # Can't use namedtuple here since killIntended needs to be mutable
     def __init__(self, startTime, popen, killIntended):

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -218,9 +218,6 @@ class hidden(object):
                                   memory=10, cores=None, disk=1000)
                 checkResourceRequest(memory=10, cores=1, disk=100)
 
-        def testGetRescueJobFrequency(self):
-            self.assertTrue(self.batchSystem.getRescueBatchJobFrequency() > 0)
-
         def testScalableBatchSystem(self):
             # If instance of scalable batch system
             pass

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -178,6 +178,7 @@ class hidden(object):
             #  '...' or python -c '...'. The safest thing to do here is to script the test and
             # invoke that script rather than inline the test via -c.
             def assertEnv():
+                import os, sys
                 sys.exit(0 if os.getenv('FOO') == 'bar' else 42)
 
             script_body = dedent('\n'.join(getsource(assertEnv).split('\n')[1:]))
@@ -410,6 +411,7 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
         self.counterPath = writeTempFile('0,0')
 
         def script():
+            import os, sys, fcntl, time
             def count(delta):
                 """
                 Adjust the first integer value in a file by the given amount. If the result

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -40,7 +40,6 @@ from toil.batchSystems.parasolTestSupport import ParasolTestSupport
 from toil.batchSystems.parasol import ParasolBatchSystem
 from toil.batchSystems.singleMachine import SingleMachineBatchSystem
 from toil.batchSystems.abstractBatchSystem import (InsufficientSystemResources,
-                                                   AbstractBatchSystem,
                                                    BatchSystemSupport)
 from toil.job import Job, JobNode
 from toil.test import (ToilTest,
@@ -179,7 +178,6 @@ class hidden(object):
             #  '...' or python -c '...'. The safest thing to do here is to script the test and
             # invoke that script rather than inline the test via -c.
             def assertEnv():
-                import os, sys
                 sys.exit(0 if os.getenv('FOO') == 'bar' else 42)
 
             script_body = dedent('\n'.join(getsource(assertEnv).split('\n')[1:]))
@@ -323,6 +321,7 @@ class hidden(object):
             self.assertTrue(locator.startswith('file:'))
             self.assertEqual(locator[len('file:'):], filePath)
 
+
 @slow
 @needs_mesos
 class MesosBatchSystemTest(hidden.AbstractBatchSystemTest, MesosTestSupport):
@@ -362,9 +361,8 @@ class MesosBatchSystemTest(hidden.AbstractBatchSystemTest, MesosTestSupport):
         self.assertEqual(set(issuedID), {job})
 
         runningJobIDs = self._waitForJobsToStart(1)
-        #Make sure job is NOT running
+        # Make sure job is NOT running
         self.assertEqual(set(runningJobIDs), set({}))
-
 
 
 class SingleMachineBatchSystemTest(hidden.AbstractBatchSystemTest):
@@ -379,10 +377,11 @@ class SingleMachineBatchSystemTest(hidden.AbstractBatchSystemTest):
         return SingleMachineBatchSystem(config=self.config,
                                         maxCores=numCores, maxMemory=1e9, maxDisk=2001)
 
+
 @slow
 class MaxCoresSingleMachineBatchSystemTest(ToilTest):
     """
-    This test ensures that single machine batch system doesn't exceed the configured number of
+    This test ensures that single machine batch system doesn't exceed the configured number
     cores
     """
 
@@ -411,7 +410,6 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
         self.counterPath = writeTempFile('0,0')
 
         def script():
-            import os, sys, fcntl, time
             def count(delta):
                 """
                 Adjust the first integer value in a file by the given amount. If the result
@@ -502,7 +500,6 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
                         self.assertEquals(maxConcurrentTasks, expectedMaxConcurrentTasks)
                         resetCounters(self.counterPath)
 
-
     @skipIf(SingleMachineBatchSystem.numCores < 3, 'Need at least three cores to run this test')
     def testServices(self):
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
@@ -552,6 +549,7 @@ class Service(Job.Service):
     def stop(self, fileStore):
         subprocess.check_call(self.cmd + ' -1', shell=True)
 
+
 @slow
 @needs_parasol
 class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport):
@@ -571,7 +569,7 @@ class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport)
     def createBatchSystem(self):
         memory = int(3e9)
         self._startParasol(numCores=numCores, memory=memory)
-        
+
         return ParasolBatchSystem(config=self.config,
                                   maxCores=numCores,
                                   maxMemory=memory,
@@ -614,7 +612,6 @@ class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport)
         memPattern = re.compile("(\d+\.\d+)([kgmbt])")
         items = batchString.split()
         batchInfo["cores"] = int(items[7])
-        name = str(items[11])
         memMatch = memPattern.match(items[8])
         ramValue = float(memMatch.group(1))
         ramUnits = memMatch.group(2)
@@ -648,6 +645,7 @@ class GridEngineBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
         for f in glob('toil_job*.o*'):
             os.unlink(f)
 
+
 @slow
 @needs_slurm
 class SlurmBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
@@ -666,6 +664,7 @@ class SlurmBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
         from glob import glob
         for f in glob('slurm-*.out'):
             os.unlink(f)
+
 
 @slow
 @needs_torque
@@ -691,6 +690,7 @@ class TorqueBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
         from glob import glob
         for f in glob('toil_job_*.[oe]*'):
             os.unlink(f)
+
 
 class SingleMachineBatchSystemJobTest(hidden.AbstractBatchSystemJobTest):
     """


### PR DESCRIPTION
enhances CWL execution on Mesos, AbstractGrinEngine, and other BatchSystemSupport
based backends

Fixes non-thread safe job ID increment on Mesos
 
Removes unused getRescueBatchJobFrequency() methods