### PR TITLE
Add citation.  (#2010)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,10 @@ Toil is an open-source pure-Python workflow engine that lets people write better
 
 Check out our `website`_ for a comprehensive list of Toil's features and read our `paper`_ to learn what Toil can do in the real world.  Feel free to also join us on `GitHub`_ and `Gitter`_.
 
+If using toil for your research, please cite::
+
+    Vivian, J., Rao, A. A., Nothaft, F. A., Ketchum, C., Armstrong, J., Novak, A., … Paten, B. (2017). Toil enables reproducible, open source, big biomedical data analyses. Nature Biotechnology, 35(4), 314–316. http://doi.org/10.1038/nbt.3772
+
 .. _website: http://toil.ucsc-cgl.org/
 .. _GridEngine: http://gridscheduler.sourceforge.net/
 .. _Parasol: http://genecats.soe.ucsc.edu/eng/parasol.html


### PR DESCRIPTION
This just adds an explicit reference to the toil citation to the beginning of the toil docs in addition to the paper link.  Hopefully this induces more people to cite toil:

Vivian, J., Rao, A. A., Nothaft, F. A., Ketchum, C., Armstrong, J., Novak, A., … Paten, B. (2017). Toil enables reproducible, open source, big biomedical data analyses. Nature Biotechnology, 35(4), 314–316. http://doi.org/10.1038/nbt.3772
  