### PR TITLE
Fix race in Mesos batch system (fixes #2027)

### DIFF
--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -190,8 +190,8 @@ class MesosBatchSystem(BatchSystemLocalSupport,
 
         # TODO: round all elements of resources
 
-        self.jobQueues.insertJob(job, jobType)
         self.taskResources[jobID] = job.resources
+        self.jobQueues.insertJob(job, jobType)
         log.debug("... queued")
         return jobID
 


### PR DESCRIPTION
Fixes #2027.

Jobs were submitted to the queue *before* their taskResources were
filled in. If the leader thread gets interrupted just before the
taskResources are filled in, and the Mesos driver thread calls
resourceOffers, the driver will crash and the pipeline will stall.