### PR TITLE
Add [all] extra.

### DIFF
--- a/docs/gettingStarted/install.rst
+++ b/docs/gettingStarted/install.rst
@@ -67,11 +67,17 @@ install any necessary headers and libraries (`python-dev`_, `libffi-dev`_). Then
 
     $ pip install toil[aws,mesos,azure,google,encryption,cwl]
 
+or::
+
+    $ pip install toil[all]
+
 Here's what each extra provides:
 
 +----------------+------------------------------------------------------------+
 | Extra          | Description                                                |
 +================+============================================================+
+| ``all``        | Installs all extras.                                       |
++----------------+------------------------------------------------------------+
 | ``aws``        | Provides support for managing a cluster on Amazon Web      |
 |                | Service (`AWS`_) using Toil's built in :ref:`clusterRef`.  |
 |                | Clusters can scale up and down automatically.              |

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@
 
 from setuptools import find_packages, setup
 
-botoRequirement = 'boto==2.38.0'
 
 
 def runSetup():
@@ -22,6 +21,19 @@ def runSetup():
     Calls setup(). This function exists so the setup() invocation preceded more internal
     functionality. The `version` module is imported dynamically by importVersion() below.
     """
+    boto = 'boto==2.38.0'
+    boto3 = 'boto3==1.4.7'
+    futures = 'futures==3.0.5'
+    pycrypto = 'pycrypto==2.6.1'
+    psutil = 'psutil==3.0.1'
+    azure = 'azure==2.0.0'
+    azureCosmosdbTable = 'azure-cosmosdb-table==0.37.1'
+    pynacl = 'pynacl==1.1.2'
+    gcs_oauth2_boto_plugin = 'gcs_oauth2_boto_plugin==1.14'
+    cwltool = 'cwltool==1.0.20180108222053'
+    schemaSalad = 'schema-salad >= 2.6, < 3'
+    galaxyLib = 'galaxy-lib==17.9.3'
+    cwltest = 'cwltest>=1.0.20170214185319'
     setup(
         name='toil',
         version=version.distVersion,
@@ -40,25 +52,40 @@ def runSetup():
             'docker==2.5.1'],
         extras_require={
             'mesos': [
-                'psutil==3.0.1'],
+                psutil],
             'aws': [
-                botoRequirement,
-                'boto3==1.4.7',
-                'futures==3.0.5',
-                'pycrypto==2.6.1'],
+                boto,
+                boto3,
+                futures,
+                pycrypto],
             'azure': [
-                'azure==2.0.0',
-                'azure-cosmosdb-table==0.37.1'],
+                azure,
+                azureCosmosdbTable],
             'encryption': [
-                'pynacl==1.1.2'],
+                pynacl],
             'google': [
-                'gcs_oauth2_boto_plugin==1.14',
-                botoRequirement],
+                gcs_oauth2_boto_plugin,
+                boto],
             'cwl': [
-                'cwltool==1.0.20180108222053',
-                'schema-salad >= 2.6, < 3',
-                'galaxy-lib==17.9.3',
-                'cwltest>=1.0.20170214185319']},
+                cwltool,
+                schemaSalad,
+                galaxyLib,
+                cwltest],
+            'all': [
+                psutil,
+                boto,
+                boto3,
+                futures,
+                pycrypto,
+                azure,
+                azureCosmosdbTable,
+                pynacl,
+                gcs_oauth2_boto_plugin,
+                boto,
+                cwltool,
+                schemaSalad,
+                galaxyLib,
+                cwltest]},
         package_dir={'': 'src'},
         packages=find_packages(where='src',
                                # Note that we intentionally include the top-level `test` package for

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,27 @@ def runSetup():
     schemaSalad = 'schema-salad >= 2.6, < 3'
     galaxyLib = 'galaxy-lib==17.9.3'
     cwltest = 'cwltest>=1.0.20170214185319'
+
+    mesos_reqs = [
+                  psutil]
+    aws_reqs = [
+                  boto,
+                  boto3,
+                  futures,
+                  pycrypto]
+    azure_reqs = [
+                  azure,
+                  azureCosmosdbTable]
+    encryption_reqs = [
+                  pynacl]
+    google_reqs = [
+                  gcs_oauth2_boto_plugin,
+                  boto]
+    cwl_reqs = [
+                  cwltool,
+                  schemaSalad,
+                  galaxyLib,
+                  cwltest]
     setup(
         name='toil',
         version=version.distVersion,
@@ -51,41 +72,18 @@ def runSetup():
             'requests==2.18.4',
             'docker==2.5.1'],
         extras_require={
-            'mesos': [
-                psutil],
-            'aws': [
-                boto,
-                boto3,
-                futures,
-                pycrypto],
-            'azure': [
-                azure,
-                azureCosmosdbTable],
-            'encryption': [
-                pynacl],
-            'google': [
-                gcs_oauth2_boto_plugin,
-                boto],
-            'cwl': [
-                cwltool,
-                schemaSalad,
-                galaxyLib,
-                cwltest],
-            'all': [
-                psutil,
-                boto,
-                boto3,
-                futures,
-                pycrypto,
-                azure,
-                azureCosmosdbTable,
-                pynacl,
-                gcs_oauth2_boto_plugin,
-                boto,
-                cwltool,
-                schemaSalad,
-                galaxyLib,
-                cwltest]},
+            'mesos': mesos_reqs,
+            'aws': aws_reqs,
+            'azure': azure_reqs,
+            'encryption': encryption_reqs,
+            'google': google_reqs,
+            'cwl': cwl_reqs,
+            'all': mesos_reqs +
+                   aws_reqs +
+                   azure_reqs +
+                   encryption_reqs +
+                   google_reqs +
+                   cwl_reqs},
         package_dir={'': 'src'},
         packages=find_packages(where='src',
                                # Note that we intentionally include the top-level `test` package for


### PR DESCRIPTION
Allows toil to be built from source using just: `make develop extras=[all]` so that I don't have to copy-paste all of the time when building from source.  Also relocates a global variable.