### PR TITLE
Changed getDirSizeRecursively to use du.

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1257,26 +1257,29 @@ def cacheDirName(workflowID):
 
 def getDirSizeRecursively(dirPath):
     """
-    This method will return the cumulative filesize in bytes of all of the files
-    in the directory and its subdirectories using 'du'.
+    This method will return the cumulative number of bytes occupied by the files 
+    on disk in the directory and its subdirectories.
 
-    This method will return a 'subprocess.CalledProcessError' if it is unable to
-    access a folder or file because of permissions.  Therefore this method should
-    only be called on the jobStore, and will alert the user if some portion is
-    inaccessible.  Everything in the jobStore should have appropriate permissions
-    as there is no way to read the filesize without permissions.
-
-    du is often faster than using os.lstat(), sometimes significantly so.
-
-    The call: 'du -s /some/path' should give the number of 512-byte blocks
-    allocated with the environment variable: BLOCKSIZE='512' set, and we
-    multiply this by 512 to return the filesize in bytes.
+    This method will raise a 'subprocess.CalledProcessError' if it is unable to
+    access a folder or file because of insufficient permissions.  Therefore this 
+    method should only be called on the jobStore, and will alert the user if some 
+    portion is inaccessible.  Everything in the jobStore should have appropriate 
+    permissions as there is no way to read the filesize without permissions.
+    
+    The environment variable 'BLOCKSIZE'='512' is set instead of the much cleaner
+    --block-size=1 because Apple can't handle it.
 
     :param str dirPath: A valid path to a directory or file.
-    :return: Size, in bytes, of dirPath, and recursively everything within it.
+    :return: Total size, in bytes, of the file or directory at dirPath.
     """
+    
+    # du is often faster than using os.lstat(), sometimes significantly so.
+    
+    # The call: 'du -s /some/path' should give the number of 512-byte blocks
+    # allocated with the environment variable: BLOCKSIZE='512' set, and we
+    # multiply this by 512 to return the filesize in bytes.
     return int(subprocess.check_output(['du', '-s', dirPath],
-               env=dict(os.environ, BLOCKSIZE='512')).split()[0].decode('utf-8')) * 512
+               env=dict(os.environ, BLOCKSIZE='512')).split()[0].decode('ascii')) * 512
 
 
 def getFileSystemSize(dirPath):

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1257,33 +1257,26 @@ def cacheDirName(workflowID):
 
 def getDirSizeRecursively(dirPath):
     """
-    This method will walk through a directory and return the cumulative filesize in bytes of all
-    the files in the directory and its subdirectories.
+    This method will return the cumulative filesize in bytes of all of the files
+    in the directory and its subdirectories using 'du'.
 
-    :param dirPath: Path to a directory.
-    :return: cumulative size in bytes of all files in the directory.
-    :rtype: int
+    This method will return a 'subprocess.CalledProcessError' if it is unable to
+    access a folder or file because of permissions.  Therefore this method should
+    only be called on the jobStore, and will alert the user if some portion is
+    inaccessible.  Everything in the jobStore should have appropriate permissions
+    as there is no way to read the filesize without permissions.
+
+    du is often faster than using os.lstat(), sometimes significantly so.
+
+    The call: 'du -s /some/path' should give the number of 512-byte blocks
+    allocated with the environment variable: BLOCKSIZE='512' set, and we
+    multiply this by 512 to return the filesize in bytes.
+
+    :param str dirPath: A valid path to a directory or file.
+    :return: Size, in bytes, of dirPath, and recursively everything within it.
     """
-    totalSize = 0
-    # The value from running stat on each linked file is equal. To prevent the same file
-    # from being counted multiple times, we save the inodes of files that have more than one
-    # nlink associated with them.
-    seenInodes = set()
-    for dirPath, dirNames, fileNames in os.walk(dirPath):
-        folderSize = 0
-        for f in fileNames:
-            fp = os.path.join(dirPath, f)
-            fileStats = os.stat(fp)
-            if fileStats.st_nlink > 1:
-                if fileStats.st_ino not in seenInodes:
-                    folderSize += fileStats.st_blocks * unixBlockSize
-                    seenInodes.add(fileStats.st_ino)
-                else:
-                    continue
-            else:
-                folderSize += fileStats.st_blocks * unixBlockSize
-        totalSize += folderSize
-    return totalSize
+    return int(subprocess.check_output(['du', '-s', dirPath],
+               env=dict(os.environ, BLOCKSIZE='512')).split()[0].decode('utf-8')) * 512
 
 
 def getFileSystemSize(dirPath):

--- a/src/toil/test/src/miscTests.py
+++ b/src/toil/test/src/miscTests.py
@@ -42,7 +42,7 @@ class MiscTests(ToilTest):
         Disk space allocation varies from system to system.  The computed value
         should always be equal to or slightly greater than the creation value.
         This test generates a number of random directories and randomly sized
-        files to test this using getDirSizeRecursively, which calls 'du'.
+        files to test this using getDirSizeRecursively.
         '''
         from toil.common import getDirSizeRecursively
         # a list of the directories used in the test

--- a/src/toil/test/src/miscTests.py
+++ b/src/toil/test/src/miscTests.py
@@ -36,25 +36,15 @@ class MiscTests(ToilTest):
 
     @slow
     def testGetSizeOfDirectoryWorks(self):
+        '''A test to make sure toil.common.getDirSizeRecursively does not
+        underestimate the amount of disk space needed.
+
+        Disk space allocation varies from system to system.  The computed value
+        should always be equal to or slightly greater than the creation value.
+        This test generates a number of random directories and randomly sized
+        files to test this using getDirSizeRecursively, which calls 'du'.
+        '''
         from toil.common import getDirSizeRecursively
-        # os.stat lists the number of 512-byte blocks used, but really, the file system is using
-        # a blocksize specific to itself.  For instance, my machine uses 4096-byte blocks.
-        #
-        #  >>> with open('/tmp/temp', 'w') as fileHandle:
-        #  ...     fileHandle.write(os.urandom(512*3))
-        #  ...
-        #  >>> os.stat('/tmp/temp').st_blksize
-        #  4096
-        #  >>> os.stat('/tmp/temp')
-        #  posix.stat_result(st_mode=33188, st_ino=2630547, st_dev=16777220, st_nlink=1, st_uid=501,
-        #                    st_gid=0, st_size=1536, st_atime=1475620048, st_mtime=1475628030,
-        #                    st_ctime=1475628030)
-        #  >>> os.stat('/tmp/temp').st_blocks
-        #  8
-        #
-        # Even though the file is just 3 * 512 bytes, the file system uses one 4096-byte block and
-        # os.stat says it is using eight 512-byte blocks.
-        systemBlockSize = os.stat('.').st_blksize
         # a list of the directories used in the test
         directories = [self.testDir]
         # A dict of {FILENAME: FILESIZE} for all files used in the test
@@ -72,7 +62,7 @@ class MiscTests(ToilTest):
                 fileSize = int(round(random.random(), 2) * 10 * 1024 * 1024)
                 with open(fileName, 'w') as fileHandle:
                     fileHandle.write(os.urandom(fileSize))
-                files[fileName] = int(math.ceil(fileSize * 1.0 / systemBlockSize) * systemBlockSize)
+                files[fileName] = fileSize
             else:
                 # Link to one of the previous files
                 if len(files) == 0:
@@ -83,9 +73,8 @@ class MiscTests(ToilTest):
 
         computedDirectorySize = getDirSizeRecursively(self.testDir)
         totalExpectedSize = sum([x for x in list(files.values()) if isinstance(x, int)])
-        self.assertEqual(computedDirectorySize, totalExpectedSize)
+        self.assertGreaterEqual(computedDirectorySize, totalExpectedSize)
 
     @staticmethod
     def _getRandomName():
         return uuid4().hex
-


### PR DESCRIPTION
Addresses #2017.

Should be faster (sometimes much faster) and won't skip 'root' protected directories, erroneously telling you it's 0 size.  Also, doesn't break on broken symlinks.  Should work on Apple things too.