### PR TITLE
Fix GridEngine/Torque race(s)

### DIFF
--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -77,7 +77,7 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
             :param: string jobID: toil job ID
             """
             if jobID not in self.batchJobIDs:
-                RuntimeError("Unknown jobID, could not be converted")
+                raise RuntimeError("Unknown jobID, could not be converted")
 
             (job, task) = self.batchJobIDs[jobID]
             if task is None:

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -43,7 +43,8 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
         """
         def getRunningJobIDs(self):
             times = {}
-            currentjobs = dict((str(self.batchJobIDs[x][0]), x) for x in self.runningJobs)
+            with self.runningJobsLock:
+                currentjobs = dict((str(self.batchJobIDs[x][0]), x) for x in self.runningJobs)
             process = subprocess.Popen(["qstat"], stdout=subprocess.PIPE)
             stdout, stderr = process.communicate()
 

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -39,7 +39,8 @@ class SlurmBatchSystem(AbstractGridEngineBatchSystem):
         def getRunningJobIDs(self):
             # Should return a dictionary of Job IDs and number of seconds
             times = {}
-            currentjobs = dict((str(self.batchJobIDs[x][0]), x) for x in self.runningJobs)
+            with self.runningJobsLock:
+                currentjobs = dict((str(self.batchJobIDs[x][0]), x) for x in self.runningJobs)
             # currentjobs is a dictionary that maps a slurm job id (string) to our own internal job id
             # squeue arguments:
             # -h for no header

--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -67,7 +67,8 @@ class TorqueBatchSystem(AbstractGridEngineBatchSystem):
         """
         def getRunningJobIDs(self):
             times = {}
-            currentjobs = dict((str(self.batchJobIDs[x][0].strip()), x) for x in self.runningJobs)
+            with self.runningJobsLock:
+                currentjobs = dict((str(self.batchJobIDs[x][0].strip()), x) for x in self.runningJobs)
             logger.debug("getRunningJobIDs current jobs are: " + str(currentjobs))
             # Skip running qstat if we don't have any current jobs
             if not currentjobs:


### PR DESCRIPTION
NB: I haven't actually tested this yet, this is just from going through visually so I may have added stupid syntax errors. I should have some time to test this tomorrow.

This fixes #2030 as well as a related race in Torque, and a similar race when jobs are killed (which pretty much never happens, so is less serious).

NB: I only looked at data that could simultaneously be written to and read from the leader and batch system worker thread as written (simultaneous read/read should be fine, e.g. https://github.com/BD2KGenomics/toil/blob/b9b6ca1c519dfc18e355cae2a4eea9753480745a/src/toil/batchSystems/abstractGridEngineBatchSystem.py#L190 which could be read in the worker while the leader also reads). So if later modifications to the leader or worker (or others) start calling new methods, they could easily trigger more problems. Also NB that I assumed the dict operations that are (supposedly) atomic in CPython are atomic in whatever version of Python is used. Probably a safe assumption.