### PR TITLE
Amend subprocess imports.  (#2039)

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -2,8 +2,14 @@ import glob
 import itertools
 import logging
 import os
-import subprocess
 import sys
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 log = logging.getLogger(__name__)
 

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -21,9 +21,16 @@ from past.utils import old_div
 import logging
 import os
 from pipes import quote
-import subprocess
 import time
 import math
+import sys
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 # Python 3 compatibility imports
 from six.moves.queue import Empty, Queue

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -23,11 +23,18 @@ from builtins import str
 from builtins import range
 from past.utils import old_div
 import logging
-import subprocess
 import time
 from threading import Thread
 from datetime import date
 import os
+import sys
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 # Python 3 compatibility imports
 from six.moves.queue import Empty, Queue

--- a/src/toil/batchSystems/lsfHelper.py
+++ b/src/toil/batchSystems/lsfHelper.py
@@ -27,8 +27,15 @@ from __future__ import division
 from past.utils import old_div
 import math
 import os
-import subprocess
 import fnmatch
+import sys
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 LSB_PARAMS_FILENAME = "lsb.params"
 LSF_CONF_FILENAME = "lsf.conf"

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -23,7 +23,6 @@ import signal
 import sys
 import threading
 import logging
-import subprocess
 import traceback
 from time import sleep, time
 
@@ -40,6 +39,13 @@ import mesos.native
 from struct import pack
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
 from toil.resource import Resource
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 log = logging.getLogger(__name__)
 

--- a/src/toil/batchSystems/mesos/test/__init__.py
+++ b/src/toil/batchSystems/mesos/test/__init__.py
@@ -5,8 +5,16 @@ from abc import ABCMeta, abstractmethod
 import logging
 import shutil
 import threading
-import subprocess
+import os
+import sys
 import multiprocessing
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 from bd2k.util.processes import which
 from bd2k.util.threading import ExceptionalThread

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -22,10 +22,16 @@ import logging
 import os
 import re
 import sys
-import subprocess
 import tempfile
 import time
 from threading import Thread
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 # Python 3 compatibility imports
 from six.moves.queue import Empty, Queue

--- a/src/toil/batchSystems/parasolTestSupport.py
+++ b/src/toil/batchSystems/parasolTestSupport.py
@@ -4,10 +4,18 @@ import logging
 import tempfile
 import threading
 import time
-import subprocess
+import sys
 import multiprocessing
 import signal
 import os
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
+
 from bd2k.util.files import rm_f
 from bd2k.util.objects import InnerClass
 

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -24,11 +24,18 @@ from contextlib import contextmanager
 import logging
 import multiprocessing
 import os
-import subprocess
+import sys
 import time
 import math
 from threading import Thread
 from threading import Lock, Condition
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 # Python 3 compatibility imports
 from six.moves.queue import Empty, Queue

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -19,9 +19,15 @@ from past.utils import old_div
 import logging
 import os
 from pipes import quote
-import subprocess
-import time
+import sys
 import math
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 # Python 3 compatibility imports
 from six.moves.queue import Empty, Queue

--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -19,13 +19,19 @@ from past.utils import old_div
 import logging
 import os
 from pipes import quote
-import subprocess
 import time
 import math
 import sys
 import shlex
 import xml.etree.ElementTree as ET
 import tempfile
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 from toil.batchSystems import MemoryString
 from toil.batchSystems.abstractGridEngineBatchSystem import AbstractGridEngineBatchSystem

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -26,16 +26,21 @@ import sys
 import tempfile
 import time
 import uuid
-import subprocess
 import requests
 from argparse import ArgumentParser
 
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
+
+# Python 3 compatibility imports
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
-
-# Python 3 compatibility imports
 from six import iteritems
 
 from bd2k.util.exceptions import require

--- a/src/toil/lib/__init__.py
+++ b/src/toil/lib/__init__.py
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import
-
-import subprocess
+import os
+import sys
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 FORGO = 0
 STOP = 1

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -28,7 +28,13 @@ import math
 import shutil
 from argparse import ArgumentParser
 from optparse import OptionContainer, OptionGroup
-import subprocess
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 # Python 3 compatibility imports
 from six.moves import xrange

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -2,11 +2,18 @@ from __future__ import absolute_import
 import logging
 import os
 import pipes
-import subprocess
+import sys
 import docker
 import base64
 import time
 import requests
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 from docker.errors import create_api_error_from_http_exception
 from docker.errors import ContainerError

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -18,7 +18,15 @@ from itertools import count
 import logging
 import pipes
 import socket
-import subprocess
+import os
+import sys
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 from future.utils import with_metaclass
 

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -15,9 +15,16 @@ from builtins import str
 from builtins import range
 import logging
 import time
-import subprocess
+import os
 import sys
 import string
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 # Python 3 compatibility imports
 from _ssl import SSLError

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -22,7 +22,7 @@ import os
 import re
 import shutil
 import signal
-import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -34,6 +34,13 @@ from inspect import getsource
 from subprocess import PIPE, Popen, CalledProcessError, check_output
 from textwrap import dedent
 from unittest.util import strclass
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 # Python 3 compatibility imports
 from six import iteritems, itervalues

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -31,8 +31,14 @@ from textwrap import dedent
 import time
 import multiprocessing
 import sys
-import subprocess
 from unittest import skipIf
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 from toil.common import Config
 from toil.batchSystems.mesos.test import MesosTestSupport

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -15,12 +15,19 @@ from __future__ import absolute_import
 from __future__ import print_function
 import json
 import os
-import subprocess
+import sys
 import re
 import shutil
 import pytest
 from future.moves.urllib.request import urlretrieve
 import zipfile
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 # Python 3 compatibility imports
 from six.moves import StringIO

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -5,9 +5,16 @@ import time
 import os
 import uuid
 import docker
-import subprocess
+import sys
 from threading import Thread
 from docker.errors import ContainerError
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 from bd2k.util.files import mkdir_p
 from toil.job import Job

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -16,10 +16,17 @@ from builtins import str
 from builtins import range
 import logging
 import os
-import subprocess
+import sys
 from abc import abstractmethod
 from inspect import getsource
 from textwrap import dedent
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 import time
 

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -21,7 +21,14 @@ import random
 from contextlib import contextmanager
 from uuid import uuid4
 import logging
-import subprocess
+import sys
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 # Python 3 compatibility imports
 import errno

--- a/src/toil/test/src/regularLogTest.py
+++ b/src/toil/test/src/regularLogTest.py
@@ -13,9 +13,15 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import mimetypes
-import subprocess
 import sys
 import os
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 from toil.test import ToilTest, slow
 from toil.test.mesos import helloWorld

--- a/src/toil/test/utils/ABCWorkflowDebug/debugWorkflow.py
+++ b/src/toil/test/utils/ABCWorkflowDebug/debugWorkflow.py
@@ -1,8 +1,15 @@
 from toil.job import Job
 from toil.common import Toil
-import subprocess
+import sys
 import os
 import logging
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 logger = logging.getLogger(__name__)
 

--- a/src/toil/test/utils/toilDebugTest.py
+++ b/src/toil/test/utils/toilDebugTest.py
@@ -17,10 +17,18 @@ from __future__ import absolute_import
 # from builtins import str
 
 import unittest
-import subprocess
+import sys
 import os
 import shutil
 import logging
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
+
 from toil.test import ToilTest, needs_aws, needs_rsync3, integrative, slow
 from toil.utils.toilDebugFile import recursiveGlob
 

--- a/src/toil/test/wdl/toilwdlTest.py
+++ b/src/toil/test/wdl/toilwdlTest.py
@@ -1,11 +1,18 @@
 from __future__ import absolute_import
 import unittest
 import os
-import subprocess
+import sys
 from toil.wdl.toilwdl import ToilWDL
 from toil.test import ToilTest, slow
 import zipfile
 import shutil
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 class ToilWdlIntegrationTest(ToilTest):
     """A set of test cases for toilwdl.py"""

--- a/src/toil/wdl/toilwdl.py
+++ b/src/toil/wdl/toilwdl.py
@@ -23,9 +23,16 @@ import json
 import csv
 import os
 import collections
-import subprocess
+import sys
 import logging
 import textwrap
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 import toil.wdl.wdl_parser as wdl_parser
 


### PR DESCRIPTION
Switch from subprocess to subprocess32 as per Joel's suggestion and partially addressing #2039.

From their site ( https://github.com/google/python-subprocess32 ):

"This is a backport of the Python 3 subprocess module for use on Python 2. This code has not been tested on Windows or other non-POSIX platforms.

subprocess32 includes many important reliability bug fixes relevant on POSIX platforms. The most important of which is a C extension module used internally to handle the code path between fork() and exec(). This module is reliable when an application is using threads."