### PR TITLE
Add buffering for large files in fileJobStore.  Addresses #1983.

### DIFF
--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -241,7 +241,7 @@ class FileJobStore(AbstractJobStore):
         """
         file_path = cls._extractPathFromUrl(url)
         with open(file_path, 'w') as f:
-            if os.path.getsize(file_path) > 1073741824:
+            if os.fstat(readable.fileno()).st_size > 1073741824:
                 while True:
                     buffer_size = 1073741824 # 1Gb RAM buffer
                     data = readable.read(buffer_size)

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -221,7 +221,12 @@ class FileJobStore(AbstractJobStore):
     @classmethod
     def _writeToUrl(cls, readable, url):
         with open(cls._extractPathFromUrl(url), 'w') as f:
-            f.write(readable.read())
+            while True:
+                buffer_size = 1073741824 # 1Gb RAM buffer
+                data = readable.read(buffer_size)
+                if not data:
+                    break
+                f.write(data)
 
     @staticmethod
     def _extractPathFromUrl(url):

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -215,18 +215,41 @@ class FileJobStore(AbstractJobStore):
 
     @classmethod
     def _readFromUrl(cls, url, writable):
-        with open(cls._extractPathFromUrl(url), 'r') as f:
-            writable.write(f.read())
+        """Writes the contents of a file to a source (writes url to writable).
+
+        Uses a buffer of 1Gb if file is larger than 1Gb, else
+        read the entire file into memory for writing.
+        """
+        file_path = cls._extractPathFromUrl(url)
+        with open(file_path, 'r') as f:
+            if os.path.getsize(file_path) > 1073741824:
+                while True:
+                    buffer_size = 1073741824 # 1Gb RAM buffer
+                    data = f.read(buffer_size)
+                    if not data:
+                        break
+                    writable.write(data)
+            else:
+                writable.write(f.read())
 
     @classmethod
     def _writeToUrl(cls, readable, url):
-        with open(cls._extractPathFromUrl(url), 'w') as f:
-            while True:
-                buffer_size = 1073741824 # 1Gb RAM buffer
-                data = readable.read(buffer_size)
-                if not data:
-                    break
-                f.write(data)
+        """Writes the contents of a file to a source (writes readable to url).
+
+        Uses a buffer of 1Gb if file is larger than 1Gb, else
+        read the entire file into memory for writing.
+        """
+        file_path = cls._extractPathFromUrl(url)
+        with open(file_path, 'w') as f:
+            if os.path.getsize(file_path) > 1073741824:
+                while True:
+                    buffer_size = 1073741824 # 1Gb RAM buffer
+                    data = readable.read(buffer_size)
+                    if not data:
+                        break
+                    f.write(data)
+            else:
+                f.write(readable.read())
 
     @staticmethod
     def _extractPathFromUrl(url):

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -232,17 +232,17 @@ class FileJobStore(AbstractJobStore):
         """
         file_path = cls._extractPathFromUrl(url)
         with open(file_path, 'rb') as f:
-            # We use a buffer here because otherwise the system attempts to read the
-            # entire file into RAM, and if the file is larger than the available RAM,
-            # it causes a MemoryError.
             if os.path.getsize(file_path) > cls.SMALL_FILE_SIZE_THRESHOLD:
+                # We use a buffer here because otherwise the system attempts to read the
+                # entire file into RAM, and if the file is larger than the available RAM,
+                # it causes a MemoryError.
                 while True:
                     data = f.read(cls.BUFFER_SIZE)
                     if not data:
                         break
                     writable.write(data)
-            # Using a buffer is slower (tested), so we only want to use it on large files
             else:
+                # Using a buffer is slower (tested), so we only want to use it on large files
                 writable.write(f.read())
 
     @classmethod
@@ -258,17 +258,17 @@ class FileJobStore(AbstractJobStore):
         """
         file_path = cls._extractPathFromUrl(url)
         with open(file_path, 'wb') as f:
-            # We use a buffer here because otherwise the system attempts to read the
-            # entire file into RAM, and if the file is larger than the available RAM,
-            # it causes a MemoryError.
             if os.fstat(readable.fileno()).st_size > cls.SMALL_FILE_SIZE_THRESHOLD:
+                # We use a buffer here because otherwise the system attempts to read the
+                # entire file into RAM, and if the file is larger than the available RAM,
+                # it causes a MemoryError.
                 while True:
                     data = readable.read(cls.BUFFER_SIZE)
                     if not data:
                         break
                     f.write(data)
-            # Using a buffer is slower (tested), so we only want to use it on large files
             else:
+                # Using a buffer is slower (tested), so we only want to use it on large files
                 f.write(readable.read())
 
     @staticmethod


### PR DESCRIPTION
I set a rather large buffer size (1Gb) after doing some speed tests.  I also made it so that it uses the original method (loads the entire file into memory) if the file is smaller than 1Gb.