### PR TITLE
make CWL specific options

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -137,6 +137,9 @@ class Config(object):
         self.badWorker = 0.0
         self.badWorkerFailInterval = 0.01
 
+        # CWL
+        self.cwl = False
+
     def setOptions(self, options):
         """
         Creates a config object from the options object.

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -348,7 +348,7 @@ def _addOptions(addGroupFn, config):
     addOptionFn = addGroupFn("toil options for specifying the batch system",
                              "Allows the specification of the batch system, and arguments to the "
                              "batch system/big batch system (see below).")
-    addBatchOptions(addOptionFn)
+    addBatchOptions(addOptionFn, config)
 
     #
     #Auto scaling options
@@ -422,23 +422,24 @@ def _addOptions(addGroupFn, config):
                 default=False, action="store_true",
                 help=("Enable the prometheus/grafana dashboard for monitoring CPU/RAM usage, queue size, "
                       "and issued jobs."))
-    
+
     #        
     # Parameters to limit service jobs / detect service deadlocks
     #
-    addOptionFn = addGroupFn("toil options for limiting the number of service jobs and detecting service deadlocks",
-                             "Allows the specification of the maximum number of service jobs "
-                             "in a cluster. By keeping this limited "
-                             " we can avoid all the nodes being occupied with services, so causing a deadlock")
-    addOptionFn("--maxServiceJobs", dest="maxServiceJobs", default=None,
-                help=("The maximum number of service jobs that can be run concurrently, excluding service jobs running on preemptable nodes. default=%s" % config.maxServiceJobs))
-    addOptionFn("--maxPreemptableServiceJobs", dest="maxPreemptableServiceJobs", default=None,
-                help=("The maximum number of service jobs that can run concurrently on preemptable nodes. default=%s" % config.maxPreemptableServiceJobs))
-    addOptionFn("--deadlockWait", dest="deadlockWait", default=None,
-                help=("The minimum number of seconds to observe the cluster stuck running only the same service jobs before throwing a deadlock exception. default=%s" % config.deadlockWait))
-    addOptionFn("--statePollingWait", dest="statePollingWait", default=1,
-                help=("Time, in seconds, to wait before doing a scheduler query for job state. "
-                      "Return cached results if within the waiting period."))
+    if not config.cwl:
+        addOptionFn = addGroupFn("toil options for limiting the number of service jobs and detecting service deadlocks",
+                                 "Allows the specification of the maximum number of service jobs "
+                                 "in a cluster. By keeping this limited "
+                                 " we can avoid all the nodes being occupied with services, so causing a deadlock")
+        addOptionFn("--maxServiceJobs", dest="maxServiceJobs", default=None,
+                    help=("The maximum number of service jobs that can be run concurrently, excluding service jobs running on preemptable nodes. default=%s" % config.maxServiceJobs))
+        addOptionFn("--maxPreemptableServiceJobs", dest="maxPreemptableServiceJobs", default=None,
+                    help=("The maximum number of service jobs that can run concurrently on preemptable nodes. default=%s" % config.maxPreemptableServiceJobs))
+        addOptionFn("--deadlockWait", dest="deadlockWait", default=None,
+                    help=("The minimum number of seconds to observe the cluster stuck running only the same service jobs before throwing a deadlock exception. default=%s" % config.deadlockWait))
+        addOptionFn("--statePollingWait", dest="statePollingWait", default=1,
+                    help=("Time, in seconds, to wait before doing a scheduler query for job state. "
+                          "Return cached results if within the waiting period."))
 
     #
     #Resource requirements

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -18,15 +18,12 @@
 # For an overview of how this all works, see discussion in
 # docs/architecture.rst
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import object
 from toil.job import Job
-from toil.common import Toil
+from toil.common import Config, Toil, addOptions
 from toil.version import baseVersion
-from toil.lib.bioio import setLoggingFromOptions
 
 import argparse
 import cwltool.errors
@@ -833,8 +830,10 @@ def visitSteps(t, op):
 
 
 def main(args=None, stdout=sys.stdout):
+    config = Config()
+    config.cwl = True
     parser = argparse.ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    addOptions(parser, config)
     parser.add_argument("cwltool", type=str)
     parser.add_argument("cwljob", nargs=argparse.REMAINDER)
 
@@ -885,7 +884,6 @@ def main(args=None, stdout=sys.stdout):
 
     use_container = not options.no_container
 
-    setLoggingFromOptions(options)
     if options.logLevel:
         cwllogger.setLevel(options.logLevel)
 
@@ -907,7 +905,6 @@ def main(args=None, stdout=sys.stdout):
         if options.restart:
             outobj = toil.restart()
         else:
-            toil.config.linkImports = False
             useStrict = not options.not_strict
             make_tool_kwargs["hints"] = [{
                 "class": "ResourceRequirement",


### PR DESCRIPTION
https://github.com/BD2KGenomics/toil/pull/2050 was wrong, so here's a better PR

It adds the ability to have `toil-cwl-runner` specific help text and options. Here I've skipped the service workers related options and added a `--noLinkImports`; both only for `toil-cwl-runner`