### PR TITLE
Doc changes.

### DIFF
--- a/docs/gettingStarted/install.rst
+++ b/docs/gettingStarted/install.rst
@@ -25,6 +25,7 @@ And create a virtual environment called ``venv`` in your home directory.
 ::
 
     $ virtualenv ~/venv
+
 .. _pip: https://pip.readthedocs.io/en/latest/installing/
 
 If the user does not have root privileges, there are a few more steps, but one can download a specific virtualenv package directly, untar the file, create, and source the virtualenv (version 15.1.0 as an example) using::
@@ -119,11 +120,16 @@ Here's what each extra provides:
 |                | `Common Workflow Language`_. This extra has no native      |
 |                | dependencies.                                              |
 +----------------+------------------------------------------------------------+
+| ``wdl``        | Provides support for running workflows written using the   |
+|                | `Workflow Description Language`_. This extra has no native |
+|                | dependencies.                                              |
++----------------+------------------------------------------------------------+
 
 .. _AWS: https://aws.amazon.com/
 .. _Apache Mesos: https://mesos.apache.org/gettingstarted/
 .. _Google Cloud Storage: https://cloud.google.com/storage/
 .. _Microsoft Azure: https://azure.microsoft.com/
+.. _Workflow Description Language: https://software.broadinstitute.org/wdl/
 
 .. _python-dev:
 .. topic:: Python headers and static libraries
@@ -168,11 +174,7 @@ during the computation of a workflow, first set up and configure an account with
 
 #. If necessary, create and activate an `AWS account`_
 
-#. Create a `key pair`_ in the availability zone of your choice (our examples use ``us-west-2a``).
-
-#. Follow `Amazon's instructions`_ to create an SSH key and import it into EC2.
-
-#. Finally, you will need to `install`_ and `configure`_ the AWS Command Line Interface (CLI).
+#. Create a key pair, install boto, install awscli, and configure your credentials using our `blog instructions`_ .
 
 
 .. _AWS account: https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/
@@ -180,6 +182,7 @@ during the computation of a workflow, first set up and configure an account with
 .. _Amazon's instructions : http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws
 .. _install: http://docs.aws.amazon.com/cli/latest/userguide/installing.html
 .. _configure: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
+.. _blog instructions: https://toilpipelines.wordpress.com/2018/01/18/running-toil-autoscaling-with-aws/
 
 
 .. _prepare_azure-ref:
@@ -190,7 +193,6 @@ Preparing your Azure environment
 Follow the steps below to prepare your Azure environment for running a Toil workflow.
 
 #. Create an `Azure account`_.
-
 
 #. Make sure you have an SSH RSA public key, usually stored in
    ``~/.ssh/id_rsa.pub``. If not, you can use ``ssh-keygen -t rsa`` to create

--- a/docs/gettingStarted/quickStart.rst
+++ b/docs/gettingStarted/quickStart.rst
@@ -30,7 +30,7 @@ A Toil workflow can be run with just three steps:
           print output
 
 
-3. Specify the name of the :ref:`job store <>` and run the workflow::
+3. Specify the name of the job store and run the workflow::
 
        (venv) $ python helloWorld.py file:my-job-store
 
@@ -69,8 +69,7 @@ Running CWL workflows using Toil is easy.
 
        (venv) $ pip install 'toil[cwl]'
 
-   This installs the ``toil-cwl-runner`` and ``cwl-runner`` executables. These are identical -
-   ``cwl-runner`` is the portable name for the default system CWL runner.
+   This installs the ``toil-cwl-runner`` and ``cwltoil`` executables.
 
 #. Copy and paste the following code block into ``example.cwl``:
 
@@ -112,6 +111,52 @@ To run this workflow on an AWS cluster have a look at :ref:`awscwl`.
 For information on using CWL with Toil see the section :ref:`cwl`
 
 .. _CWL User Guide: http://www.commonwl.org/v1.0/UserGuide.html
+
+Running a basic WDL workflow
+----------------------------
+
+The `Workflow Description Language`_ (WDL) is another emerging language for writing workflows that are portable across multiple workflow engines and platforms.
+Running WDL workflows using Toil is still in alpha, and currently experimental.  Toil currently supports basic workflow syntax (see :ref:`wdlSupport` for more details and examples).  Here we go over running a basic WDL helloworld workflow.
+
+#. First ensure that Toil is installed with the
+   ``wdl`` extra (see :ref:`extras`).  ::
+
+        (venv) $ pip install 'toil[wdl]'
+
+   This installs the ``toil-wdl-runner`` executable.
+
+#. Copy and paste the following code block into ``wdl-helloworld.wdl``:
+
+::
+
+        workflow write_simple_file {
+          call write_file
+        }
+        task write_file {
+          String message
+          command { echo ${message} > wdl-helloworld-output.txt }
+          output { File test = "wdl-helloworld-output.txt" }
+        }
+
+   and this code into ``wdl-helloworld.json``::
+
+        {
+          "write_simple_file.write_file.message": "Hello world!"
+        }
+
+#. To run the workflow simply enter ::
+
+        (venv) $ toil-wdl-runner wdl-helloworld.wdl wdl-helloworld.json
+
+   Your output will be in ``wdl-helloworld-output.txt`` ::
+
+        (venv) $ cat output.txt
+        Hello world!
+
+To learn more about WDL, see the main `WDL website`_ .
+
+.. _WDL website: https://software.broadinstitute.org/wdl/
+.. _Workflow Description Language: https://software.broadinstitute.org/wdl/
 
 .. _runningDetail:
 
@@ -341,6 +386,8 @@ Note that when running in AWS, users can either run the workflow on a single ins
 cluster (which is running across multiple containers on multiple AWS instances).  For more information
 on running Toil workflows on a cluster, see :ref:`runningAWS`.
 
+Also!  Remember to use the :ref:`destroyCluster` command when finished to destroy the cluster!  Otherwise things may not be cleaned up properly.
+
 
 #. Launch a cluster in AWS using the :ref:`launchCluster` command. The arguments ``keyPairName``,
    ``leaderNodeType``, and ``zone`` are required to launch a cluster. ::
@@ -381,12 +428,14 @@ on running Toil workflows on a cluster, see :ref:`runningAWS`.
 Running a CWL Workflow on AWS
 -----------------------------
 After having installed the ``aws`` and ``cwl`` extras for Toil during the :ref:`installation-ref` and set up AWS
-(see :ref:`prepare_aws-ref`),
-the user can run a CWL workflow with Toil on AWS.
+(see :ref:`prepare_aws-ref`), the user can run a CWL workflow with Toil on AWS.
+
+Also!  Remember to use the :ref:`destroyCluster` command when finished to destroy the cluster!  Otherwise things may not be cleaned up properly.
+
 
 #. First launch a node in AWS using the :ref:`launchCluster` command. ::
 
-      (venv) $ toil launch-cluster <cluster-name> --keyPairName <AWS-key-pair-name> --leaderNodeType t2.micro --zone us-west-2a
+      (venv) $ toil launch-cluster <cluster-name> --keyPairName <AWS-key-pair-name> --leaderNodeType t2.medium --zone us-west-2a
 
 #. Copy ``example.cwl`` and ``example-job.cwl`` from the :ref:`CWL example <cwlquickstart>` to the node using
    the :ref:`rsyncCluster` command. ::
@@ -415,6 +464,8 @@ Running a Workflow with Autoscaling on AWS - Cactus
 
 `Cactus <https://github.com/ComparativeGenomicsToolkit/cactus>`__ is a reference-free whole-genome multiple alignment
 program.
+
+Also!  Remember to use the :ref:`destroyCluster` command when finished to destroy the cluster!  Otherwise things may not be cleaned up properly.
 
 #. Download :download:`pestis.tar.gz <../../src/toil/test/cactus/pestis.tar.gz>`.
 

--- a/docs/gettingStarted/quickStart.rst
+++ b/docs/gettingStarted/quickStart.rst
@@ -125,9 +125,7 @@ Running WDL workflows using Toil is still in alpha, and currently experimental. 
 
    This installs the ``toil-wdl-runner`` executable.
 
-#. Copy and paste the following code block into ``wdl-helloworld.wdl``:
-
-::
+#. Copy and paste the following code block into ``wdl-helloworld.wdl``::
 
         workflow write_simple_file {
           call write_file
@@ -138,7 +136,7 @@ Running WDL workflows using Toil is still in alpha, and currently experimental. 
           output { File test = "wdl-helloworld-output.txt" }
         }
 
-   and this code into ``wdl-helloworld.json``::
+#. and this code into ``wdl-helloworld.json``::
 
         {
           "write_simple_file.write_file.message": "Hello world!"
@@ -150,7 +148,7 @@ Running WDL workflows using Toil is still in alpha, and currently experimental. 
 
    Your output will be in ``wdl-helloworld-output.txt`` ::
 
-        (venv) $ cat output.txt
+        (venv) $ cat wdl-helloworld-output.txt
         Hello world!
 
 To learn more about WDL, see the main `WDL website`_ .

--- a/docs/running/amazon.rst
+++ b/docs/running/amazon.rst
@@ -147,7 +147,7 @@ Autoscaling is a feature of running Toil in a cloud whereby additional cloud ins
 
         (venv) $ toil launch-cluster <cluster-name> \
         --keyPairName <AWS-key-pair-name> \
-        --leaderNodeType t2.micro \
+        --leaderNodeType t2.medium \
         --zone us-west-2a
 
 #. Copy the `sort.py` script up to the leader node. ::

--- a/docs/running/wdl.rst
+++ b/docs/running/wdl.rst
@@ -1,3 +1,5 @@
+.. _wdlSupport:
+
 WDL Support in Toil
 *******************
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ def runSetup():
                   schemaSalad,
                   galaxyLib,
                   cwltest]
+    wdl_reqs = []
     htcondor_reqs = [
                   htcondor]
     setup(
@@ -82,6 +83,7 @@ def runSetup():
             'encryption': encryption_reqs,
             'google': google_reqs,
             'cwl': cwl_reqs,
+            'wdl': wdl_reqs,
             'htcondor': htcondor_reqs,
             'all': mesos_reqs +
                    aws_reqs +


### PR DESCRIPTION
We sat down with Brian to "kick the tires" on WDL and he had some suggestions for the docs.  This PR addresses some of those issues:

- Add wdl to extras with comments (no dependencies as of now).
- Add a wdl helloworld example to the quickstart.
- Warn the user to use destroy-cluster at the start of the autoscaling scripts in the quickstart rather than relying on them to see it in the final step.
- Change the CWL AWS example to use a t2.medium instead of a t2.micro.
- Change the AWS sort.py example to use a t2.medium instead of a t2.micro.