### PR TITLE
Support NVMe ephemeral drives (e.g. the i3 series) (resolves #2057)

### DIFF
--- a/src/toil/provisioners/aws/__init__.py
+++ b/src/toil/provisioners/aws/__init__.py
@@ -213,7 +213,7 @@ write_files:
         ephemeral_count=0
         drives=""
         directories="toil mesos docker"
-        for drive in /dev/xvd{{b..z}}; do
+        for drive in /dev/xvd{{b..z}} /dev/nvme*n*; do
             echo checking for $drive
             if [ -b $drive ]; then
                 echo found it

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -383,7 +383,7 @@ class AWSProvisioner(AbstractProvisioner):
     @memoize
     def _discoverAMI(cls, ctx):
         def descriptionMatches(ami):
-            return ami.description is not None and 'stable 1235.4.0' in ami.description
+            return ami.description is not None and 'stable 1632.2.1' in ami.description
         coreOSAMI = os.environ.get('TOIL_AWS_AMI')
         if coreOSAMI is not None:
             return coreOSAMI


### PR DESCRIPTION
NB: this requires a Container Linux version upgrade as well. The (very) old version currently used by toil has a kernel that fails to recognize more than one NVMe drive.

I haven't tested this Container Linux version extensively with this version of toil. On my fork (which may use a different docker client version), the stable branch works great, though, so this shouldn't introduce major problems.