### PR TITLE
Fix a few flaky aws tests

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -150,6 +150,9 @@ class AWSProvisioner(AbstractProvisioner):
                                                    num_instances=1))[0]
             leader = instances[0]
 
+        wait_instances_running(ctx.ec2, [leader])
+        self._waitForNode(leader, 'toil_leader')
+
         defaultTags = {'Name': clusterName, 'Owner': keyName}
         defaultTags.update(userTags)
 


### PR DESCRIPTION
This (hopefully) handles the EC2 400 errors on instance creation, and another rare error when creating a leader. Both are related to consistency issues with EC2: the results of instance creation aren't immediately propagated to all the servers that handle our requests.

There are still a few flaky AWS tests remaining, because the t2.small instances used in some of the tests have only a few MB of headroom to be able to run the jobs we issue. We are somehow using nearly a GB (and sometimes more) of RAM as overhead on worker nodes.