### PR TITLE
Set log level to error when jobs fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ def runSetup():
             'six>=1.10.0',
             'future',
             'requests==2.18.4',
-            'docker==2.5.1'],
+            'docker==2.5.1',
+            'python-dateutil'],
         extras_require={
             'mesos': mesos_reqs,
             'aws': aws_reqs,

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -280,16 +280,6 @@ class BatchSystemSupport(AbstractBatchSystem):
                 raise RuntimeError("%s does not exist in current environment", name)
         self.environment[name] = value
 
-    def _getResultsFileName(self, toilPath):
-        """
-        Get a path for the batch systems to store results. GridEngine, slurm,
-        and LSF currently use this and only work if locator is file.
-        """
-        # Use  parser to extract the path and type
-        locator, filePath = Toil.parseLocator(toilPath)
-        assert locator == "file"
-        return os.path.join(filePath, "results.txt")
-
     @staticmethod
     def workerCleanup(info):
         """

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -279,11 +279,6 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         super(AbstractGridEngineBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
 
-        self.resultsFile = self._getResultsFileName(config.jobStore)
-        # Reset the job queue and results (initially, we do this again once we've killed the jobs)
-        self.resultsFileHandle = open(self.resultsFile, 'w')
-        # We lose any previous state in this file, and ensure the files existence
-        self.resultsFileHandle.close()
         self.currentJobs = set()
 
         # NOTE: this may be batch system dependent, maybe move into the worker?
@@ -301,10 +296,6 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
         self.worker.start()
         self._getRunningBatchJobIDsTimestamp = None
         self._getRunningBatchJobIDsCache = {}
-
-    def __des__(self):
-        # Closes the file handle associated with the results file.
-        self.resultsFileHandle.close()
 
     @classmethod
     def supportsWorkerCleanup(cls):

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -106,8 +106,8 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                                  "{}".format(job))
                     return None
                 elif "Exited with exit code" in line:
-                    exit = int(line[line.find("Exited with exit code "):]
-                               .split()[0])
+                    exit = int(line[line.find("Exited with exit code ")+22:]
+                               .split('.')[0])
                     logger.debug("bjobs detected job exit code: "
                                  "{}".format(exit))
                     return exit

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -25,273 +25,158 @@ from past.utils import old_div
 import logging
 import subprocess
 import time
-from threading import Thread
 from datetime import date
 import os
 
-# Python 3 compatibility imports
-from six.moves.queue import Empty, Queue
-
 from toil.batchSystems import MemoryString
-from toil.batchSystems.abstractBatchSystem import BatchSystemLocalSupport
-from toil.batchSystems.lsfHelper import parse_memory_resource, parse_memory_limit, per_core_reservation
+from toil.batchSystems.abstractGridEngineBatchSystem import \
+        AbstractGridEngineBatchSystem
+from toil.batchSystems.lsfHelper import (parse_memory_resource,
+                                         parse_memory_limit,
+                                         per_core_reservation)
 
-logger = logging.getLogger( __name__ )
-
-
-def prepareBsub(cpu, mem):
-    """
-    Make a bsub commandline to execute.
-
-    params:
-      cpu: number of cores needed
-      mem: number of bytes of memory needed
-    """
-    if mem:
-        if per_core_reservation():
-            mem = float(mem)/1024**3/int(cpu)
-            mem_resource = parse_memory_resource(mem)
-            mem_limit = parse_memory_limit(mem)
-        else:
-            mem = old_div(float(mem),1024**3)
-            mem_resource = parse_memory_resource(mem)
-            mem_limit = parse_memory_limit(mem)
-        bsubMem = '-R "select[type==X86_64 && mem > ' + str(mem_resource) + '] '\
-            'rusage[mem=' + str(mem_resource) + ']" -M' + str(mem_limit)
-    else:
-        bsubMem = ''
-    cpuStr = '' if cpu is None else '-n ' + str(int(cpu))
-    bsubline = ["bsub", bsubMem, cpuStr,"-cwd", ".", "-o", "/dev/null", "-e",
-        "/dev/null"]
-    lsfArgs = os.getenv('TOIL_LSF_ARGS')
-    if lsfArgs:
-        bsubline.extend(lsfArgs.split())
-    return bsubline
+logger = logging.getLogger(__name__)
 
 
-def bsub(bsubline):
-    process = subprocess.Popen(" ".join(bsubline), shell=True, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
-    liney = process.stdout.readline()
-    logger.debug("BSUB: " + liney)
-    result = int(liney.strip().split()[1].strip('<>'))
-    logger.debug("Got the job id: %s" % (str(result)))
-    return result
+class LSFBatchSystem(AbstractGridEngineBatchSystem):
 
+    class Worker(AbstractGridEngineBatchSystem.Worker):
+        """LSF specific AbstractGridEngineWorker methods."""
 
-def getjobexitcode(lsfJobID):
-        job, task = lsfJobID
+        def getRunningJobIDs(self):
+            times = {}
+            currentjobs = dict((str(self.batchJobIDs[x][0]), x) for x in
+                               self.runningJobs)
+            process = subprocess.Popen(["bjobs", "-o",
+                                        "jobid stat start_time delimiter="
+                                        + chr(30)], stdout=subprocess.PIPE)
+            stdout, stderr = process.communicate()
 
-        # first try bjobs to find out job state
-        args = ["bjobs", "-l", str(job)]
-        logger.debug("Checking job exit code for job via bjobs: " + str(job))
-        process = subprocess.Popen(" ".join(args), shell=True, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
-        started = 0
-        for line in process.stdout:
-            if line.find("Done successfully") > -1:
-                logger.debug("bjobs detected job completed for job: " + str(job))
-                return 0
-            elif line.find("Completed <exit>") > -1:
-                logger.debug("bjobs detected job failed for job: " + str(job))
-                return 1
-            elif line.find("New job is waiting for scheduling") > -1:
-                logger.debug("bjobs detected job pending scheduling for job: " + str(job))
+            for curline in process.stdout:
+                items = curline.strip().split(chr(30))
+                if items[0] in currentjobs and items[1] == 'RUN':
+                    jobstart = time.strptime("%s %s %s" % items[2].split(),
+                                             str(date.today().year),
+                                             "%b %d %H:%M")
+                    times[currentjobs[items[0]]] = time.time() - jobstart
+            return times
+
+        def killJob(self, jobID):
+            subprocess.check_call(['bkill', self.getBatchSystemID(jobID)])
+
+        def prepareSubmission(self, cpu, memory, jobID, command):
+            return self.prepareBsub(cpu, memory, jobID) + [command]
+
+        def submitJob(self, subLine):
+            process = subprocess.Popen(subLine, stdout=subprocess.PIPE,
+                                       stderr=subprocess.STDOUT,
+                                       env=self.boss.environment)
+            line = process.stdout.readline()
+            logger.debug("BSUB: " + line)
+            result = int(line.strip().split()[1].strip('<>'))
+            logger.debug("Got the job id: %s" % (str(result)))
+            return result
+
+        def getJobExitCode(self, lsfJobID):
+            # the task is set as part of the job ID if using getBatchSystemID()
+            job, task = (lsfJobID, None)
+            if '.' in lsfJobID:
+                job, task = lsfJobID.split('.', 1)
+
+            # first try bjobs to find out job state
+            args = ["bjobs", "-l", str(job)]
+            logger.debug("Checking job exit code for job via bjobs: %d" % job)
+            process = subprocess.Popen(args, stdout=subprocess.PIPE,
+                                       stderr=subprocess.STDOUT)
+            started = 0
+            for line in process.stdout:
+                if line.find("Done successfully") > -1:
+                    logger.debug("bjobs detected job completed for job: %d"
+                                 % job)
+                    return 0
+                elif line.find("Completed <exit>") > -1:
+                    logger.debug("bjobs detected job failed for job: %d"
+                                 % job)
+                    return 1
+                elif line.find("New job is waiting for scheduling") > -1:
+                    logger.debug("bjobs detected job pending scheduling for "
+                                 "job: %d" % job)
+                    return None
+                elif line.find("PENDING REASONS") > -1:
+                    logger.debug("bjobs detected job pending for job: %d"
+                                 % job)
+                    return None
+                elif line.find("Started on ") > -1:
+                    started = 1
+
+            if started == 1:
+                logger.debug("bjobs detected job started but not completed: %d"
+                             % job)
                 return None
-            elif line.find("PENDING REASONS") > -1:
-                logger.debug("bjobs detected job pending for job: " + str(job))
-                return None
-            elif line.find("Started on ") > -1:
-                started = 1
 
-        if started == 1:
-            logger.debug("bjobs detected job started but not completed: " + str(job))
+            # if not found in bjobs, then try bacct (slower than bjobs)
+            logger.debug("bjobs failed to detect job - trying bacct: %d" % job)
+
+            args = ["bacct", "-l", str(job)]
+            process = subprocess.Popen(args, stdout=subprocess.PIPE,
+                                       stderr=subprocess.STDOUT)
+            for line in process.stdout:
+                if line.find("Completed <done>") > -1:
+                    logger.debug("Detected job completed for job: %d" % job)
+                    return 0
+                elif line.find("Completed <exit>") > -1:
+                    logger.debug("Detected job failed for job: %d" % job)
+                    return 1
+            logger.debug("Can't determine exit code for job or job still "
+                         "running: %d" % job)
             return None
 
-        # if not found in bjobs, then try bacct (slower than bjobs)
-        logger.debug("bjobs failed to detect job - trying bacct: " + str(job))
-
-        args = ["bacct", "-l", str(job)]
-        logger.debug("Checking job exit code for job via bacct:" + str(job))
-        process = subprocess.Popen(" ".join(args), shell=True, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
-        for line in process.stdout:
-            if line.find("Completed <done>") > -1:
-                logger.debug("Detected job completed for job: " + str(job))
-                return 0
-            elif line.find("Completed <exit>") > -1:
-                logger.debug("Detected job failed for job: " + str(job))
-                return 1
-        logger.debug("Cant determine exit code for job or job still running: " + str(job))
-        return None
-
-
-class Worker(Thread):
-    def __init__(self, newJobsQueue, updatedJobsQueue, boss):
-        Thread.__init__(self)
-        self.newJobsQueue = newJobsQueue
-        self.updatedJobsQueue = updatedJobsQueue
-        self.currentjobs = list()
-        self.runningjobs = set()
-        self.boss = boss
-
-    def run(self):
-        while True:
-            # Load new job ids:
-            while not self.newJobsQueue.empty():
-                self.currentjobs.append(self.newJobsQueue.get())
-
-            # Launch jobs as necessary:
-            while len(self.currentjobs) > 0:
-                jobID, bsubline = self.currentjobs.pop()
-                lsfJobID = bsub(bsubline)
-                self.boss.jobIDs[(lsfJobID, None)] = jobID
-                self.boss.lsfJobIDs[jobID] = (lsfJobID, None)
-                self.runningjobs.add((lsfJobID, None))
-
-            # Test known job list
-            for lsfJobID in list(self.runningjobs):
-                exit = getjobexitcode(lsfJobID)
-                if exit is not None:
-                    self.updatedJobsQueue.put((lsfJobID, exit))
-                    self.runningjobs.remove(lsfJobID)
-
-            time.sleep(10)
-
-
-class LSFBatchSystem(BatchSystemLocalSupport):
-    """
-    The interface for running jobs on lsf, runs all the jobs you give it as they come in,
-    but in parallel.
-    """
-    @classmethod
-    def supportsWorkerCleanup(cls):
-        return False
-
-    @classmethod
-    def supportsHotDeployment(cls):
-        return False
-
-    def shutdown(self):
-        self.shutdownLocal()
-
-    def __init__(self, config, maxCores, maxMemory, maxDisk):
-        super(LSFBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
-        self.lsfResultsFile = self._getResultsFileName(config.jobStore)
-        # Reset the job queue and results (initially, we do this again once we've killed the jobs)
-        self.lsfResultsFileHandle = open(self.lsfResultsFile, 'w')
-        self.lsfResultsFileHandle.close()  # We lose any previous state in this file, and ensure the files existence
-        self.currentjobs = set()
-        self.obtainSystemConstants()
-        self.jobIDs = dict()
-        self.lsfJobIDs = dict()
-
-        self.newJobsQueue = Queue()
-        self.updatedJobsQueue = Queue()
-        self.worker = Worker(self.newJobsQueue, self.updatedJobsQueue, self)
-        self.worker.setDaemon(True)
-        self.worker.start()
-
-    def __des__(self):
-        # Closes the file handle associated with the results file.
-        self.lsfResultsFileHandle.close() # Close the results file, cos were done.
-
-    def issueBatchJob(self, jobNode):
-        localID = self.handleLocalJob(jobNode)
-        if localID:
-            return localID
-        jobID = self.getNextJobID()
-        self.currentjobs.add(jobID)
-        bsubline = prepareBsub(jobNode.cores, jobNode.memory) + [jobNode.command]
-        self.newJobsQueue.put((jobID, bsubline))
-        logger.debug("Issued the job command: %s with job id: %s " % (jobNode.command, str(jobID)))
-        return jobID
-
-    def getLsfID(self, jobID):
-        if jobID not in self.lsfJobIDs:
-            RuntimeError("Unknown jobID, could not be converted")
-
-        (job,task) = self.lsfJobIDs[jobID]
-        if task is None:
-            return str(job)
-        else:
-            return str(job) + "." + str(task)
-
-    def killBatchJobs(self, jobIDs):
-        self.killLocalJobs(jobIDs)
-        """Kills the given job IDs.
         """
-        for jobID in jobIDs:
-            try:
-                lsfID = self.getLsfID(jobID)
-                logger.debug("DEL: " + str(lsfID))
-                self.currentjobs.remove(jobID)
-                subprocess.Popen(["bkill", lsfID])
-                del self.jobIDs[self.lsfJobIDs[jobID]]
-                del self.lsfJobIDs[jobID]
-            except RuntimeError:
-                jobIDs.remove(jobID)
-
-        toKill = set(jobIDs)
-        while len(toKill) > 0:
-            for jobID in list(toKill):
-                if getjobexitcode(self.lsfJobIDs[jobID]) is not None:
-                    toKill.remove(jobID)
-
-            if len(toKill) > 0:
-                logger.warn("Tried to kill some jobs, but something happened and they are still going, "
-                             "so I'll try again")
-                time.sleep(5)
-
-    def getIssuedBatchJobIDs(self):
-        """A list of jobs (as jobIDs) currently issued (may be running, or maybe 
-        just waiting).
+        Implementation-specific helper methods
         """
-        return list(self.getIssuedLocalJobIDs()) + list(self.currentjobs)
+        @staticmethod
+        def prepareBsub(cpu, mem, jobID):
+            """
+            Make a bsub commandline to execute.
 
-    def getRunningBatchJobIDs(self):
-        """Gets a map of jobs (as jobIDs) currently running (not just waiting) 
-        and a how long they have been running for (in seconds).
-        """
-        times = {}
-        currentjobs = set()
-        for x in self.getIssuedBatchJobIDs():
-            if x in self.lsfJobIDs:
-                currentjobs.add(self.lsfJobIDs[x])
+            params:
+              cpu: number of cores needed
+              mem: number of bytes of memory needed
+              jobID: ID number of the job
+            """
+            if mem:
+                if per_core_reservation():
+                    mem = float(mem)/1024**3/int(cpu)
+                    mem_resource = parse_memory_resource(mem)
+                    mem_limit = parse_memory_limit(mem)
+                else:
+                    mem = old_div(float(mem), 1024**3)
+                    mem_resource = parse_memory_resource(mem)
+                    mem_limit = parse_memory_limit(mem)
+                bsubMem = ['-R', 'select[type==X86_64 && mem > %d] '
+                           'rusage[mem=%d]' % mem_resource, mem_resource,
+                           '-M', str(mem_limit)]
             else:
-                # not yet started
-                pass
-        process = subprocess.Popen(["bjobs"], stdout = subprocess.PIPE)
-
-        for curline in process.stdout:
-            items = curline.strip().split()
-            if (len(items) > 9 and (items[0]) in currentjobs) and items[2] == 'RUN':
-                jobstart = "/".join(items[7:9]) + '/' + str(date.today().year)
-                jobstart = jobstart + ' ' + items[9]
-                jobstart = time.mktime(time.strptime(jobstart,"%b/%d/%Y %H:%M"))
-                jobstart = time.mktime(time.strptime(jobstart,"%m/%d/%Y %H:%M:%S"))
-                times[self.jobIDs[(items[0])]] = time.time() - jobstart
-        times.update(self.getRunningLocalJobIDs())
-        return times
-
-    def getUpdatedBatchJob(self, maxWait):
-        local_tuple = self.getUpdatedLocalJob(0)
-        if local_tuple:
-            return local_tuple
-        try:
-            sgeJobID, retcode = self.updatedJobsQueue.get(timeout=maxWait)
-            self.updatedJobsQueue.task_done()
-            jobID, retcode = (self.jobIDs[sgeJobID], retcode)
-            self.currentjobs -= {self.jobIDs[sgeJobID]}
-        except Empty:
-            pass
-        else:
-            return jobID, retcode, None
+                bsubMem = []
+            bsubCpu = [] if cpu is None else ['-n', str(int(cpu))]
+            bsubline = ["bsub", "-cwd", ".", "-o", "/dev/null",
+                        "-e", "/dev/null", "-J", "toil_job_%d" % jobID]
+            bsubline.extend(bsubMem)
+            bsubline.extend(bsubCpu)
+            lsfArgs = os.getenv('TOIL_LSF_ARGS')
+            if lsfArgs:
+                bsubline.extend(lsfArgs.split())
+            return bsubline
 
     def getWaitDuration(self):
         """We give LSF a second to catch its breath (in seconds)
         """
         return 15
 
-    def obtainSystemConstants(self):
-        p = subprocess.Popen(["lshosts"], stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
+    @classmethod
+    def obtainSystemConstants(cls):
+        p = subprocess.Popen(["lshosts"], stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
 
         line = p.stdout.readline()
         items = line.strip().split()
@@ -305,21 +190,26 @@ class LSFBatchSystem(BatchSystemLocalSupport):
                         mem_index = i
 
         if cpu_index is None or mem_index is None:
-                RuntimeError("lshosts command does not return ncpus or maxmem columns")
+                RuntimeError("lshosts command does not return ncpus or maxmem "
+                             "columns")
 
-        p.stdout.readline()
+        # p.stdout.readline()
 
-        self.maxCPU = 0
-        self.maxMEM = MemoryString("0")
+        maxCPU = 0
+        maxMEM = MemoryString("0")
         for line in p.stdout:
                 items = line.strip().split()
                 if len(items) < num_columns:
-                        RuntimeError("lshosts output has a varying number of columns")
-                if items[cpu_index] != '-' and items[cpu_index] > self.maxCPU:
-                        self.maxCPU = items[cpu_index]
-                if items[mem_index] != '-' and MemoryString(items[mem_index]) > self.maxMEM:
-                        self.maxMEM = MemoryString(items[mem_index])
+                        RuntimeError("lshosts output has a varying number of "
+                                     "columns")
+                if items[cpu_index] != '-' and items[cpu_index] > maxCPU:
+                        maxCPU = items[cpu_index]
+                if (items[mem_index] != '-' and
+                        MemoryString(items[mem_index]) > maxMEM):
+                    maxMEM = MemoryString(items[mem_index])
 
-        if self.maxCPU is 0 or self.maxMEM is 0:
+        if maxCPU is 0 or maxMEM is 0:
                 RuntimeError("lshosts returns null ncpus or maxmem info")
-        logger.debug("Got the maxCPU: %s" % (self.maxMEM))
+        logger.debug("Got the maxCPU: %s" % (maxMEM))
+
+        return maxCPU, maxMEM

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -52,9 +52,9 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
             process = subprocess.Popen(
                     ["bjobs", "-o", "jobid stat start_time delimiter='|'"],
                     stdout=subprocess.PIPE)
-            stdout, stderr = process.communicate()
+            stdout, _ = process.communicate()
 
-            for curline in process.stdout:
+            for curline in stdout:
                 items = curline.strip().split('|')
                 if items[0] in currentjobs and items[1] == 'RUN':
                     jobstart = parse(items[2], default=datetime.now(tzlocal()))

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -124,7 +124,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                 return None
 
             # if not found in bjobs, then try bacct (slower than bjobs)
-            logger.error("bjobs failed to detect job - trying bacct: "
+            logger.debug("bjobs failed to detect job - trying bacct: "
                          "{}".format(job))
 
             args = ["bacct", "-l", str(job)]

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -109,6 +109,12 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                     logger.debug("bjobs detected job pending for job: "
                                  "{}".format(job))
                     return None
+                elif line.find("Exited with exit code") > -1:
+                    exit = int(line[
+                            line.find("Exited with exit code "):].split()[0])
+                    logger.debug("bjobs detected job exit code: "
+                                 "{}".format(exit))
+                    return exit
                 elif line.find("Started on ") > -1:
                     started = 1
 

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -49,13 +49,13 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
             times = {}
             currentjobs = dict((str(self.batchJobIDs[x][0]), x) for x in
                                self.runningJobs)
-            process = subprocess.Popen(["bjobs", "-o",
-                                        "jobid stat start_time delimiter="
-                                        + chr(30)], stdout=subprocess.PIPE)
+            process = subprocess.Popen(
+                    ["bjobs", "-o", "jobid stat start_time delimiter='|'"],
+                    stdout=subprocess.PIPE)
             stdout, stderr = process.communicate()
 
             for curline in process.stdout:
-                items = curline.strip().split(chr(30))
+                items = curline.strip().split('|')
                 if items[0] in currentjobs and items[1] == 'RUN':
                     jobstart = parse(items[2], default=datetime.now(tzlocal()))
                     times[currentjobs[items[0]]] = datetime.now() - jobstart

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -54,11 +54,12 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                     stdout=subprocess.PIPE)
             stdout, _ = process.communicate()
 
-            for curline in stdout:
+            for curline in stdout.split('\n'):
                 items = curline.strip().split('|')
                 if items[0] in currentjobs and items[1] == 'RUN':
                     jobstart = parse(items[2], default=datetime.now(tzlocal()))
-                    times[currentjobs[items[0]]] = datetime.now() - jobstart
+                    times[currentjobs[items[0]]] = datetime.now(tzlocal()) \
+                        - jobstart
             return times
 
         def killJob(self, jobID):

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -124,7 +124,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                 return None
 
             # if not found in bjobs, then try bacct (slower than bjobs)
-            logger.debug("bjobs failed to detect job - trying bacct: "
+            logger.error("bjobs failed to detect job - trying bacct: "
                          "{}".format(job))
 
             args = ["bacct", "-l", str(job)]
@@ -136,7 +136,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                                  "{}".format(job))
                     return 0
                 elif line.find("Completed <exit>") > -1:
-                    logger.debug("Detected job failed for job: "
+                    logger.error("Detected job failed for job: "
                                  "{}".format(job))
                     return 1
             logger.debug("Can't determine exit code for job or job still "

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -68,8 +68,10 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
             return self.prepareBsub(cpu, memory, jobID) + [command]
 
         def submitJob(self, subLine):
+            combinedEnv = self.boss.environment
+            combinedEnv.update(os.environ)
             process = subprocess.Popen(subLine, stdout=subprocess.PIPE,
-                                       env=self.boss.environment)
+                                       env=combinedEnv)
             line = process.stdout.readline()
             logger.debug("BSUB: " + line)
             result = int(line.strip().split()[1].strip('<>'))

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -24,9 +24,11 @@ from builtins import range
 from past.utils import old_div
 import logging
 import subprocess
-import time
-from datetime import date
 import os
+
+from dateutil.parser import parse
+from dateutil.tz import tzlocal
+from datetime import datetime
 
 from toil.batchSystems import MemoryString
 from toil.batchSystems.abstractGridEngineBatchSystem import \
@@ -55,10 +57,8 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
             for curline in process.stdout:
                 items = curline.strip().split(chr(30))
                 if items[0] in currentjobs and items[1] == 'RUN':
-                    jobstart = time.strptime("%s %s %s" % items[2].split(),
-                                             str(date.today().year),
-                                             "%b %d %H:%M")
-                    times[currentjobs[items[0]]] = time.time() - jobstart
+                    jobstart = parse(items[2], default=datetime.now(tzlocal()))
+                    times[currentjobs[items[0]]] = datetime.now() - jobstart
             return times
 
         def killJob(self, jobID):
@@ -74,7 +74,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
             line = process.stdout.readline()
             logger.debug("BSUB: " + line)
             result = int(line.strip().split()[1].strip('<>'))
-            logger.debug("Got the job id: %s" % (str(result)))
+            logger.debug("Got the job id: {}".format(result))
             return result
 
         def getJobExitCode(self, lsfJobID):
@@ -85,50 +85,54 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
 
             # first try bjobs to find out job state
             args = ["bjobs", "-l", str(job)]
-            logger.debug("Checking job exit code for job via bjobs: %d" % job)
+            logger.debug("Checking job exit code for job via bjobs: "
+                         "{}".format(job))
             process = subprocess.Popen(args, stdout=subprocess.PIPE,
                                        stderr=subprocess.STDOUT)
             started = 0
             for line in process.stdout:
                 if line.find("Done successfully") > -1:
-                    logger.debug("bjobs detected job completed for job: %d"
-                                 % job)
+                    logger.debug("bjobs detected job completed for job: "
+                                 "{}".format(job))
                     return 0
                 elif line.find("Completed <exit>") > -1:
-                    logger.debug("bjobs detected job failed for job: %d"
-                                 % job)
+                    logger.debug("bjobs detected job failed for job: "
+                                 "{}".format(job))
                     return 1
                 elif line.find("New job is waiting for scheduling") > -1:
                     logger.debug("bjobs detected job pending scheduling for "
-                                 "job: %d" % job)
+                                 "job: {}".format(job))
                     return None
                 elif line.find("PENDING REASONS") > -1:
-                    logger.debug("bjobs detected job pending for job: %d"
-                                 % job)
+                    logger.debug("bjobs detected job pending for job: "
+                                 "{}".format(job))
                     return None
                 elif line.find("Started on ") > -1:
                     started = 1
 
             if started == 1:
-                logger.debug("bjobs detected job started but not completed: %d"
-                             % job)
+                logger.debug("bjobs detected job started but not completed: "
+                             "{}".format(job))
                 return None
 
             # if not found in bjobs, then try bacct (slower than bjobs)
-            logger.debug("bjobs failed to detect job - trying bacct: %d" % job)
+            logger.debug("bjobs failed to detect job - trying bacct: "
+                         "{}".format(job))
 
             args = ["bacct", "-l", str(job)]
             process = subprocess.Popen(args, stdout=subprocess.PIPE,
                                        stderr=subprocess.STDOUT)
             for line in process.stdout:
                 if line.find("Completed <done>") > -1:
-                    logger.debug("Detected job completed for job: %d" % job)
+                    logger.debug("Detected job completed for job: "
+                                 "{}".format(job))
                     return 0
                 elif line.find("Completed <exit>") > -1:
-                    logger.debug("Detected job failed for job: %d" % job)
+                    logger.debug("Detected job failed for job: "
+                                 "{}".format(job))
                     return 1
             logger.debug("Can't determine exit code for job or job still "
-                         "running: %d" % job)
+                         "running: {}".format(job))
             return None
 
         """
@@ -153,14 +157,14 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                     mem = old_div(float(mem), 1024**3)
                     mem_resource = parse_memory_resource(mem)
                     mem_limit = parse_memory_limit(mem)
-                bsubMem = ['-R', 'select[type==X86_64 && mem > %d] '
-                           'rusage[mem=%d]' % mem_resource, mem_resource,
+                bsubMem = ['-R', 'select[type==X86_64 && mem > {m}] '
+                           'rusage[mem={m}]'.format(m=mem_resource),
                            '-M', str(mem_limit)]
             else:
                 bsubMem = []
             bsubCpu = [] if cpu is None else ['-n', str(int(cpu))]
             bsubline = ["bsub", "-cwd", ".", "-o", "/dev/null",
-                        "-e", "/dev/null", "-J", "toil_job_%d" % jobID]
+                        "-e", "/dev/null", "-J", "toil_job_{}".format(jobID)]
             bsubline.extend(bsubMem)
             bsubline.extend(bsubCpu)
             lsfArgs = os.getenv('TOIL_LSF_ARGS')
@@ -210,6 +214,6 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
 
         if maxCPU is 0 or maxMEM is 0:
                 RuntimeError("lshosts returns null ncpus or maxmem info")
-        logger.debug("Got the maxCPU: %s" % (maxMEM))
+        logger.debug("Got the maxCPU: {}".format(maxMEM))
 
         return maxCPU, maxMEM

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -69,7 +69,6 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
 
         def submitJob(self, subLine):
             process = subprocess.Popen(subLine, stdout=subprocess.PIPE,
-                                       stderr=subprocess.STDOUT,
                                        env=self.boss.environment)
             line = process.stdout.readline()
             logger.debug("BSUB: " + line)
@@ -214,6 +213,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
 
         if maxCPU is 0 or maxMEM is 0:
                 RuntimeError("lshosts returns null ncpus or maxmem info")
-        logger.debug("Got the maxCPU: {}".format(maxMEM))
+        logger.debug("Got the maxMEM: {}".format(maxMEM))
+        logger.debug("Got the maxCPU: {}".format(maxCPU))
 
         return maxCPU, maxMEM

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -93,28 +93,28 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                                        stderr=subprocess.STDOUT)
             started = 0
             for line in process.stdout:
-                if line.find("Done successfully") > -1:
+                if "Done successfully" in line:
                     logger.debug("bjobs detected job completed for job: "
                                  "{}".format(job))
                     return 0
-                elif line.find("Completed <exit>") > -1:
-                    logger.debug("bjobs detected job failed for job: "
-                                 "{}".format(job))
-                    return 1
-                elif line.find("New job is waiting for scheduling") > -1:
+                elif "New job is waiting for scheduling" in line:
                     logger.debug("bjobs detected job pending scheduling for "
                                  "job: {}".format(job))
                     return None
-                elif line.find("PENDING REASONS") > -1:
+                elif "PENDING REASONS" in line:
                     logger.debug("bjobs detected job pending for job: "
                                  "{}".format(job))
                     return None
-                elif line.find("Exited with exit code") > -1:
-                    exit = int(line[
-                            line.find("Exited with exit code "):].split()[0])
+                elif "Exited with exit code" in line:
+                    exit = int(line[line.find("Exited with exit code "):]
+                               .split()[0])
                     logger.debug("bjobs detected job exit code: "
                                  "{}".format(exit))
                     return exit
+                elif "Completed <exit>" in line:
+                    logger.debug("bjobs detected job failed for job: "
+                                 "{}".format(job))
+                    return 1
                 elif line.find("Started on ") > -1:
                     started = 1
 

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -433,6 +433,18 @@ def needs_lsf(test_item):
         return unittest.skip("Install LSF to include this test.")(test_item)
 
 
+def needs_docker(test_item):
+    """
+    Use as a decorator before test classes or methods to only run them if
+    docker is installed.
+    """
+    test_item = _mark_test('docker', test_item)
+    if next(which('docker'), None):
+        return test_item
+    else:
+        return unittest.skip("Install docker to include this test.")(test_item)
+
+
 def needs_encryption(test_item):
     """
     Use as a decorator before test classes or methods to only run them if PyNaCl is installed

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -421,6 +421,18 @@ def needs_slurm(test_item):
         return unittest.skip("Install Slurm to include this test.")(test_item)
 
 
+def needs_lsf(test_item):
+    """
+    Use as a decorator before test classes or methods to only run them if LSF
+    is installed.
+    """
+    test_item = _mark_test('lsf', test_item)
+    if next(which('bsub'), None):
+        return test_item
+    else:
+        return unittest.skip("Install LSF to include this test.")(test_item)
+
+
 def needs_encryption(test_item):
     """
     Use as a decorator before test classes or methods to only run them if PyNaCl is installed

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -166,6 +166,8 @@ class hidden(object):
                 self.assertTrue(wallTime > 0)
             else:
                 self.assertIsNone(wallTime)
+            if not os.path.exists(testPath):
+                time.sleep(20)
             self.assertTrue(os.path.exists(testPath))
             self.assertFalse(self.batchSystem.getUpdatedBatchJob(0))
 
@@ -180,7 +182,7 @@ class hidden(object):
             # invoke that script rather than inline the test via -c.
             def assertEnv():
                 import os, sys
-                sys.exit(0 if os.getenv('FOO') == 'bar' else 42)
+                sys.exit(23 if os.getenv('FOO') == 'bar' else 42)
 
             script_body = dedent('\n'.join(getsource(assertEnv).split('\n')[1:]))
             with tempFileContaining(script_body, suffix='.py') as script_path:
@@ -198,7 +200,7 @@ class hidden(object):
                                    jobStoreID='5', requirements=defaultRequirements)
                 job5 = self.batchSystem.issueBatchJob(jobNode5)
                 jobID, exitStatus, wallTime = self.batchSystem.getUpdatedBatchJob(maxWait=1000)
-                self.assertEqual(exitStatus, 0)
+                self.assertEqual(exitStatus, 23)
                 self.assertEqual(jobID, job5)
 
         def testCheckResourceRequest(self):

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -312,18 +312,6 @@ class hidden(object):
             config.jobStore = 'file:' + self._createTempDir('jobStore')
             return config
 
-        def testResultFile(self):
-            """
-            Tests that the result file name is formatted properly
-            """
-            # noinspection PyUnresolvedReferences
-            fileName = self.batchSystem._getResultsFileName(self.config.jobStore)
-            filePath, _ = os.path.split(fileName)  # removes file so dir matches config.jobStore
-            locator = self.config.jobStore
-            self.assertTrue(locator.startswith('file:'))
-            self.assertEqual(locator[len('file:'):], filePath)
-
-
 @slow
 @needs_mesos
 class MesosBatchSystemTest(hidden.AbstractBatchSystemTest, MesosTestSupport):

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -43,6 +43,7 @@ from toil.batchSystems.abstractBatchSystem import (InsufficientSystemResources,
                                                    BatchSystemSupport)
 from toil.job import Job, JobNode
 from toil.test import (ToilTest,
+                       needs_lsf,
                        needs_mesos,
                        needs_parasol,
                        needs_gridengine,
@@ -666,6 +667,18 @@ class SlurmBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
         from glob import glob
         for f in glob('slurm-*.out'):
             os.unlink(f)
+
+
+@slow
+@needs_lsf
+class LSFBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
+    """
+    Tests against the LSF batch system
+    """
+    def createBatchSystem(self):
+        from toil.batchSystems.lsf import LSFBatchSystem
+        return LSFBatchSystem(config=self.config, maxCores=numCores,
+                              maxMemory=1000e9, maxDisk=1e9)
 
 
 @slow

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 import json
 import os
 import subprocess
+import unittest
 import re
 import shutil
 import pytest
@@ -177,31 +178,37 @@ class CWLTest(ToilTest):
 
     @slow
     @needs_lsf
+    @unittest.skip
     def test_lsf_cwl_conformance(self):
         return self.test_run_conformance("LSF")
 
     @slow
     @needs_slurm
+    @unittest.skip
     def test_slurm_cwl_conformance(self):
         return self.test_run_conformance("Slurm")
 
     @slow
     @needs_torque
+    @unittest.skip
     def test_torque_cwl_conformance(self):
         return self.test_run_conformance("Torque")
 
     @slow
     @needs_gridengine
+    @unittest.skip
     def test_gridengine_cwl_conformance(self):
         return self.test_run_conformance("gridEngine")
 
     @slow
     @needs_mesos
+    @unittest.skip
     def test_mesos_cwl_conformance(self):
         return self.test_run_conformance("mesos")
 
     @slow
     @needs_parasol
+    @unittest.skip
     def test_parasol_cwl_conformance(self):
         return self.test_run_conformance("parasol")
 

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -138,7 +138,7 @@ class CWLTest(ToilTest):
             os.remove("spec.zip")
         try:
             cmd = ["bash", "run_test.sh", "RUNNER=toil-cwl-runner",
-                   "DRAFT=v1.0", "-j4"]
+                   "DRAFT=v1.0", "-j2"]
             if batchSystem:
                 cmd.extend(["--batchSystem", batchSystem])
             subprocess.check_output(cmd, cwd=cwlSpec, stderr=subprocess.STDOUT)

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -137,7 +137,7 @@ class CWLTest(ToilTest):
             os.remove("spec.zip")
         try:
             cmd = ["bash", "run_test.sh", "RUNNER=toil-cwl-runner",
-                   "DRAFT=v1.0"]
+                   "DRAFT=v1.0", "-j4"]
             if batchSystem:
                 cmd.extend(["--batchSystem", batchSystem])
             subprocess.check_output(cmd, cwd=cwlSpec, stderr=subprocess.STDOUT)


### PR DESCRIPTION
I'd like to add this small change to this PR. I think that if a LSF job fails, whe should log `error` not `debug`. What do you think?