### PR TITLE
Fix some flaky AWS tests (resolves #1840)

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -669,7 +669,7 @@ class AWSProvisioner(AbstractProvisioner):
         elif preemptable and not both:
             return [x for x in allInstances if x.spot_instance_request_id is not None]
         elif both:
-            return allInstances
+            return list(allInstances)
 
     @classmethod
     def _getSpotRequestIDs(cls, ctx, clusterName):

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -150,6 +150,9 @@ class AWSProvisioner(AbstractProvisioner):
                                                    num_instances=1))[0]
             leader = instances[0]
 
+        wait_instances_running(ctx.ec2, [leader])
+        self._waitForNode(leader, 'toil_leader')
+
         defaultTags = {'Name': clusterName, 'Owner': keyName}
         defaultTags.update(userTags)
 

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -465,22 +465,14 @@ class AWSProvisioner(AbstractProvisioner):
 
     @classmethod
     @awsRetry
-    def _addTags(cls, instances, tags):
-        def tagThrottlePredicate(e):
-            """Check for common retriable issues when creating tags."""
-                return True
-            else:
-                return cls._throttlePredicate
+    def _addTag(cls, instance, key, value):
+        instance.add_tag(key, value)
 
+    @classmethod
+    def _addTags(cls, instances, tags):
         for instance in instances:
             for key, value in iteritems(tags):
-<<<<<<< HEAD
-                for attempt in retry(predicate=tagThrottlePredicate):
-                    with attempt:
-                        instance.add_tag(key, value)
-=======
-                instance.add_tag(key, value)
->>>>>>> Refactor and improve AWS retry
+                cls._addTag(instance, key, value)
 
     @classmethod
     def _waitForNode(cls, instance, role):


### PR DESCRIPTION
This is a continuation of #2061. 

It should fix a few different kinds of AWS errors.

- Adding tags would fail with `EC2ResponseError: EC2ResponseError: 400 Bad Request` [example](http://jenkins.cgcloud.info/job/toil-pull-request-integration-tests/1950/testReport/junit/src.toil.test.provisioners.aws.awsProvisionerTest/AWSAutoscaleTestMultipleNodeTypes/testAutoScale/)
This is fixed in 6682bac then refactored in 7659c0b

- Counting workers would fail with assertion error. [example](http://jenkins.cgcloud.info/job/toil-pull-request-integration-tests/1955/testReport/junit/src.toil.test.provisioners.aws.awsProvisionerTest/AWSStaticAutoscaleTest/testSpotAutoScale/)
This is fixed in e01298a

This PR also contains a refactor of the AWS retry mechanism 7659c0b. Now there is a decorator `@awsRetry` which retries the function if any regular AWS exceptions are thrown.