### PR TITLE
Omit htcondor extra from ALL extra.  Addresses #2070.

### DIFF
--- a/docs/gettingStarted/install.rst
+++ b/docs/gettingStarted/install.rst
@@ -73,7 +73,7 @@ Here's what each extra provides:
 +----------------+------------------------------------------------------------+
 | Extra          | Description                                                |
 +================+============================================================+
-| ``all``        | Installs all extras.                                       |
+| ``all``        | Installs all extras except htcondor.                       |
 +----------------+------------------------------------------------------------+
 | ``aws``        | Provides support for managing a cluster on Amazon Web      |
 |                | Service (`AWS`_) using Toil's built in :ref:`clusterRef`.  |
@@ -108,6 +108,10 @@ Here's what each extra provides:
 |                |                                                            |
 |                |        ImportError: No module named mesos.native           |
 |                |                                                            |
++----------------+------------------------------------------------------------+
+| ``htcondor``   | Support for the htcondor batch system.  This is linux only |
+|                | with no apple support currently and is therefore not in    |
+|                | the ``all`` extra and must be included separately.         |
 +----------------+------------------------------------------------------------+
 | ``encryption`` | Provides client-side encryption for files stored in the    |
 |                | Azure and AWS job stores. This extra requires the          |

--- a/setup.py
+++ b/setup.py
@@ -90,8 +90,7 @@ def runSetup():
                    azure_reqs +
                    encryption_reqs +
                    google_reqs +
-                   cwl_reqs +
-                   htcondor_reqs},
+                   cwl_reqs},
         package_dir={'': 'src'},
         packages=find_packages(where='src',
                                # Note that we intentionally include the top-level `test` package for


### PR DESCRIPTION
Straight forward removal of the `htcondor` extra from being included in the `all` installation.