### PR TITLE
Replace subprocess with subprocess32.  Partially addresses #2039.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,8 @@ def runSetup():
             'six>=1.10.0',
             'future',
             'requests==2.18.4',
-            'docker==2.5.1'],
+            'docker==2.5.1',
+            'subprocess32==3.5.0rc1'],
         extras_require={
             'mesos': mesos_reqs,
             'aws': aws_reqs,

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -18,9 +18,14 @@ import logging
 import os
 import sys
 
-from subprocess import check_output
-
 from bd2k.util import memoize
+
+# subprocess32 is a backport of python3's subprocess module for use on Python2,
+# and includes many reliability bug fixes relevant on POSIX platforms.
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +84,7 @@ def physicalMemory():
     try:
         return os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
     except ValueError:
-        return int(check_output(['sysctl', '-n', 'hw.memsize']).strip())
+        return int(subprocess.check_output(['sysctl', '-n', 'hw.memsize']).strip())
 
 
 def physicalDisk(config, toilWorkflowDir=None):

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -21,7 +21,7 @@ from past.utils import old_div
 import logging
 import os
 from pipes import quote
-import subprocess
+from toil import subprocess
 import time
 import math
 

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -23,7 +23,7 @@ from builtins import str
 from builtins import range
 from past.utils import old_div
 import logging
-import subprocess
+from toil import subprocess
 import time
 from threading import Thread
 from datetime import date

--- a/src/toil/batchSystems/lsfHelper.py
+++ b/src/toil/batchSystems/lsfHelper.py
@@ -27,7 +27,7 @@ from __future__ import division
 from past.utils import old_div
 import math
 import os
-import subprocess
+from toil import subprocess
 import fnmatch
 
 LSB_PARAMS_FILENAME = "lsb.params"

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -23,7 +23,7 @@ import signal
 import sys
 import threading
 import logging
-import subprocess
+from toil import subprocess
 import traceback
 from time import sleep, time
 

--- a/src/toil/batchSystems/mesos/test/__init__.py
+++ b/src/toil/batchSystems/mesos/test/__init__.py
@@ -5,7 +5,7 @@ from abc import ABCMeta, abstractmethod
 import logging
 import shutil
 import threading
-import subprocess
+from toil import subprocess
 import multiprocessing
 
 from bd2k.util.processes import which

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -22,7 +22,7 @@ import logging
 import os
 import re
 import sys
-import subprocess
+from toil import subprocess
 import tempfile
 import time
 from threading import Thread

--- a/src/toil/batchSystems/parasolTestSupport.py
+++ b/src/toil/batchSystems/parasolTestSupport.py
@@ -4,7 +4,7 @@ import logging
 import tempfile
 import threading
 import time
-import subprocess
+from toil import subprocess
 import multiprocessing
 import signal
 import os

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -24,7 +24,7 @@ from contextlib import contextmanager
 import logging
 import multiprocessing
 import os
-import subprocess
+from toil import subprocess
 import time
 import math
 from threading import Thread

--- a/src/toil/batchSystems/slurm.py
+++ b/src/toil/batchSystems/slurm.py
@@ -19,7 +19,7 @@ from past.utils import old_div
 import logging
 import os
 from pipes import quote
-import subprocess
+from toil import subprocess
 import time
 import math
 

--- a/src/toil/batchSystems/torque.py
+++ b/src/toil/batchSystems/torque.py
@@ -19,7 +19,7 @@ from past.utils import old_div
 import logging
 import os
 from pipes import quote
-import subprocess
+from toil import subprocess
 import time
 import math
 import sys

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -26,7 +26,7 @@ import sys
 import tempfile
 import time
 import uuid
-import subprocess
+from toil import subprocess
 import requests
 from argparse import ArgumentParser
 

--- a/src/toil/lib/__init__.py
+++ b/src/toil/lib/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import absolute_import
 
-import subprocess
+from toil import subprocess
 
 FORGO = 0
 STOP = 1

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -28,7 +28,7 @@ import math
 import shutil
 from argparse import ArgumentParser
 from optparse import OptionContainer, OptionGroup
-import subprocess
+from toil import subprocess
 
 # Python 3 compatibility imports
 from six.moves import xrange

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import logging
 import os
 import pipes
-import subprocess
+from toil import subprocess
 import docker
 import base64
 import time

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -18,7 +18,7 @@ from itertools import count
 import logging
 import pipes
 import socket
-import subprocess
+from toil import subprocess
 
 from future.utils import with_metaclass
 

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -17,7 +17,7 @@ from builtins import str
 from builtins import range
 import logging
 import time
-import subprocess
+from toil import subprocess
 import sys
 import string
 

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -31,7 +31,7 @@ from textwrap import dedent
 import time
 import multiprocessing
 import sys
-import subprocess
+from toil import subprocess
 from unittest import skipIf
 
 from toil.common import Config

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import json
 import os
-import subprocess
+from toil import subprocess
 import re
 import shutil
 import pytest

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -5,7 +5,7 @@ import time
 import os
 import uuid
 import docker
-import subprocess
+from toil import subprocess
 from threading import Thread
 from docker.errors import ContainerError
 
@@ -17,7 +17,6 @@ from toil.lib import FORGO, STOP, RM
 from toil.lib.docker import dockerCall, dockerCheckOutput, apiDockerCall, containerIsRunning, dockerKill
 
 # only needed for subprocessDockerCall tests
-from subprocess import CalledProcessError
 from pwd import getpwuid
 from bd2k.util.retry import retry
 from toil.lib import dockerPredicate
@@ -512,7 +511,7 @@ def _testSubprocessDockerPipeChainErrorFn(job):
     parameters = [ ['exit', '1'], ['wc', '-l'] ]
     try:
         return dockerCheckOutput(job, tool='quay.io/ucsc_cgl/spooky_test', parameters=parameters)
-    except CalledProcessError:
+    except subprocess.CalledProcessError:
         return True
     return False
 

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -16,7 +16,7 @@ from builtins import str
 from builtins import range
 import logging
 import os
-import subprocess
+from toil import subprocess
 from abc import abstractmethod
 from inspect import getsource
 from textwrap import dedent

--- a/src/toil/test/sort/sortTest.py
+++ b/src/toil/test/sort/sortTest.py
@@ -21,7 +21,7 @@ import random
 from contextlib import contextmanager
 from uuid import uuid4
 import logging
-import subprocess
+from toil import subprocess
 
 # Python 3 compatibility imports
 import errno

--- a/src/toil/test/src/hotDeploymentTest.py
+++ b/src/toil/test/src/hotDeploymentTest.py
@@ -3,10 +3,10 @@ from builtins import str
 from builtins import object
 import logging
 from contextlib import contextmanager
-from subprocess import CalledProcessError
 
 from bd2k.util.iterables import concat
 
+from toil import subprocess
 from toil.test import needs_mesos, ApplianceTestSupport, needs_appliance, slow
 
 log = logging.getLogger(__name__)
@@ -78,7 +78,7 @@ class HotDeploymentTest(ApplianceTestSupport):
                         '--defaultMemory=10M',
                         '/data/jobstore']
             command = concat(pythonArgs, toilArgs)
-            self.assertRaises(CalledProcessError, leader.runOnAppliance, *command)
+            self.assertRaises(subprocess.CalledProcessError, leader.runOnAppliance, *command)
 
             # Deploy an updated version of the script ...
             userScript = userScript.replace('assert False', 'assert True')
@@ -138,7 +138,7 @@ class HotDeploymentTest(ApplianceTestSupport):
             # Assert that output file isn't there
             worker.runOnAppliance('test', '!', '-f', '/data/foo.txt')
             # Just being paranoid
-            self.assertRaises(CalledProcessError,
+            self.assertRaises(subprocess.CalledProcessError,
                               worker.runOnAppliance, 'test', '-f', '/data/foo.txt')
             leader.runOnAppliance('venv/bin/python',
                                   '-m', 'toil_script.bar',

--- a/src/toil/test/src/regularLogTest.py
+++ b/src/toil/test/src/regularLogTest.py
@@ -13,10 +13,10 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import mimetypes
-import subprocess
 import sys
 import os
 
+from toil import subprocess
 from toil.test import ToilTest, slow
 from toil.test.mesos import helloWorld
 

--- a/src/toil/test/src/resourceTest.py
+++ b/src/toil/test/src/resourceTest.py
@@ -19,13 +19,13 @@ import os
 import sys
 from inspect import getsource
 from io import BytesIO
-from subprocess import check_call, Popen, PIPE
 from textwrap import dedent
 from zipfile import ZipFile
 
 from bd2k.util.files import mkdir_p
 from mock import MagicMock, patch
 
+from toil import subprocess
 from toil import inVirtualEnv
 from toil.resource import ModuleDescriptor, Resource, ResourceException
 from toil.test import ToilTest, tempFileContaining
@@ -68,7 +68,7 @@ class ResourceTest(ToilTest):
         if virtualenv:
             self.assertTrue(inVirtualEnv())
             # --never-download prevents silent upgrades to pip, wheel and setuptools
-            check_call(['virtualenv', '--never-download', dirPath])
+            subprocess.check_call(['virtualenv', '--never-download', dirPath])
             sitePackages = os.path.join(dirPath, 'lib', 'python2.7', 'site-packages')
             # tuple assignment is necessary to make this line immediately precede the try:
             oldPrefix, sys.prefix, dirPath = sys.prefix, dirPath, sitePackages
@@ -213,7 +213,7 @@ class ResourceTest(ToilTest):
             self.assertFalse(scriptPath.endswith(('.py', '.pyc')))
             os.chmod(scriptPath, 0o755)
             jobStorePath = scriptPath + '.jobStore'
-            process = Popen([scriptPath, jobStorePath], stderr=PIPE)
+            process = subprocess.Popen([scriptPath, jobStorePath], stderr=subprocess.PIPE)
             stdout, stderr = process.communicate()
             self.assertTrue('The name of a user script/module must end in .py or .pyc.' in stderr)
             self.assertNotEquals(0, process.returncode)

--- a/src/toil/test/src/userDefinedJobArgTypeTest.py
+++ b/src/toil/test/src/userDefinedJobArgTypeTest.py
@@ -15,7 +15,8 @@
 from __future__ import absolute_import
 from builtins import object
 import sys
-from subprocess import check_call
+
+from toil import subprocess
 from toil.job import Job
 from toil.test import ToilTest, slow
 
@@ -55,7 +56,7 @@ class UserDefinedJobArgTypeTest(ToilTest):
     def _testFromMain(self):
         testMethodName = self.id().split('.')[-1]
         self.assertTrue(testMethodName.endswith('FromMain'))
-        check_call([sys.executable, '-m', self.__module__, testMethodName[:-8]])
+        subprocess.check_call([sys.executable, '-m', self.__module__, testMethodName[:-8]])
 
 
 class JobClass(Job):

--- a/src/toil/test/utils/ABCWorkflowDebug/debugWorkflow.py
+++ b/src/toil/test/utils/ABCWorkflowDebug/debugWorkflow.py
@@ -1,6 +1,6 @@
 from toil.job import Job
 from toil.common import Toil
-import subprocess
+from toil import subprocess
 import os
 import logging
 

--- a/src/toil/test/utils/toilDebugTest.py
+++ b/src/toil/test/utils/toilDebugTest.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 # from builtins import str
 
 import unittest
-import subprocess
+from toil import subprocess
 import os
 import shutil
 import logging

--- a/src/toil/test/utils/utilsTest.py
+++ b/src/toil/test/utils/utilsTest.py
@@ -19,7 +19,6 @@ import os
 import sys
 import uuid
 import shutil
-from subprocess import CalledProcessError, check_call
 import tempfile
 
 import pytest
@@ -27,6 +26,7 @@ import pytest
 import toil
 import logging
 import toil.test.sort.sort
+from toil import subprocess
 from toil import resolveEntryPoint
 from toil.job import Job
 from toil.lib.bioio import getTempFile, system
@@ -206,7 +206,7 @@ class UtilsTest(ToilTest):
                        '--badWorker=0.5',
                        '--badWorkerFailInterval=0.05']
         # Try restarting it to check that a JobStoreException is thrown
-        self.assertRaises(CalledProcessError, system, toilCommand + ['--restart'])
+        self.assertRaises(subprocess.CalledProcessError, system, toilCommand + ['--restart'])
         # Check that trying to run it in restart mode does not create the jobStore
         self.assertFalse(os.path.exists(self.toilDir))
 
@@ -215,14 +215,14 @@ class UtilsTest(ToilTest):
         try:
             system(toilCommand)
             finished = True
-        except CalledProcessError:  # This happens when the script fails due to having unfinished jobs
+        except subprocess.CalledProcessError:  # This happens when the script fails due to having unfinished jobs
             system(self.statusCommand())
-            self.assertRaises(CalledProcessError, system, self.statusCommand(failIfNotComplete=True))
+            self.assertRaises(subprocess.CalledProcessError, system, self.statusCommand(failIfNotComplete=True))
             finished = False
         self.assertTrue(os.path.exists(self.toilDir))
 
         # Try running it without restart and check an exception is thrown
-        self.assertRaises(CalledProcessError, system, toilCommand)
+        self.assertRaises(subprocess.CalledProcessError, system, toilCommand)
 
         # Now restart it until done
         totalTrys = 1
@@ -230,9 +230,9 @@ class UtilsTest(ToilTest):
             try:
                 system(toilCommand + ['--restart'])
                 finished = True
-            except CalledProcessError:  # This happens when the script fails due to having unfinished jobs
+            except subprocess.CalledProcessError:  # This happens when the script fails due to having unfinished jobs
                 system(self.statusCommand())
-                self.assertRaises(CalledProcessError, system, self.statusCommand(failIfNotComplete=True))
+                self.assertRaises(subprocess.CalledProcessError, system, self.statusCommand(failIfNotComplete=True))
                 if totalTrys > 16:
                     self.fail()  # Exceeded a reasonable number of restarts
                 totalTrys += 1
@@ -314,7 +314,7 @@ def printUnicodeCharacter():
     # We want to get a unicode character to stdout but we can't print it directly because of
     # Python encoding issues. To work around this we print in a separate Python process. See
     # http://stackoverflow.com/questions/492483/setting-the-correct-encoding-when-piping-stdout-in-python
-    check_call([sys.executable, '-c', "print '\\xc3\\xbc'"])
+    subprocess.check_call([sys.executable, '-c', "print '\\xc3\\xbc'"])
 
 class RunTwoJobsPerWorker(Job):
     """

--- a/src/toil/test/wdl/toilwdlTest.py
+++ b/src/toil/test/wdl/toilwdlTest.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import unittest
 import os
-import subprocess
+from toil import subprocess
 from toil.wdl.toilwdl import ToilWDL
 from toil.test import ToilTest, slow
 import zipfile

--- a/src/toil/wdl/toilwdl.py
+++ b/src/toil/wdl/toilwdl.py
@@ -23,7 +23,7 @@ import json
 import csv
 import os
 import collections
-import subprocess
+from toil import subprocess
 import logging
 import textwrap
 


### PR DESCRIPTION
Should be a clean replacement of the subprocess module with a backport of python 3.2's subprocess module (subprocess32) which fixes a number of bugs.  The only exception is `template_version.py` which cannot have dependencies and so summons the original subprocess module (this case is assumed to be harmless and unlikely to benefit from this update in any case).