### PR TITLE
Replace regex pattern in AzureJobStore to avoid backtracking.  Addresses #2079.

### DIFF
--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -107,7 +107,7 @@ class AzureJobStore(AbstractJobStore):
     # URLs where the may interfere with the certificate common name. We use a double underscore
     # as a separator instead.
     #
-    containerNameRe = re.compile(r'^[a-z0-9](-?[a-z0-9]+)+[a-z0-9]$')
+    containerNameRe = re.compile(r'^[a-z0-9][a-z0-9-]+[a-z0-9]$')
 
     # See https://msdn.microsoft.com/en-us/library/azure/dd135715.aspx
     #


### PR DESCRIPTION
Addresses #2079.

Should avoid a vulnerability pointed out thanks to James Davis over at Virginia Tech.