### PR TITLE
Fixes broken help menu.  Addresses #2081.

### DIFF
--- a/src/toil/utils/toilMain.py
+++ b/src/toil/utils/toilMain.py
@@ -59,4 +59,4 @@ def printHelp(modules):
     print(usage.format(
         name=os.path.basename(sys.argv[0]),
         commands='|'.join(iterkeys(modules)),
-        descriptions='\n'.join("%s - %s" % (n, m.__doc__.strip()) for n, m in iteritems(modules))))
+        descriptions='\n'.join("%s - %s" % (n, m.__doc__.strip()) for n, m in iteritems(modules) if m is not None)))

--- a/src/toil/utils/toilMain.py
+++ b/src/toil/utils/toilMain.py
@@ -59,4 +59,4 @@ def printHelp(modules):
     print(usage.format(
         name=os.path.basename(sys.argv[0]),
         commands='|'.join(iterkeys(modules)),
-        descriptions='\n'.join("%s - %s" % (n, m.__doc__.strip()) for n, m in iteritems(modules) if m is not None)))
+        descriptions='\n'.join("%s - %s" % (n, str(m.__doc__).strip()) for n, m in iteritems(modules) if m is not None)))

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Tool for reporting on job status.
+"""
 
 # python 2/3 compatibility imports
 from __future__ import absolute_import


### PR DESCRIPTION
Addresses #2081.

Currently if one pip installs toil and runs the command `toil --help`, toil breaks.  This PR fixes this.