### PR TITLE
Change "hot" to "remote"-deployment.  Addresses #2089.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ test_offline: check_venv check_build_reqs
 	TOIL_SKIP_DOCKER=True \
 		$(python) -m pytest $(pytest_args_local) $(tests_local)
 
-# The hot deployment test needs the docker appliance
+# The remote-deployment test needs the docker appliance
 test: check_venv check_build_reqs docker
 	TOIL_APPLIANCE_SELF=$(docker_registry)/$(docker_base_name):$(docker_tag) \
 	    $(python) -m pytest $(pytest_args_local) $(tests)

--- a/docs/developingWorkflows/developing.rst
+++ b/docs/developingWorkflows/developing.rst
@@ -920,8 +920,7 @@ dependency on Toil, you would have to hard-code a particular combination of
 extras (or no extras at all), robbing the user of the choice what Toil extras
 to install. Secondly, and more importantly, declaring a dependency on Toil
 would only lead to Toil being installed on the leader node of a cluster, but
-not the worker nodes. Hot-deployment does not work here because Toil cannot
-hot-deploy itself, the classic "Which came first, chicken or egg?" problem.
+not the worker nodes.
 
 In other words, you shouldn't explicitly depend on Toil. Document the
 dependency instead (as in "This workflow needs Toil version X.Y.Z to be

--- a/docs/running/amazon.rst
+++ b/docs/running/amazon.rst
@@ -21,6 +21,8 @@ that will dynamically scale depending on the workflow's needs.
 The :ref:`StaticProvisioning` section explains how a static cluster (one that
 won't automatically change in size) can be created and provisioned (grown, shrunk, destroyed, etc.).
 
+Currently, it's recommended that users do not run their scripts from system folders (``/var``, ``/``, or ``/tmp`` for example.).
+
 
 .. _EC2 instance type: https://aws.amazon.com/ec2/instance-types/
 

--- a/docs/running/amazon.rst
+++ b/docs/running/amazon.rst
@@ -130,7 +130,7 @@ look like::
 
 .. note::
 
-    If your toil workflow has dependencies have a look at the :ref:`remoteDeploying`
+    If your toil workflow has dependencies have a look at the :ref:`hotDeploying`
     section for a detailed explanation on how to include them.
 
 

--- a/docs/running/amazon.rst
+++ b/docs/running/amazon.rst
@@ -22,7 +22,7 @@ The :ref:`StaticProvisioning` section explains how a static cluster (one that
 won't automatically change in size) can be created and provisioned (grown, shrunk, destroyed, etc.).
 
 Currently, it's recommended that users do not run their scripts from system folders (``/var``, ``/``, or ``/tmp`` for example.).
-
+It's recommended to create a new folder such as ``/tmp/working`` as the working directory.
 
 .. _EC2 instance type: https://aws.amazon.com/ec2/instance-types/
 
@@ -130,7 +130,7 @@ look like::
 
 .. note::
 
-    If your toil workflow has dependencies have a look at the :ref:`hotDeploying`
+    If your toil workflow has dependencies have a look at the :ref:`remoteDeploying`
     section for a detailed explanation on how to include them.
 
 
@@ -139,7 +139,7 @@ look like::
 Running a Workflow with Autoscaling
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Autoscaling is a feature of running Toil in a cloud whereby additional cloud instances are launched to run the workflow.  Autoscaling leverages Mesos containers to provide an execution environment for these workflows.  
+Autoscaling is a feature of running Toil in a cloud whereby additional cloud instances are launched to run the workflow.  Autoscaling leverages Mesos containers to provide an execution environment for these workflows.
 
 
 

--- a/docs/running/deploying.rst
+++ b/docs/running/deploying.rst
@@ -84,7 +84,7 @@ From here, you can install your project and its dependencies::
        └── main.py
 
    3 directories, 5 files
-   $ pip install fairydust
+   $ pip install matplotlib
    $ cp -R workflow util venv/lib/python2.7/site-packages
 
 Ideally, your project would have a ``setup.py`` file (see `setuptools`_) which
@@ -110,7 +110,7 @@ Or, if your project has been published to PyPI::
    $ pip install my-project
 
 In each case, we have created a virtualenv with the ``--system-site-packages``
-flag in the ``venv`` subdirectory then installed the ``fairydust`` distribution
+flag in the ``venv`` subdirectory then installed the ``matplotlib`` distribution
 from PyPI along with the two packages that our project consists of. (Again, both
 Python and Toil are assumed to be present on the leader and all worker nodes.)
 We can now run our workflow::

--- a/docs/running/deploying.rst
+++ b/docs/running/deploying.rst
@@ -40,7 +40,7 @@ The script can have dependencies, as long as those are installed on the machine,
 either globally, in a user-specific location or in a virtualenv. In the latter
 case, the virtualenv must of course be active when you run the user script.
 
-.. _remoteDeploying:
+.. _hotDeploying:
 
 Deploying a Remote Workflow
 ---------------------------
@@ -49,15 +49,15 @@ multiple worker machines, either in the cloud or on a bare-metal cluster, your
 script needs to be made available to those other machines. If your script
 imports other modules, those modules also need to be made available on the
 workers. Toil can automatically do that for you, with a little help on your
-part. We call this feature *remote-deployment* of a workflow.
+part. We call this feature *hot-deployment* of a workflow.
 
-Let's first examine various scenarios of remote-deploying a workflow and then take
+Let's first examine various scenarios of hot-deploying a workflow and then take
 a look at :ref:`deploying Toil <deploying_toil>`, which, as we'll see shortly
-cannot be remotely deployed. Lastly we'll deal with the issue of declaring
+cannot be hot-deployed. Lastly we'll deal with the issue of declaring
 :ref:`Toil as a dependency <depending_on_toil>` of a workflow that is packaged
 as a setuptools distribution.
 
-Toil can be easily deployed to a remote host, given that both Python and Toil
+Toil can be easily hot-deployed to a remote host, given that both Python and Toil
 are present. The first order of business after copying your workflow to each
 host is to create and activate a virtualenv::
 
@@ -82,7 +82,7 @@ From here, you can install your project and its dependencies::
        └── main.py
 
    3 directories, 5 files
-   $ pip install fairydust
+   $ pip install matplotlib
    $ cp -R workflow util venv/lib/python2.7/site-packages
 
 Ideally, your project would have a ``setup.py`` file (see `setuptools`_) which
@@ -108,7 +108,7 @@ Or, if your project has been published to PyPI::
    $ pip install my-project
 
 In each case, we have created a virtualenv with the ``--system-site-packages``
-flag in the ``venv`` subdirectory then installed the ``fairydust`` distribution
+flag in the ``venv`` subdirectory then installed the ``matplotlib`` distribution
 from PyPI along with the two packages that our project consists of. (Again, both
 Python and Toil are assumed to be present on the leader and all worker nodes.)
 We can now run our workflow::
@@ -124,7 +124,7 @@ We can now run our workflow::
 
    Neither ``python setup.py develop`` nor ``pip install -e .`` can be used in
    this process as, instead of copying the source files, they create ``.egg-link``
-   files that Toil can't remotely-deploy. Similarly, ``python setup.py install``
+   files that Toil can't hot-deploy. Similarly, ``python setup.py install``
    doesn't work either as it installs the project as a Python ``.egg`` which is
    also not currently supported by Toil (though it `could be`_ in the future).
 
@@ -137,7 +137,7 @@ We can now run our workflow::
 .. _setuptools: http://setuptools.readthedocs.io/en/latest/index.html
 .. _could be: https://github.com/BD2KGenomics/toil/issues/1367
 
-Remote deployment with sibling modules
+Hot deployment with sibling modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This scenario applies if the user script imports modules that are its siblings::
@@ -150,15 +150,15 @@ This scenario applies if the user script imports modules that are its siblings::
 Here ``userScript.py`` imports additional functionality from ``utilities.py``.
 Toil detects that ``userScript.py`` has sibling modules and copies them to the
 workers, alongside the user script. Note that sibling modules will be
-remotely-deployed regardless of whether they are actually imported by the user
+hot-deployed regardless of whether they are actually imported by the user
 script–all .py files residing in the same directory as the user script will
-automatically be remotely-deployed.
+automatically be hot-deployed.
 
 Sibling modules are a suitable method of organizing the source code of
 reasonably complicated workflows.
 
 
-Remotely deploying a package hierarchy
+Hot deploying a package hierarchy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Recall that in Python, a `package`_ is a directory containing one or more
 ``.py`` files—one of which must be called ``__init__.py``—and optionally other

--- a/docs/running/deploying.rst
+++ b/docs/running/deploying.rst
@@ -5,6 +5,7 @@ Deploying a Workflow
 You can deploy a workflow locally (on a single machine) or remotely (i.e. distributed on a cluster), as described below.
 
 Currently, it's recommended that users do not run their scripts from system folders (``/var``, ``/``, or ``/tmp`` for example.).
+It's recommended to create a new folder such as ``/tmp/working`` as the working directory.
 
 .. _localDeploying:
 
@@ -40,7 +41,7 @@ The script can have dependencies, as long as those are installed on the machine,
 either globally, in a user-specific location or in a virtualenv. In the latter
 case, the virtualenv must of course be active when you run the user script.
 
-.. _hotDeploying:
+.. _remoteDeploying:
 
 Deploying a Remote Workflow
 ---------------------------
@@ -49,15 +50,16 @@ multiple worker machines, either in the cloud or on a bare-metal cluster, your
 script needs to be made available to those other machines. If your script
 imports other modules, those modules also need to be made available on the
 workers. Toil can automatically do that for you, with a little help on your
-part. We call this feature *hot-deployment* of a workflow.
+part. We call this feature *remote-deployment* of a workflow.
 
-Let's first examine various scenarios of hot-deploying a workflow and then take
+Let's first examine various scenarios of remote-deploying a workflow and then take
 a look at :ref:`deploying Toil <deploying_toil>`, which, as we'll see shortly
-cannot be hot-deployed. Lastly we'll deal with the issue of declaring
+cannot be remotely deployed. Lastly we'll deal with the issue of declaring
 :ref:`Toil as a dependency <depending_on_toil>` of a workflow that is packaged
 as a setuptools distribution.
 
-Toil can be easily hot-deployed to a remote host, given that both Python and Toil
+
+Toil can be easily deployed to a remote host, given that both Python and Toil
 are present. The first order of business after copying your workflow to each
 host is to create and activate a virtualenv::
 
@@ -82,7 +84,7 @@ From here, you can install your project and its dependencies::
        └── main.py
 
    3 directories, 5 files
-   $ pip install matplotlib
+   $ pip install fairydust
    $ cp -R workflow util venv/lib/python2.7/site-packages
 
 Ideally, your project would have a ``setup.py`` file (see `setuptools`_) which
@@ -108,7 +110,7 @@ Or, if your project has been published to PyPI::
    $ pip install my-project
 
 In each case, we have created a virtualenv with the ``--system-site-packages``
-flag in the ``venv`` subdirectory then installed the ``matplotlib`` distribution
+flag in the ``venv`` subdirectory then installed the ``fairydust`` distribution
 from PyPI along with the two packages that our project consists of. (Again, both
 Python and Toil are assumed to be present on the leader and all worker nodes.)
 We can now run our workflow::
@@ -124,7 +126,7 @@ We can now run our workflow::
 
    Neither ``python setup.py develop`` nor ``pip install -e .`` can be used in
    this process as, instead of copying the source files, they create ``.egg-link``
-   files that Toil can't hot-deploy. Similarly, ``python setup.py install``
+   files that Toil can't remotely-deploy. Similarly, ``python setup.py install``
    doesn't work either as it installs the project as a Python ``.egg`` which is
    also not currently supported by Toil (though it `could be`_ in the future).
 
@@ -137,7 +139,7 @@ We can now run our workflow::
 .. _setuptools: http://setuptools.readthedocs.io/en/latest/index.html
 .. _could be: https://github.com/BD2KGenomics/toil/issues/1367
 
-Hot deployment with sibling modules
+Remote deployment with sibling modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This scenario applies if the user script imports modules that are its siblings::
@@ -150,15 +152,15 @@ This scenario applies if the user script imports modules that are its siblings::
 Here ``userScript.py`` imports additional functionality from ``utilities.py``.
 Toil detects that ``userScript.py`` has sibling modules and copies them to the
 workers, alongside the user script. Note that sibling modules will be
-hot-deployed regardless of whether they are actually imported by the user
+remotely-deployed regardless of whether they are actually imported by the user
 script–all .py files residing in the same directory as the user script will
-automatically be hot-deployed.
+automatically be remotely-deployed.
 
 Sibling modules are a suitable method of organizing the source code of
 reasonably complicated workflows.
 
 
-Hot deploying a package hierarchy
+Remotely deploying a package hierarchy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Recall that in Python, a `package`_ is a directory containing one or more
 ``.py`` files—one of which must be called ``__init__.py``—and optionally other
@@ -241,4 +243,3 @@ Toil comes with the Toil Appliance, a Docker image with Mesos and Toil baked in.
 It's easily deployed, only needs Docker, and allows for workflows to be run in
 single-machine mode and for clusters of VMs to be provisioned. For more
 information, see the :ref:`runningAWS` section.
-

--- a/docs/running/deploying.rst
+++ b/docs/running/deploying.rst
@@ -4,6 +4,8 @@ Deploying a Workflow
 ====================
 You can deploy a workflow locally (on a single machine) or remotely (i.e. distributed on a cluster), as described below.
 
+Currently, it's recommended that users do not run their scripts from system folders (``/var``, ``/``, or ``/tmp`` for example.).
+
 .. _localDeploying:
 
 Deploying a Local Workflow
@@ -54,7 +56,6 @@ a look at :ref:`deploying Toil <deploying_toil>`, which, as we'll see shortly
 cannot be remotely deployed. Lastly we'll deal with the issue of declaring
 :ref:`Toil as a dependency <depending_on_toil>` of a workflow that is packaged
 as a setuptools distribution.
-
 
 Toil can be easily deployed to a remote host, given that both Python and Toil
 are present. The first order of business after copying your workflow to each

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -57,9 +57,9 @@ class AbstractBatchSystem(with_metaclass(ABCMeta, object)):
 
     # noinspection PyMethodParameters
     @abstractclassmethod
-    def supportsHotDeployment(cls):
+    def supportsRemoteDeployment(cls):
         """
-        Whether this batch system supports hot deployment of the user script itself. If it does,
+        Whether this batch system supports remote-deployment of the user script itself. If it does,
         the :meth:`.setUserScript` can be invoked to set the resource object representing the user
         script.
 
@@ -87,7 +87,7 @@ class AbstractBatchSystem(with_metaclass(ABCMeta, object)):
     def setUserScript(self, userScript):
         """
         Set the user script for this workflow. This method must be called before the first job is
-        issued to this batch system, and only if :meth:`.supportsHotDeployment` returns True,
+        issued to this batch system, and only if :meth:`.supportsRemoteDeployment` returns True,
         otherwise it will raise an exception.
 
         :param toil.resource.Resource userScript: the resource object representing the user script

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
     """
     A partial implementation of BatchSystemSupport for batch systems run on a
-    standard HPC cluster. By default worker cleanup and hot deployment are not
+    standard HPC cluster. By default worker cleanup and remote-deployment are not
     implemented.
     """
 
@@ -314,7 +314,7 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
         return False
 
     @classmethod
-    def supportsHotDeployment(cls):
+    def supportsRemoteDeployment(cls):
         return False
 
     def issueBatchJob(self, jobNode):

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -166,7 +166,7 @@ class LSFBatchSystem(BatchSystemLocalSupport):
         return False
 
     @classmethod
-    def supportsHotDeployment(cls):
+    def supportsRemoteDeployment(cls):
         return False
 
     def shutdown(self):

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -66,7 +66,7 @@ class MesosBatchSystem(BatchSystemLocalSupport,
     """
 
     @classmethod
-    def supportsHotDeployment(cls):
+    def supportsRemoteDeployment(cls):
         return True
 
     @classmethod
@@ -84,7 +84,7 @@ class MesosBatchSystem(BatchSystemLocalSupport,
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         super(MesosBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
 
-        # The hot-deployed resource representing the user script. Will be passed along in every
+        # The remote-deployed resource representing the user script. Will be passed along in every
         # Mesos task. Also see setUserScript().
         self.userScript = None
         """

--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -106,10 +106,10 @@ def addOptions(addOptionFn, config):
     addOptionFn("--batchSystem", dest="batchSystem", default=defaultBatchSystem(),
                 help=("The type of batch system to run the job(s) with, currently can be one "
                       "of %s'. default=%s" % (', '.join(uniqueNames()), defaultBatchSystem())))
-    addOptionFn("--disableHotDeployment", dest="disableHotDeployment", action='store_true', default=None,
-                help=("Should hot-deployment of the user script be deactivated? If True, the user "
-                      "script/package should be present at the same location on all workers. "
-                      "default=false"))
+    addOptionFn("--disableRemoteDeployment", "--disableHotDeployment", dest="disableRemoteDeployment",
+                action='store_true', default=None,
+                help=("Remote-deployment=True copies the toil virtualenv and user script to the same location "
+                "on all workers automatically.  The default is False."))
 
     for o in _options:
         o(addOptionFn, config)
@@ -120,7 +120,7 @@ def setDefaultOptions(config):
     object is not constructed from an Options object.
     """
     config.batchSystem = "singleMachine"
-    config.disableHotDeployment = False
+    config.disableRemoteDeployment = False
     config.environment = {}
     config.statePollingWait = 1 # seconds
 

--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -106,10 +106,14 @@ def addOptions(addOptionFn, config):
     addOptionFn("--batchSystem", dest="batchSystem", default=defaultBatchSystem(),
                 help=("The type of batch system to run the job(s) with, currently can be one "
                       "of %s'. default=%s" % (', '.join(uniqueNames()), defaultBatchSystem())))
-    addOptionFn("--disableRemoteDeployment", "--disableHotDeployment", dest="disableRemoteDeployment",
+    addOptionFn("--disableHotDeployment", dest="disableRemoteDeployment",
                 action='store_true', default=None,
-                help=("Remote-deployment=True copies the toil virtualenv and user script to the same location "
-                "on all workers automatically.  The default is False."))
+                help=("Deprecated, use --disableRemoteDeployment instead.  Hot-Deployment is the old phrase for "
+                "Remote-Deployment and has been left as a deprecated option for backwards compatibility."))
+    addOptionFn("--disableRemoteDeployment", dest="disableRemoteDeployment",
+                action='store_true', default=None,
+                help=("--disableRemoteDeployment=False copies the toil virtualenv and user script to the same location "
+                      "on all workers automatically.  The default is False."))
 
     for o in _options:
         o(addOptionFn, config)

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -51,7 +51,7 @@ class ParasolBatchSystem(BatchSystemSupport):
         return False
 
     @classmethod
-    def supportsHotDeployment(cls):
+    def supportsRemoteDeployment(cls):
         return False
 
     def __init__(self, config, maxCores, maxMemory, maxDisk):

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -48,7 +48,7 @@ class SingleMachineBatchSystem(BatchSystemSupport):
     """
 
     @classmethod
-    def supportsHotDeployment(cls):
+    def supportsRemoteDeployment(cls):
         return False
 
     @classmethod

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -213,7 +213,7 @@ class Config(object):
         #Batch system options
         setOption("batchSystem")
         setBatchOptions(self, setOption)
-        setOption("disableHotDeployment")
+        setOption("disableRemoteDeployment")
         setOption("scale", float, fC(0.0))
         setOption("mesosMasterAddress")
         setOption("parasolCommand")
@@ -724,7 +724,7 @@ class Toil(object):
                                        'Toil.restart() to resume it.')
 
         self._batchSystem = self.createBatchSystem(self.config)
-        self._setupHotDeployment(rootJob.getUserScript())
+        self._setupRemoteDeployment(rootJob.getUserScript())
         try:
             self._setBatchSystemEnvVars()
             self._serialiseEnv()
@@ -767,7 +767,7 @@ class Toil(object):
             return self._jobStore.getRootJobReturnValue()
 
         self._batchSystem = self.createBatchSystem(self.config)
-        self._setupHotDeployment()
+        self._setupRemoteDeployment()
         try:
             self._setBatchSystemEnvVars()
             self._serialiseEnv()
@@ -875,10 +875,10 @@ class Toil(object):
 
         return batchSystemClass(**kwargs)
 
-    def _setupHotDeployment(self, userScript=None):
+    def _setupRemoteDeployment(self, userScript=None):
         """
         Determine the user script, save it to the job store and inject a reference to the saved
-        copy into the batch system such that it can hot-deploy the resource on the worker
+        copy into the batch system such that it can remote-deploy the resource on the worker
         nodes.
 
         :param toil.resource.ModuleDescriptor userScript: the module descriptor referencing the
@@ -887,11 +887,11 @@ class Toil(object):
         if userScript is not None:
             # This branch is hit when a workflow is being started
             if userScript.belongsToToil:
-                logger.info('User script %s belongs to Toil. No need to hot-deploy it.', userScript)
+                logger.info('User script %s belongs to Toil. No need to remote-deploy it.', userScript)
                 userScript = None
             else:
-                if (self._batchSystem.supportsHotDeployment() and
-                        not self.config.disableHotDeployment):
+                if (self._batchSystem.supportsRemoteDeployment() and
+                        not self.config.disableRemoteDeployment):
                     # Note that by saving the ModuleDescriptor, and not the Resource we allow for
                     # redeploying a potentially modified user script on workflow restarts.
                     with self._jobStore.writeSharedFileStream('userScript') as f:
@@ -899,7 +899,7 @@ class Toil(object):
                 else:
                     from toil.batchSystems.singleMachine import SingleMachineBatchSystem
                     if not isinstance(self._batchSystem, SingleMachineBatchSystem):
-                        logger.warn('Batch system does not support hot-deployment. The user '
+                        logger.warn('Batch system does not support remote-deployment. The user '
                                     'script %s will have to be present at the same location on '
                                     'every worker.', userScript)
                     userScript = None
@@ -913,7 +913,7 @@ class Toil(object):
                 logger.info('User script neither set explicitly nor present in the job store.')
                 userScript = None
         if userScript is None:
-            logger.info('No user script to hot-deploy.')
+            logger.info('No user script to remote-deploy.')
         else:
             logger.debug('Saving user script %s as a resource', userScript)
             userScriptResource = userScript.saveAsResourceTo(self._jobStore)

--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -414,7 +414,7 @@ class ModuleDescriptor(namedtuple('ModuleDescriptor', ('dirPath', 'name', 'fromV
             dirPath = os.path.sep.join(filePath)
         log.debug("Module dir is %s", dirPath)
         require(os.path.isdir(dirPath),
-                'Bad directory path %s for module %s. Note that hot-deployment does not support \
+                'Bad directory path %s for module %s. Note that remote-deployment does not support \
                 .egg-link files yet, or scripts located in the root directory.', dirPath, name)
         fromVirtualEnv = inVirtualEnv() and dirPath.startswith(sys.prefix)
         return cls(dirPath=dirPath, name=name, fromVirtualEnv=fromVirtualEnv)
@@ -461,7 +461,7 @@ class ModuleDescriptor(namedtuple('ModuleDescriptor', ('dirPath', 'name', 'fromV
 
     def _getResourceClass(self):
         """
-        Return the concrete subclass of Resource that's appropriate for hot-deploying this module.
+        Return the concrete subclass of Resource that's appropriate for remote-deploying this module.
         """
         if self.fromVirtualEnv:
             subcls = VirtualEnvResource

--- a/src/toil/test/src/remoteDeploymentTest.py
+++ b/src/toil/test/src/remoteDeploymentTest.py
@@ -15,17 +15,17 @@ log = logging.getLogger(__name__)
 @needs_mesos
 @needs_appliance
 @slow
-class HotDeploymentTest(ApplianceTestSupport):
+class RemoteDeploymentTest(ApplianceTestSupport):
     """
-    Tests various hot-deployment scenarios. Using the appliance, i.e. a docker container,
+    Tests various remote-deployment scenarios. Using the appliance, i.e. a docker container,
     for these tests allows for running worker processes on the same node as the leader process
     while keeping their file systems separate from each other and the leader process. Separate
-    file systems are crucial to prove that hot-deployment does its job.
+    file systems are crucial to prove that remote-deployment does its job.
     """
 
     def setUp(self):
         logging.basicConfig(level=logging.INFO)
-        super(HotDeploymentTest, self).setUp()
+        super(RemoteDeploymentTest, self).setUp()
 
     @contextmanager
     def _venvApplianceCluster(self):
@@ -46,7 +46,7 @@ class HotDeploymentTest(ApplianceTestSupport):
 
     def testRestart(self):
         """
-        Test whether hot-deployment works on restart.
+        Test whether remote-deployment works on restart.
         """
         with self._venvApplianceCluster() as (leader, worker):
             def userScript():
@@ -91,8 +91,8 @@ class HotDeploymentTest(ApplianceTestSupport):
 
     def testSplitRootPackages(self):
         """
-        Test whether hot-deployment works with a virtualenv in which jobs are defined in
-        completely separate branches of the package hierarchy. Initially, hot deployment did
+        Test whether remote-deployment works with a virtualenv in which jobs are defined in
+        completely separate branches of the package hierarchy. Initially, remote-deployment did
         deploy the entire virtualenv but jobs could only be defined in one branch of the package
         hierarchy. We define a branch as the maximum set of fully qualified package paths that
         share the same first component. IOW, a.b and a.c are in the same branch, while a.b and
@@ -120,7 +120,7 @@ class HotDeploymentTest(ApplianceTestSupport):
                 # noinspection PyUnusedLocal
                 def job(job, disk='10M', cores=1, memory='10M'):
                     # Double the requirements to prevent chaining as chaining might hide problems
-                    # in hot deployment code.
+                    # in remote-deployment code.
                     job.addChildJobFn(libraryJob, disk='20M', cores=cores, memory=memory)
 
                 if __name__ == '__main__':
@@ -178,7 +178,7 @@ class HotDeploymentTest(ApplianceTestSupport):
                         r = toil.start(Job.wrapJobFn(job, x).encapsulate())
                     # Assert that the return value is of type X, but not X from the __main__
                     # module but X from foo.bar, the canonical name for the user module. The
-                    # translation from __main__ to foo.bar is a side effect of hot-deployment.
+                    # translation from __main__ to foo.bar is a side effect of remote-deployment.
                     assert r.__class__ is not X
                     import foo.bar
                     assert r.__class__ is foo.bar.X
@@ -341,7 +341,7 @@ class HotDeploymentTest(ApplianceTestSupport):
 
         `Encapsulated` has two children to ensure that `Follow-on` is run in a new worker. That's
         the only way to guarantee that the user script has not been loaded yet, which would cause
-        the test to succeed coincidentally. We want to test that hot-deploying and loading of the
+        the test to succeed coincidentally. We want to test that remote-deploying and loading of the
         user script are done properly *before* deferred functions are being run and before any
         jobs have been executed by that worker.
         """

--- a/src/toil/test/src/resourceTest.py
+++ b/src/toil/test/src/resourceTest.py
@@ -185,7 +185,7 @@ class ResourceTest(ToilTest):
     def testNonPyStandAlone(self):
         """
         Asserts that Toil enforces the user script to have a .py or .pyc extension because that's
-        the only way hot deployment can re-import the module on a worker. See
+        the only way remote-deployment can re-import the module on a worker. See
 
         https://github.com/BD2KGenomics/toil/issues/631 and
         https://github.com/BD2KGenomics/toil/issues/858


### PR DESCRIPTION
`Hot-deployment` was renamed `remote-deployment` for some reason in one part of the docs but nowhere else.  The current explanation of `hot-deployment` is documented here: http://toil.readthedocs.io/en/latest/running/deploying.html?highlight=remote-deployment

However, this was done improperly.  Some of the docs still mention `hot-deployment`, the test file is still called `hotDeploymentTest.py`, there are mentions of hot-deployment in many code comments (which in docstrings carries over to the API docs), there's an option called `--disableHotDeployment` and even functions like `supportsHotDeployment(cls)`.  This PR addresses this and reverts back this small section to `hot-deployment`.

Also took out `pip install fairydust` which is a fake PyPi and can confuse the easily confused like myself.  I used `matplotlib` as an example instead.