### PR TITLE
Change sort.py memory.

### DIFF
--- a/src/toil/test/sort/sort.py
+++ b/src/toil/test/sort/sort.py
@@ -29,7 +29,7 @@ from toil.job import Job
 
 defaultLines = 1000
 defaultLineLen = 50
-sortMemory = '1000M'
+sortMemory = '200M'
 
 
 def setup(job, inputFile, N, downCheckpoints, options):


### PR DESCRIPTION
Changes the amount of memory that the sort example requires.  I want to see if this fixes our flaky tests in the short term (though resource allocation in the long term should be reworked because this seems like a symptom of a different problem).