### PR TITLE
Fix flaky tests by lowering sort.py memory requirements.

### DIFF
--- a/attic/toil-sort-example.py
+++ b/attic/toil-sort-example.py
@@ -17,7 +17,7 @@ def setup(job, input_file_id, n, down_checkpoints):
     return job.addChildJobFn(down,
                              input_file_id, n,
                              down_checkpoints=down_checkpoints,
-                             memory='1000M').rv()
+                             memory='600M').rv()
 
 
 def down(job, input_file_id, n, down_checkpoints):
@@ -45,10 +45,10 @@ def down(job, input_file_id, n, down_checkpoints):
 
         # Call the down function recursively
         return job.addFollowOnJobFn(up, job.addChildJobFn(down, job.fileStore.writeGlobalFile(t1), n,
-                                    down_checkpoints=down_checkpoints, memory='1000M').rv(),
+                                    down_checkpoints=down_checkpoints, memory='600M').rv(),
                                     job.addChildJobFn(down, job.fileStore.writeGlobalFile(t2), n,
                                                       down_checkpoints=down_checkpoints,
-                                                      memory='1000M').rv()).rv()
+                                                      memory='600M').rv()).rv()
     else:
         # We can sort this bit of the file
         job.fileStore.logToMaster("Sorting file: %s of size: %s"
@@ -163,7 +163,7 @@ def main():
         sort_file_url = 'file://' + os.path.abspath('file_to_sort.txt')
         if not toil.options.restart:
             sort_file_id = toil.importFile(sort_file_url)
-            sorted_file_id = toil.start(Job.wrapJobFn(setup, sort_file_id, int(options.N), False, memory='1000M'))
+            sorted_file_id = toil.start(Job.wrapJobFn(setup, sort_file_id, int(options.N), False, memory='600M'))
         else:
             sorted_file_id = toil.restart()
         toil.exportFile(sorted_file_id, sort_file_url)

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -440,7 +440,8 @@ class MesosBatchSystem(BatchSystemLocalSupport,
                     remainingMemory -= toMiB(jobType.memory)
                     remainingDisk -= toMiB(jobType.disk)
                     nextToLaunchIndex += 1
-                else:
+                if not self.jobQueues.typeEmpty(jobType):
+                    # report that remaining jobs cannot be run with the current resourcesq:
                     log.debug('Offer %(offer)s not suitable to run the tasks with requirements '
                               '%(requirements)r. Mesos offered %(memory)s memory, %(cores)s cores '
                               'and %(disk)s of disk on a %(non)spreemptable slave.',

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -44,7 +44,7 @@ from toil.provisioners import (awsRemainingBillingInterval, awsFilterImpairedNod
                                Node, NoSuchClusterException)
 
 logger = logging.getLogger(__name__)
-
+logging.getLogger("boto").setLevel(logging.WARNING)
 
 def awsRetryPredicate(e):
     if not isinstance(e, BotoServerError):

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -314,7 +314,7 @@ class AWSAutoscaleTestMultipleNodeTypes(AbstractAWSAutoscaleTest):
         #Set memory requirements so that sort jobs can be run
         # on small instances, but merge jobs must be run on large
         # instances
-        runCommand = ['/home/venv/bin/python', '/home/sort.py', '--fileToSort=/home/s3am/bin/asadmin', '--sortMemory=1.0G', '--mergeMemory=3.0G']
+        runCommand = ['/home/venv/bin/python', '/home/sort.py', '--fileToSort=/home/s3am/bin/asadmin', '--sortMemory=0.6G', '--mergeMemory=3.0G']
         runCommand.extend(toilOptions)
         runCommand.append('--sseKey=/home/keyFile')
         self.sshUtil(runCommand)

--- a/src/toil/test/provisioners/gceProvisionerTest.py
+++ b/src/toil/test/provisioners/gceProvisionerTest.py
@@ -283,7 +283,7 @@ class GCEAutoscaleTestMultipleNodeTypes(AbstractGCEAutoscaleTest):
         #Set memory requirements so that sort jobs can be run
         # on small instances, but merge jobs must be run on large
         # instances
-        runCommand = ['/home/venv/bin/python', '/home/sort.py', '--fileToSort=/home/s3am/bin/asadmin', '--sortMemory=1.0G', '--mergeMemory=3.0G']
+        runCommand = ['/home/venv/bin/python', '/home/sort.py', '--fileToSort=/home/s3am/bin/asadmin', '--sortMemory=0.6G', '--mergeMemory=3.0G']
         runCommand.extend(toilOptions)
         runCommand.append('--sseKey=/home/keyFile')
         log.info("_runScript: %s" % ''.join(runCommand))

--- a/src/toil/test/sort/sort.py
+++ b/src/toil/test/sort/sort.py
@@ -29,7 +29,7 @@ from toil.job import Job
 
 defaultLines = 1000
 defaultLineLen = 50
-sortMemory = '1000M'
+sortMemory = '600M'
 
 
 def setup(job, inputFile, N, downCheckpoints, options):
@@ -43,7 +43,7 @@ def setup(job, inputFile, N, downCheckpoints, options):
                              downCheckpoints,
                              options = options,
                              preemptable=True,
-                             memory='1000M').rv()
+                             memory=sortMemory).rv()
 
 
 def down(job, inputFileStoreID, N, downCheckpoints, options, memory=sortMemory):


### PR DESCRIPTION
Changes the amount of memory that the sort example requires. I want to see if this fixes our flaky tests in the short term (though resource allocation in the long term should be reworked because this seems like a symptom of a different problem).