### PR TITLE
GCE fixes - closes #2096

### DIFF
--- a/src/toil/provisioners/gceProvisioner.py
+++ b/src/toil/provisioners/gceProvisioner.py
@@ -541,10 +541,12 @@ class GCEProvisioner(AbstractProvisioner):
             # If this field is not found in the extra meta-data, assume the node is not preemptable.
             if scheduling and scheduling.get('preemptible', False) != preemptable:
                 continue
+            isWorker = True
             for ip in instance.private_ips[0]:
                 if ip == self.leaderIP:
-                    continue # don't include the leader
-            if instance.state == 'running':
+                    isWorker = False
+                    break # don't include the leader
+            if isWorker and instance.state == 'running':
                 workerInstances.append(instance)
 
         logger.debug('All workers found in cluster: %s', workerInstances)

--- a/src/toil/provisioners/gceProvisioner.py
+++ b/src/toil/provisioners/gceProvisioner.py
@@ -789,7 +789,7 @@ class GCEProvisioner(AbstractProvisioner):
         startTime = time.time()
         while True:
             if time.time() - startTime > cls.maxWaitTime:
-                logger.error("Key propagation failed on machine with ip" % instanceIP)
+                logger.error("Key propagation failed on machine with ip %s" % instanceIP)
                 return False
             try:
                 logger.info('Attempting to establish SSH connection...')
@@ -810,7 +810,7 @@ class GCEProvisioner(AbstractProvisioner):
         startTime = time.time()
         while True:
             if time.time() - startTime > cls.maxWaitTime:
-                logger.error("Docker daemon failed to start on machine with ip" % ip_address)
+                logger.error("Docker daemon failed to start on machine with ip %s" % ip_address)
                 return False
             try:
                 output = cls._sshInstance(ip_address, '/usr/bin/ps', 'aux', sshOptions=['-oBatchMode=yes'], user=keyName)

--- a/src/toil/provisioners/gceProvisioner.py
+++ b/src/toil/provisioners/gceProvisioner.py
@@ -542,7 +542,7 @@ class GCEProvisioner(AbstractProvisioner):
             if scheduling and scheduling.get('preemptible', False) != preemptable:
                 continue
             isWorker = True
-            for ip in instance.private_ips[0]:
+            for ip in instance.private_ips:
                 if ip == self.leaderIP:
                     isWorker = False
                     break # don't include the leader

--- a/src/toil/test/provisioners/gceProvisionerTest.py
+++ b/src/toil/test/provisioners/gceProvisionerTest.py
@@ -172,7 +172,7 @@ class AbstractGCEAutoscaleTest(ToilTest):
 
 
 
-@pytest.mark.timeout(1200)
+@pytest.mark.timeout(1600)
 class GCEAutoscaleTest(AbstractGCEAutoscaleTest):
 
     def __init__(self, name):
@@ -218,11 +218,11 @@ class GCEAutoscaleTest(AbstractGCEAutoscaleTest):
     @needs_google
     def testSpotAutoScale(self):
         self.instanceTypes = ["n1-standard-2:%f" % self.spotBid]
-        self.numWorkers = ['2']
+        self.numWorkers = ['3']
         self._test(preemptableJobs=True)
 
 
-@pytest.mark.timeout(1200)
+@pytest.mark.timeout(1600)
 class GCEStaticAutoscaleTest(GCEAutoscaleTest):
     """
     Runs the tests on a statically provisioned cluster with autoscaling enabled.

--- a/src/toil/test/provisioners/gceProvisionerTest.py
+++ b/src/toil/test/provisioners/gceProvisionerTest.py
@@ -218,7 +218,9 @@ class GCEAutoscaleTest(AbstractGCEAutoscaleTest):
     @needs_google
     def testSpotAutoScale(self):
         self.instanceTypes = ["n1-standard-2:%f" % self.spotBid]
-        self.numWorkers = ['3']
+        # Some spot workers have a stopped state after being started, strangely.
+        # This could be the natural preemption process, but it seems too rapid.
+        self.numWorkers = ['3'] # Try 3 to account for a stopped node.
         self._test(preemptableJobs=True)
 
 


### PR DESCRIPTION
* Some tests were timing out too early.
* Some nodes were in a stopped state. Changed getProvisionedWorkers to only return running nodes.
* Implemented the preemptable option for getProvsionedWorkers