### PR TITLE
Autoscaler revamp

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -39,7 +39,7 @@ except ImportError:
 # Python 3 compatibility imports
 from six import iteritems
 
-from bd2k.util.humanize import bytes2human
+from toil.lib.humanize import bytes2human
 from bd2k.util.retry import retry
 
 from toil import logProcessContext

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 Regents of the University of California
+# Copyright (C) 2015-2016 Regents of the University of California
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ from toil import lookupEnvVar
 from toil.version import dockerRegistry, dockerTag
 
 # aim to pack autoscaling jobs within a 20 minute block before provisioning a new node
-defaultTargetTime = 1200
+defaultTargetTime = 1800
 logger = logging.getLogger(__name__)
 
 
@@ -103,7 +103,7 @@ class Config(object):
         # Parameters to limit service jobs, so preventing deadlock scheduling scenarios
         self.maxPreemptableServiceJobs = sys.maxsize
         self.maxServiceJobs = sys.maxsize
-        self.deadlockWait = 80  # Wait 80 seconds before declaring a deadlock
+        self.deadlockWait = 60  # Wait 80 seconds before declaring a deadlock
         self.statePollingWait = 1  # Wait 1 seconds before querying job state
 
         # Resource requirements

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -49,11 +49,11 @@ from toil.batchSystems.options import addOptions as addBatchOptions
 from toil.batchSystems.options import setDefaultOptions as setDefaultBatchOptions
 from toil.batchSystems.options import setOptions as setBatchOptions
 from toil.provisioners import clusterFactory
-from toil.provisioners.clusterScaler import defaultTargetTime
-
 from toil import lookupEnvVar
 from toil.version import dockerRegistry, dockerTag
 
+
+defaultTargetTime = 1800
 logger = logging.getLogger(__name__)
 
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -231,6 +231,8 @@ class Config(object):
         setOption("minNodes", parseIntList)
         setOption("maxNodes", parseIntList)
         setOption("alphaTime", int)
+        if self.alphaTime <= 0:
+            raise RuntimeError('alphaTime must be a positive integer (was set to %s)' % self.alphaTime)
         setOption("betaInertia", float)
         setOption("scaleInterval", float)
         setOption("metrics")

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -52,7 +52,7 @@ from toil.provisioners import clusterFactory
 from toil import lookupEnvVar
 from toil.version import dockerRegistry, dockerTag
 
-# aim to pack autoscaling jobs within a 20 minute block before provisioning a new node
+# aim to pack autoscaling jobs within a 30 minute block before provisioning a new node
 defaultTargetTime = 1800
 logger = logging.getLogger(__name__)
 
@@ -103,8 +103,8 @@ class Config(object):
         # Parameters to limit service jobs, so preventing deadlock scheduling scenarios
         self.maxPreemptableServiceJobs = sys.maxsize
         self.maxServiceJobs = sys.maxsize
-        self.deadlockWait = 60  # Wait 80 seconds before declaring a deadlock
-        self.statePollingWait = 1  # Wait 1 seconds before querying job state
+        self.deadlockWait = 60  # Number of seconds to wait before declaring a deadlock
+        self.statePollingWait = 1  # Number of seconds to wait before querying job state
 
         # Resource requirements
         self.defaultMemory = 2147483648
@@ -240,7 +240,7 @@ class Config(object):
         setOption("metrics")
         setOption("preemptableCompensation", float)
         if not 0.0 <= self.preemptableCompensation <= 1.0:
-            raise RuntimeError('preemptableCompensation (%f) must be between 0.1 and 0.9!'
+            raise RuntimeError('preemptableCompensation (%f) must be between 0.0 and 1.0!'
                                '' % self.preemptableCompensation)
         setOption("nodeStorage", int)
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -209,8 +209,6 @@ class Config(object):
         elif self.clean is None:
             self.clean = "onSuccess"
         setOption('clusterStats')
-
-        # Restarting the workflow options
         setOption("restart")
 
         # Batch system options
@@ -222,7 +220,6 @@ class Config(object):
         setOption("parasolCommand")
         setOption("parasolMaxBatches", int, iC(1))
         setOption("linkImports")
-
         setOption("environment", parseSetEnv)
 
         # Autoscaling options
@@ -233,17 +230,18 @@ class Config(object):
         setOption("maxNodes", parseIntList)
         setOption("targetTime", int)
         if self.targetTime <= 0:
-            raise RuntimeError(
-                'targetTime must be a positive integer (was set to %s)' % self.targetTime)
+            raise RuntimeError('targetTime (%s) must be a positive integer!'
+                               '' % self.targetTime)
         setOption("betaInertia", float)
-        if not 0.0 <= self.betaInertia <= 1.0:
-            raise RuntimeError('--betaInertia (%f) must be >= 0.0 and <= 1.0.' % self.betaInertia)
+        if not 0.1 <= self.betaInertia <= 0.9:
+            raise RuntimeError('betaInertia (%f) must be between 0.1 and 0.9!'
+                               '' % self.betaInertia)
         setOption("scaleInterval", float)
         setOption("metrics")
         setOption("preemptableCompensation", float)
         if not 0.0 <= self.preemptableCompensation <= 1.0:
-            raise Exception(
-                '--preemptableCompensation (%f) must be >= 0.0 and <= 1.0.' % self.preemptableCompensation)
+            raise RuntimeError('preemptableCompensation (%f) must be between 0.1 and 0.9!'
+                               '' % self.preemptableCompensation)
         setOption("nodeStorage", int)
 
         # Parameters to limit service jobs / detect deadlocks

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -94,7 +94,7 @@ class Config(object):
         self.nodeOptions = None
         self.minNodes = None
         self.maxNodes = [10]
-        self.alphaPacking = 0.0
+        self.alphaTime = 1800
         self.betaInertia = 1.2
         self.scaleInterval = 30
         self.preemptableCompensation = 0.0
@@ -230,7 +230,7 @@ class Config(object):
         setOption("nodeOptions")
         setOption("minNodes", parseIntList)
         setOption("maxNodes", parseIntList)
-        setOption("alphaPacking", float)
+        setOption("alphaTime", int)
         setOption("betaInertia", float)
         setOption("scaleInterval", float)
         setOption("metrics")
@@ -398,12 +398,11 @@ def _addOptions(addGroupFn, config):
                 "as a default if the list length is less than the number of nodeTypes. "
                 "default=%s" % config.maxNodes[0])
 
-    # TODO: DESCRIBE THE FOLLOWING TWO PARAMETERS
-    addOptionFn("--alphaPacking", dest="alphaPacking", default=None,
-                help=("The total number of nodes estimated to be required to compute the issued "
-                      "jobs is multiplied by the alpha packing parameter to produce the actual "
-                      "number of nodes requested. Values of this coefficient greater than one will "
-                      "tend to over provision and values less than one will under provision. default=%s" % config.alphaPacking))
+    addOptionFn("--alphaTime", dest="alphaTime", default=None,
+                help=("Sets how rapidly you aim to complete jobs. Shorter times mean more "
+                      "aggressive parallelization. The autoscaler attempts to scale up/down "
+                      "so that it expects all queued jobs will complete within alphaTime "
+                      "seconds. default=%s" % config.alphaTime))
     addOptionFn("--betaInertia", dest="betaInertia", default=None,
                 help=("A smoothing parameter to prevent unnecessary oscillations in the "
                       "number of provisioned nodes. If the number of nodes is within the beta "

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import range
@@ -63,6 +64,7 @@ class Config(object):
     """
     Class to represent configuration operations for a toil workflow run.
     """
+
     def __init__(self):
         # Core options
         self.workflowID = None
@@ -82,32 +84,32 @@ class Config(object):
         self.cleanWorkDir = None
         self.clusterStats = None
 
-        #Restarting the workflow options
+        # Restarting the workflow options
         self.restart = False
 
-        #Batch system options
+        # Batch system options
         setDefaultBatchOptions(self)
 
-        #Autoscaling options
+        # Autoscaling options
         self.provisioner = None
         self.nodeTypes = []
         self.nodeOptions = None
         self.minNodes = None
         self.maxNodes = [10]
-        self.alphaTime = 1800
+        self.targetTime = 1800
         self.betaInertia = 0.1
         self.scaleInterval = 30
         self.preemptableCompensation = 0.0
         self.nodeStorage = 50
         self.metrics = False
-        
+
         # Parameters to limit service jobs, so preventing deadlock scheduling scenarios
         self.maxPreemptableServiceJobs = sys.maxsize
         self.maxServiceJobs = sys.maxsize
-        self.deadlockWait = 60 # Wait one minute before declaring a deadlock
-        self.statePollingWait = 1 # Wait 1 seconds before querying job state
+        self.deadlockWait = 60  # Wait one minute before declaring a deadlock
+        self.statePollingWait = 1  # Wait 1 seconds before querying job state
 
-        #Resource requirements
+        # Resource requirements
         self.defaultMemory = 2147483648
         self.defaultCores = 1
         self.defaultDisk = 2147483648
@@ -117,12 +119,12 @@ class Config(object):
         self.maxMemory = sys.maxsize
         self.maxDisk = sys.maxsize
 
-        #Retrying/rescuing jobs
+        # Retrying/rescuing jobs
         self.retryCount = 1
         self.maxJobDuration = sys.maxsize
         self.rescueJobsFrequency = 3600
 
-        #Misc
+        # Misc
         self.disableCaching = True
         self.disableChaining = False
         self.maxLogFileSize = 64000
@@ -134,7 +136,7 @@ class Config(object):
         self.useAsync = True
         self.forceDockerAppliance = False
 
-        #Debug options
+        # Debug options
         self.debugWorker = False
         self.badWorker = 0.0
         self.badWorkerFailInterval = 0.01
@@ -146,11 +148,11 @@ class Config(object):
         """
         Creates a config object from the options object.
         """
-        from bd2k.util.humanize import human2bytes #This import is used to convert
-        #from human readable quantites to integers
+        from bd2k.util.humanize import human2bytes  # This import is used to convert
+        # from human readable quantites to integers
         def setOption(varName, parsingFn=None, checkFn=None, default=None):
-            #If options object has the option "varName" specified
-            #then set the "varName" attrib to this value in the config object
+            # If options object has the option "varName" specified
+            # then set the "varName" attrib to this value in the config object
             x = getattr(options, varName, None)
             if x is None:
                 x = default
@@ -167,7 +169,7 @@ class Config(object):
                 setattr(self, varName, x)
 
         # Function to parse integer from string expressed in different formats
-        h2b = lambda x : human2bytes(str(x))
+        h2b = lambda x: human2bytes(str(x))
 
         def parseJobStore(s):
             name, rest = Toil.parseLocator(s)
@@ -177,18 +179,20 @@ class Config(object):
                 return Toil.buildLocator(name, os.path.abspath(rest))
             else:
                 return s
+
         def parseStrList(s):
             s = s.split(",")
             s = [str(x) for x in s]
             return s
+
         def parseIntList(s):
             s = s.split(",")
             s = [int(x) for x in s]
             return s
 
-        #Core options
+        # Core options
         setOption("jobStore", parsingFn=parseJobStore)
-        #TODO: LOG LEVEL STRING
+        # TODO: LOG LEVEL STRING
         setOption("workDir")
         if self.workDir is not None:
             self.workDir = os.path.abspath(self.workDir)
@@ -209,10 +213,10 @@ class Config(object):
             self.clean = "onSuccess"
         setOption('clusterStats')
 
-        #Restarting the workflow options
+        # Restarting the workflow options
         setOption("restart")
 
-        #Batch system options
+        # Batch system options
         setOption("batchSystem")
         setBatchOptions(self, setOption)
         setOption("disableAutoDeployment")
@@ -224,15 +228,16 @@ class Config(object):
 
         setOption("environment", parseSetEnv)
 
-        #Autoscaling options
+        # Autoscaling options
         setOption("provisioner")
         setOption("nodeTypes", parseStrList)
         setOption("nodeOptions")
         setOption("minNodes", parseIntList)
         setOption("maxNodes", parseIntList)
-        setOption("alphaTime", int)
-        if self.alphaTime <= 0:
-            raise RuntimeError('alphaTime must be a positive integer (was set to %s)' % self.alphaTime)
+        setOption("targetTime", int)
+        if self.targetTime <= 0:
+            raise RuntimeError(
+                'targetTime must be a positive integer (was set to %s)' % self.targetTime)
         setOption("betaInertia", float)
         if not 0.0 <= self.betaInertia <= 1.0:
             raise RuntimeError('--betaInertia (%f) must be >= 0.0 and <= 1.0.' % self.betaInertia)
@@ -240,7 +245,8 @@ class Config(object):
         setOption("metrics")
         setOption("preemptableCompensation", float)
         if not 0.0 <= self.preemptableCompensation <= 1.0:
-            raise Exception('--preemptableCompensation (%f) must be >= 0.0 and <= 1.0.' % self.preemptableCompensation)
+            raise Exception(
+                '--preemptableCompensation (%f) must be >= 0.0 and <= 1.0.' % self.preemptableCompensation)
         setOption("nodeStorage", int)
 
         # Parameters to limit service jobs / detect deadlocks
@@ -259,7 +265,7 @@ class Config(object):
         setOption("maxDisk", h2b, iC(1))
         setOption("defaultPreemptable")
 
-        #Retrying/rescuing jobs
+        # Retrying/rescuing jobs
         setOption("retryCount", int, iC(1))
         setOption("maxJobDuration", int, iC(1))
         setOption("rescueJobsFrequency", int, iC(1))
@@ -274,13 +280,14 @@ class Config(object):
 
         def checkSse(sseKey):
             with open(sseKey) as f:
-                assert(len(f.readline().rstrip()) == 32)
+                assert (len(f.readline().rstrip()) == 32)
+
         setOption("sseKey", checkFn=checkSse)
         setOption("cseKey", checkFn=checkSse)
         setOption("servicePollingInterval", float, fC(0.0))
         setOption("forceDockerAppliance")
 
-        #Debug options
+        # Debug options
         setOption("debugWorker")
         setOption("badWorker", float, fC(0.0, 1.0))
         setOption("badWorkerFailInterval", float, fC(0.0))
@@ -290,6 +297,7 @@ class Config(object):
 
     def __hash__(self):
         return self.__dict__.__hash__()
+
 
 jobStoreLocatorHelp = ("A job store holds persistent information about the jobs and files in a "
                        "workflow. If the workflow is run with a distributed batch system, the job "
@@ -305,9 +313,10 @@ jobStoreLocatorHelp = ("A job store holds persistent information about the jobs 
                        "For backwards compatibility, you may also specify ./foo (equivalent to "
                        "file:./foo or just file:foo) or /bar (equivalent to file:/bar).")
 
+
 def _addOptions(addGroupFn, config):
     #
-    #Core options
+    # Core options
     #
     addOptionFn = addGroupFn("toil core options",
                              "Options to specify the location of the Toil workflow and turn on "
@@ -332,9 +341,10 @@ def _addOptions(addGroupFn, config):
                       "Default is \'never\' if stats is enabled, and \'onSuccess\' otherwise"))
     addOptionFn("--cleanWorkDir", dest="cleanWorkDir",
                 choices=['always', 'never', 'onSuccess', 'onError'], default='always',
-                help=("Determines deletion of temporary worker directory upon completion of a job. Choices: 'always', "
-                      "'never', 'onSuccess'. Default = always. WARNING: This option should be changed for debugging "
-                      "only. Running a full pipeline with this option could fill your disk with intermediate data."))
+                help=(
+                "Determines deletion of temporary worker directory upon completion of a job. Choices: 'always', "
+                "'never', 'onSuccess'. Default = always. WARNING: This option should be changed for debugging "
+                "only. Running a full pipeline with this option could fill your disk with intermediate data."))
     addOptionFn("--clusterStats", dest="clusterStats", nargs='?', action='store',
                 default=None, const=os.getcwd(),
                 help="If enabled, writes out JSON resource usage statistics to a file. "
@@ -343,7 +353,7 @@ def _addOptions(addGroupFn, config):
                      "should be written. This options only applies when using scalable batch "
                      "systems.")
     #
-    #Restarting the workflow options
+    # Restarting the workflow options
     #
     addOptionFn = addGroupFn("toil options for restarting an existing workflow",
                              "Allows the restart of an existing workflow")
@@ -353,7 +363,7 @@ def _addOptions(addGroupFn, config):
                      "if the workflow does not exist")
 
     #
-    #Batch system options
+    # Batch system options
     #
 
     addOptionFn = addGroupFn("toil options for specifying the batch system",
@@ -362,7 +372,7 @@ def _addOptions(addGroupFn, config):
     addBatchOptions(addOptionFn, config)
 
     #
-    #Auto scaling options
+    # Auto scaling options
     #
     addOptionFn = addGroupFn("toil options for autoscaling the cluster of worker nodes",
                              "Allows the specification of the minimum and maximum number of nodes "
@@ -374,39 +384,39 @@ def _addOptions(addGroupFn, config):
                      "'azure', 'gce', or 'aws'. The default is %s." % config.provisioner)
 
     addOptionFn('--nodeTypes', default=None,
-                 help="List of node types separated by commas. The syntax for each node type "
-                      "depends on the provisioner used. For the cgcloud and AWS provisioners "
-                      "this is the name of an EC2 instance type, optionally followed by a "
-                      "colon and the price in dollars "
-                      "to bid for a spot instance of that type, for example 'c3.8xlarge:0.42'."
-                      "If no spot bid is specified, nodes of this type will be non-preemptable."
-                      "It is acceptable to specify an instance as both preemptable and "
-                      "non-preemptable, including it twice in the list. In that case,"
-                      "preemptable nodes of that type will be preferred when creating "
-                      "new nodes once the maximum number of preemptable-nodes has been"
-                      "reached.")
+                help="List of node types separated by commas. The syntax for each node type "
+                     "depends on the provisioner used. For the cgcloud and AWS provisioners "
+                     "this is the name of an EC2 instance type, optionally followed by a "
+                     "colon and the price in dollars "
+                     "to bid for a spot instance of that type, for example 'c3.8xlarge:0.42'."
+                     "If no spot bid is specified, nodes of this type will be non-preemptable."
+                     "It is acceptable to specify an instance as both preemptable and "
+                     "non-preemptable, including it twice in the list. In that case,"
+                     "preemptable nodes of that type will be preferred when creating "
+                     "new nodes once the maximum number of preemptable-nodes has been"
+                     "reached.")
 
     addOptionFn('--nodeOptions', default=None,
-                 help="Options for provisioning the nodes. The syntax "
-                      "depends on the provisioner used. Neither the CGCloud nor the AWS "
-                      "provisioner support any node options.")
+                help="Options for provisioning the nodes. The syntax "
+                     "depends on the provisioner used. Neither the CGCloud nor the AWS "
+                     "provisioner support any node options.")
 
-    addOptionFn('--minNodes', default=None, 
-                 help="Mininum number of nodes of each type in the cluster, if using "
-                              "auto-scaling. This should be provided as a comma-separated "
-                              "list of the same length as the list of node types. default=0")
+    addOptionFn('--minNodes', default=None,
+                help="Mininum number of nodes of each type in the cluster, if using "
+                     "auto-scaling. This should be provided as a comma-separated "
+                     "list of the same length as the list of node types. default=0")
 
     addOptionFn('--maxNodes', default=None,
                 help="Maximum number of nodes of each type in the cluster, if using "
-                "autoscaling, provided as a comma-separated list. The first value is used "
-                "as a default if the list length is less than the number of nodeTypes. "
-                "default=%s" % config.maxNodes[0])
+                     "autoscaling, provided as a comma-separated list. The first value is used "
+                     "as a default if the list length is less than the number of nodeTypes. "
+                     "default=%s" % config.maxNodes[0])
 
-    addOptionFn("--alphaTime", dest="alphaTime", default=None,
+    addOptionFn("--targetTime", dest="targetTime", default=None,
                 help=("Sets how rapidly you aim to complete jobs. Shorter times mean more "
                       "aggressive parallelization. The autoscaler attempts to scale up/down "
-                      "so that it expects all queued jobs will complete within alphaTime "
-                      "seconds. default=%s" % config.alphaTime))
+                      "so that it expects all queued jobs will complete within targetTime "
+                      "seconds. default=%s" % config.targetTime))
     addOptionFn("--betaInertia", dest="betaInertia", default=None,
                 help=("A smoothing parameter to prevent unnecessary oscillations in the "
                       "number of provisioned nodes. This controls an exponentially weighted "
@@ -431,29 +441,34 @@ def _addOptions(addGroupFn, config):
                       "space. The default value is 50."))
     addOptionFn("--metrics", dest="metrics",
                 default=False, action="store_true",
-                help=("Enable the prometheus/grafana dashboard for monitoring CPU/RAM usage, queue size, "
-                      "and issued jobs."))
+                help=(
+                "Enable the prometheus/grafana dashboard for monitoring CPU/RAM usage, queue size, "
+                "and issued jobs."))
 
-    #        
+    #
     # Parameters to limit service jobs / detect service deadlocks
     #
     if not config.cwl:
-        addOptionFn = addGroupFn("toil options for limiting the number of service jobs and detecting service deadlocks",
-                                 "Allows the specification of the maximum number of service jobs "
-                                 "in a cluster. By keeping this limited "
-                                 " we can avoid all the nodes being occupied with services, so causing a deadlock")
+        addOptionFn = addGroupFn(
+            "toil options for limiting the number of service jobs and detecting service deadlocks",
+            "Allows the specification of the maximum number of service jobs "
+            "in a cluster. By keeping this limited "
+            " we can avoid all the nodes being occupied with services, so causing a deadlock")
         addOptionFn("--maxServiceJobs", dest="maxServiceJobs", default=None,
-                    help=("The maximum number of service jobs that can be run concurrently, excluding service jobs running on preemptable nodes. default=%s" % config.maxServiceJobs))
+                    help=(
+                    "The maximum number of service jobs that can be run concurrently, excluding service jobs running on preemptable nodes. default=%s" % config.maxServiceJobs))
         addOptionFn("--maxPreemptableServiceJobs", dest="maxPreemptableServiceJobs", default=None,
-                    help=("The maximum number of service jobs that can run concurrently on preemptable nodes. default=%s" % config.maxPreemptableServiceJobs))
+                    help=(
+                    "The maximum number of service jobs that can run concurrently on preemptable nodes. default=%s" % config.maxPreemptableServiceJobs))
         addOptionFn("--deadlockWait", dest="deadlockWait", default=None,
-                    help=("The minimum number of seconds to observe the cluster stuck running only the same service jobs before throwing a deadlock exception. default=%s" % config.deadlockWait))
+                    help=(
+                    "The minimum number of seconds to observe the cluster stuck running only the same service jobs before throwing a deadlock exception. default=%s" % config.deadlockWait))
         addOptionFn("--statePollingWait", dest="statePollingWait", default=1,
                     help=("Time, in seconds, to wait before doing a scheduler query for job state. "
                           "Return cached results if within the waiting period."))
 
     #
-    #Resource requirements
+    # Resource requirements
     #
     addOptionFn = addGroupFn("toil options for cores/memory requirements",
                              "The options to specify default cores/memory requirements (if not "
@@ -463,7 +478,7 @@ def _addOptions(addGroupFn, config):
                 help='The default amount of memory to request for a job. Only applicable to jobs '
                      'that do not specify an explicit value for this requirement. Standard '
                      'suffixes like K, Ki, M, Mi, G or Gi are supported. Default is %s' %
-                     bytes2human( config.defaultMemory, symbols='iec' ))
+                     bytes2human(config.defaultMemory, symbols='iec'))
     addOptionFn('--defaultCores', dest='defaultCores', default=None, metavar='FLOAT',
                 help='The default number of CPU cores to dedicate a job. Only applicable to jobs '
                      'that do not specify an explicit value for this requirement. Fractions of a '
@@ -473,7 +488,7 @@ def _addOptions(addGroupFn, config):
                 help='The default amount of disk space to dedicate a job. Only applicable to jobs '
                      'that do not specify an explicit value for this requirement. Standard '
                      'suffixes like K, Ki, M, Mi, G or Gi are supported. Default is %s' %
-                     bytes2human( config.defaultDisk, symbols='iec' ))
+                     bytes2human(config.defaultDisk, symbols='iec'))
     assert not config.defaultPreemptable, 'User would be unable to reset config.defaultPreemptable'
     addOptionFn('--defaultPreemptable', dest='defaultPreemptable', action='store_true')
     addOptionFn('--maxCores', dest='maxCores', default=None, metavar='INT',
@@ -483,32 +498,32 @@ def _addOptions(addGroupFn, config):
     addOptionFn('--maxMemory', dest='maxMemory', default=None, metavar='INT',
                 help="The maximum amount of memory to request from the batch system at any one "
                      "time. Standard suffixes like K, Ki, M, Mi, G or Gi are supported. Default "
-                     "is %s" % bytes2human( config.maxMemory, symbols='iec'))
+                     "is %s" % bytes2human(config.maxMemory, symbols='iec'))
     addOptionFn('--maxDisk', dest='maxDisk', default=None, metavar='INT',
                 help='The maximum amount of disk space to request from the batch system at any '
                      'one time. Standard suffixes like K, Ki, M, Mi, G or Gi are supported. '
                      'Default is %s' % bytes2human(config.maxDisk, symbols='iec'))
 
     #
-    #Retrying/rescuing jobs
+    # Retrying/rescuing jobs
     #
     addOptionFn = addGroupFn("toil options for rescuing/killing/restarting jobs", \
-            "The options for jobs that either run too long/fail or get lost \
-            (some batch systems have issues!)")
+                             "The options for jobs that either run too long/fail or get lost \
+                             (some batch systems have issues!)")
     addOptionFn("--retryCount", dest="retryCount", default=None,
-                      help=("Number of times to retry a failing job before giving up and "
-                            "labeling job failed. default=%s" % config.retryCount))
+                help=("Number of times to retry a failing job before giving up and "
+                      "labeling job failed. default=%s" % config.retryCount))
     addOptionFn("--maxJobDuration", dest="maxJobDuration", default=None,
-                      help=("Maximum runtime of a job (in seconds) before we kill it "
-                            "(this is a lower bound, and the actual time before killing "
-                            "the job may be longer). default=%s" % config.maxJobDuration))
+                help=("Maximum runtime of a job (in seconds) before we kill it "
+                      "(this is a lower bound, and the actual time before killing "
+                      "the job may be longer). default=%s" % config.maxJobDuration))
     addOptionFn("--rescueJobsFrequency", dest="rescueJobsFrequency", default=None,
-                      help=("Period of time to wait (in seconds) between checking for "
-                            "missing/overlong jobs, that is jobs which get lost by the batch "
-                            "system. Expert parameter. default=%s" % config.rescueJobsFrequency))
+                help=("Period of time to wait (in seconds) between checking for "
+                      "missing/overlong jobs, that is jobs which get lost by the batch "
+                      "system. Expert parameter. default=%s" % config.rescueJobsFrequency))
 
     #
-    #Misc options
+    # Misc options
     #
     addOptionFn = addGroupFn("Toil Miscellaneous Options", "Miscellaneous Options")
     addOptionFn('--disableCaching', dest='disableCaching', action='store_true', default=True,
@@ -539,11 +554,11 @@ def _addOptions(addGroupFn, config):
                 help="Enable real-time logging from workers to masters")
 
     addOptionFn("--sseKey", dest="sseKey", default=None,
-            help="Path to file containing 32 character key to be used for server-side encryption on "
-                 "awsJobStore or googleJobStore. SSE will not be used if this flag is not passed.")
+                help="Path to file containing 32 character key to be used for server-side encryption on "
+                     "awsJobStore or googleJobStore. SSE will not be used if this flag is not passed.")
     addOptionFn("--cseKey", dest="cseKey", default=None,
                 help="Path to file containing 256-bit key to be used for client-side encryption on "
-                "azureJobStore. By default, no encryption is used.")
+                     "azureJobStore. By default, no encryption is used.")
     addOptionFn("--setEnv", '-e', metavar='NAME=VALUE or NAME',
                 dest="environment", default=[], action="append",
                 help="Set an environment variable early on in the worker. If VALUE is omitted, "
@@ -559,18 +574,20 @@ def _addOptions(addGroupFn, config):
                 help='Disables sanity checking the existence of the docker image specified by '
                 'TOIL_APPLIANCE_SELF, which Toil uses to provision mesos for autoscaling.')
     #
-    #Debug options
+    # Debug options
     #
     addOptionFn = addGroupFn("toil debug options", "Debug options")
     addOptionFn("--debugWorker", default=False, action="store_true",
-            help="Experimental no forking mode for local debugging."
-                 " Specifically, workers are not forked and"
-                 " stderr/stdout are not redirected to the log.")
+                help="Experimental no forking mode for local debugging."
+                     " Specifically, workers are not forked and"
+                     " stderr/stdout are not redirected to the log.")
     addOptionFn("--badWorker", dest="badWorker", default=None,
-                      help=("For testing purposes randomly kill 'badWorker' proportion of jobs using SIGKILL, default=%s" % config.badWorker))
+                help=(
+                "For testing purposes randomly kill 'badWorker' proportion of jobs using SIGKILL, default=%s" % config.badWorker))
     addOptionFn("--badWorkerFailInterval", dest="badWorkerFailInterval", default=None,
-                      help=("When killing the job pick uniformly within the interval from 0.0 to "
-                            "'badWorkerFailInterval' seconds after the worker starts, default=%s" % config.badWorkerFailInterval))
+                help=("When killing the job pick uniformly within the interval from 0.0 to "
+                      "'badWorkerFailInterval' seconds after the worker starts, default=%s" % config.badWorkerFailInterval))
+
 
 def addOptions(parser, config=Config()):
     """
@@ -578,27 +595,29 @@ def addOptions(parser, config=Config()):
     """
     # Wrapper function that allows toil to be used with both the optparse and
     # argparse option parsing modules
-    addLoggingOptions(parser) # This adds the logging stuff.
+    addLoggingOptions(parser)  # This adds the logging stuff.
     if isinstance(parser, ArgumentParser):
         def addGroup(headingString, bodyString):
             return parser.add_argument_group(headingString, bodyString).add_argument
+
         _addOptions(addGroup, config)
     else:
         raise RuntimeError("Unanticipated class passed to addOptions(), %s. Expecting "
                            "argparse.ArgumentParser" % parser.__class__)
 
+
 def getNodeID(extraIDFiles=None):
     """
     Return unique ID of the current node (host).
-    Tries several methods until success. The returned ID should be identical across calls from different processes on 
+    Tries several methods until success. The returned ID should be identical across calls from different processes on
     the same node at least until the next OS reboot.
 
     The last resort method is uuid.getnode() that in some rare OS configurations may return a random ID each time it is
-    called. However, this method should never be reached on a Linux system, because reading from 
+    called. However, this method should never be reached on a Linux system, because reading from
     /proc/sys/kernel/random/boot_id will be tried prior to that. If uuid.getnode() is reached, it will be called twice,
     and exception raised if the values are not identical.
 
-    :param list extraIDFiles: Optional list of additional file names to try reading node ID before trying default 
+    :param list extraIDFiles: Optional list of additional file names to try reading node ID before trying default
     methods. ID should be a single word (no spaces) on the first line of the file.
     """
     if extraIDFiles is None:
@@ -610,15 +629,17 @@ def getNodeID(extraIDFiles=None):
                 with open(idSourceFile, "r") as inp:
                     nodeID = inp.readline().strip()
             except EnvironmentError:
-                logger.warning(("Exception when trying to read ID file {}. Will try next method to get node ID").\
-                        format(idSourceFile), exc_info=True)
+                logger.warning((
+                               "Exception when trying to read ID file {}. Will try next method to get node ID"). \
+                               format(idSourceFile), exc_info=True)
             else:
                 if len(nodeID.split()) == 1:
-                    logger.debug("Obtained node ID {} from file {}".format(nodeID,idSourceFile))
+                    logger.debug("Obtained node ID {} from file {}".format(nodeID, idSourceFile))
                     break
                 else:
-                    logger.warning(("Node ID {} from file {} contains spaces. Will try next method to get node ID").\
-                            format(nodeID, idSourceFile))
+                    logger.warning((
+                                   "Node ID {} from file {} contains spaces. Will try next method to get node ID"). \
+                                   format(nodeID, idSourceFile))
     else:
         nodeIDs = []
         for i_call in range(2):
@@ -632,15 +653,18 @@ def getNodeID(extraIDFiles=None):
             if nodeIDs[0] == nodeIDs[1]:
                 nodeID = nodeIDs[0]
             else:
-                logger.warning("Different node IDs {} received from repeated calls to uuid.getnode(). You should use "\
-                        "another method to generate node ID.".format(nodeIDs))
+                logger.warning(
+                    "Different node IDs {} received from repeated calls to uuid.getnode(). You should use " \
+                    "another method to generate node ID.".format(nodeIDs))
 
             logger.debug("Obtained node ID {} from uuid.getnode()".format(nodeID))
     if not nodeID:
-        logger.warning("Failed to generate stable node ID, returning empty string. If you see this message with a "\
-                "work dir on a shared file system when using workers running on multiple nodes, you might experience "\
-                "cryptic job failures")
+        logger.warning(
+            "Failed to generate stable node ID, returning empty string. If you see this message with a " \
+            "work dir on a shared file system when using workers running on multiple nodes, you might experience " \
+            "cryptic job failures")
     return nodeID
+
 
 class Toil(object):
     """
@@ -778,7 +802,8 @@ class Toil(object):
         try:
             self._jobStore.loadRootJob()
         except JobException:
-            logger.warning('Requested restart but the workflow has already been completed; allowing exports to rerun.')
+            logger.warning(
+                'Requested restart but the workflow has already been completed; allowing exports to rerun.')
             return self._jobStore.getRootJobReturnValue()
 
         self._batchSystem = self.createBatchSystem(self.config)
@@ -1050,6 +1075,7 @@ class Toil(object):
         if not self._inContextManager:
             raise ToilContextManagerException()
 
+
 class ToilRestartException(Exception):
     def __init__(self, message):
         super(ToilRestartException, self).__init__(message)
@@ -1076,7 +1102,7 @@ class ToilMetrics:
         self.grafanaImage = "%s/toil-grafana:%s" % (registry, dockerTag)
         self.prometheusImage = "%s/toil-prometheus:%s" % (registry, dockerTag)
 
-        self.startDashboard(clusterName = self.clusterName)
+        self.startDashboard(clusterName=self.clusterName)
 
         # Always restart the mtail container, because metrics should start from scratch
         # for each workflow
@@ -1115,7 +1141,8 @@ class ToilMetrics:
                                                           "-collector.filesystem.ignored-mount-points",
                                                           "^/(sys|proc|dev|host|etc)($|/)"])
             except subprocess.CalledProcessError:
-                logger.warn("Couldn't start node exporter, won't get RAM and CPU usage for dashboard.")
+                logger.warn(
+                    "Couldn't start node exporter, won't get RAM and CPU usage for dashboard.")
                 self.nodeExporterProc = None
             except KeyboardInterrupt:
                 self.nodeExporterProc.terminate()
@@ -1124,7 +1151,7 @@ class ToilMetrics:
     def _containerRunning(containerName):
         try:
             result = subprocess.check_output(["docker", "inspect", "-f",
-                                                          "'{{.State.Running}}'", containerName]) == "true"
+                                              "'{{.State.Running}}'", containerName]) == "true"
         except subprocess.CalledProcessError:
             result = False
         return result
@@ -1137,12 +1164,12 @@ class ToilMetrics:
                 except subprocess.CalledProcessError:
                     pass
                 subprocess.check_call(["docker", "run",
-                                 "--name", "toil_prometheus",
-                                 "--net=host",
-                                 "-d",
-                                 "-p", "9090:9090",
-                                 self.prometheusImage,
-                                 clusterName])
+                                       "--name", "toil_prometheus",
+                                       "--net=host",
+                                       "-d",
+                                       "-p", "9090:9090",
+                                       self.prometheusImage,
+                                       clusterName])
 
             if not self._containerRunning("toil_grafana"):
                 try:
@@ -1150,27 +1177,29 @@ class ToilMetrics:
                 except subprocess.CalledProcessError:
                     pass
                 subprocess.check_call(["docker", "run",
-                                 "--name", "toil_grafana",
-                                 "-d", "-p=3000:3000",
-                                 self.grafanaImage])
+                                       "--name", "toil_grafana",
+                                       "-d", "-p=3000:3000",
+                                       self.grafanaImage])
         except subprocess.CalledProcessError:
             logger.warn("Could not start prometheus/grafana dashboard.")
             return
 
-        #Add prometheus data source
+        # Add prometheus data source
         def requestPredicate(e):
             if isinstance(e, requests.exceptions.ConnectionError):
                 return True
             return False
+
         try:
             for attempt in retry(delays=(0, 1, 1, 4, 16), predicate=requestPredicate):
                 with attempt:
-                    requests.post('http://localhost:3000/api/datasources', auth=('admin','admin'),
+                    requests.post('http://localhost:3000/api/datasources', auth=('admin', 'admin'),
                                   data='{"name":"DS_PROMETHEUS","type":"prometheus", \
                                   "url":"http://localhost:9090", "access":"direct"}',
-                                  headers = {'content-type': 'application/json', "access": "direct"})
+                                  headers={'content-type': 'application/json', "access": "direct"})
         except requests.exceptions.ConnectionError:
-            logger.info("Could not add data source to Grafana dashboard - no metrics will be displayed.")
+            logger.info(
+                "Could not add data source to Grafana dashboard - no metrics will be displayed.")
 
     def log(self, message):
         if self.mtailProc:
@@ -1203,6 +1232,7 @@ class ToilMetrics:
             self.mtailProc.kill()
         if self.nodeExporterProc:
             self.nodeExporterProc.kill()
+
 
 # Nested functions can't have doctests so we have to make this global
 
@@ -1255,6 +1285,7 @@ def iC(minValue, maxValue=sys.maxsize):
     assert isinstance(minValue, int) and isinstance(maxValue, int)
     return lambda x: minValue <= x < maxValue
 
+
 def fC(minValue, maxValue=None):
     # Returns function that checks if a given float is in the given half-open interval
     assert isinstance(minValue, float)
@@ -1274,29 +1305,30 @@ def cacheDirName(workflowID):
 
 def getDirSizeRecursively(dirPath):
     """
-    This method will return the cumulative number of bytes occupied by the files 
+    This method will return the cumulative number of bytes occupied by the files
     on disk in the directory and its subdirectories.
 
     This method will raise a 'subprocess.CalledProcessError' if it is unable to
-    access a folder or file because of insufficient permissions.  Therefore this 
-    method should only be called on the jobStore, and will alert the user if some 
-    portion is inaccessible.  Everything in the jobStore should have appropriate 
+    access a folder or file because of insufficient permissions.  Therefore this
+    method should only be called on the jobStore, and will alert the user if some
+    portion is inaccessible.  Everything in the jobStore should have appropriate
     permissions as there is no way to read the filesize without permissions.
-    
+
     The environment variable 'BLOCKSIZE'='512' is set instead of the much cleaner
     --block-size=1 because Apple can't handle it.
 
     :param str dirPath: A valid path to a directory or file.
     :return: Total size, in bytes, of the file or directory at dirPath.
     """
-    
+
     # du is often faster than using os.lstat(), sometimes significantly so.
-    
+
     # The call: 'du -s /some/path' should give the number of 512-byte blocks
     # allocated with the environment variable: BLOCKSIZE='512' set, and we
     # multiply this by 512 to return the filesize in bytes.
     return int(subprocess.check_output(['du', '-s', dirPath],
-               env=dict(os.environ, BLOCKSIZE='512')).split()[0].decode('ascii')) * 512
+                                       env=dict(os.environ, BLOCKSIZE='512')).split()[0].decode(
+        'ascii')) * 512
 
 
 def getFileSystemSize(dirPath):

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -233,8 +233,8 @@ class Config(object):
             raise RuntimeError('targetTime (%s) must be a positive integer!'
                                '' % self.targetTime)
         setOption("betaInertia", float)
-        if not 0.1 <= self.betaInertia <= 0.9:
-            raise RuntimeError('betaInertia (%f) must be between 0.1 and 0.9!'
+        if not 0.0 <= self.betaInertia <= 0.9:
+            raise RuntimeError('betaInertia (%f) must be between 0.0 and 0.9!'
                                '' % self.betaInertia)
         setOption("scaleInterval", float)
         setOption("metrics")

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -49,15 +49,12 @@ from toil.batchSystems.options import addOptions as addBatchOptions
 from toil.batchSystems.options import setDefaultOptions as setDefaultBatchOptions
 from toil.batchSystems.options import setOptions as setBatchOptions
 from toil.provisioners import clusterFactory
+from toil.provisioners.clusterScaler import defaultTargetTime
 
 from toil import lookupEnvVar
 from toil.version import dockerRegistry, dockerTag
 
 logger = logging.getLogger(__name__)
-
-# This constant is set to the default value used on unix for block size (in bytes) when
-# os.stat(<file>).st_blocks is called.
-unixBlockSize = 512
 
 
 class Config(object):
@@ -96,7 +93,7 @@ class Config(object):
         self.nodeOptions = None
         self.minNodes = None
         self.maxNodes = [10]
-        self.targetTime = 1800
+        self.targetTime = defaultTargetTime
         self.betaInertia = 0.1
         self.scaleInterval = 30
         self.preemptableCompensation = 0.0

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -95,7 +95,7 @@ class Config(object):
         self.minNodes = None
         self.maxNodes = [10]
         self.alphaTime = 1800
-        self.betaInertia = 1.2
+        self.betaInertia = 0.1
         self.scaleInterval = 30
         self.preemptableCompensation = 0.0
         self.nodeStorage = 50
@@ -234,6 +234,8 @@ class Config(object):
         if self.alphaTime <= 0:
             raise RuntimeError('alphaTime must be a positive integer (was set to %s)' % self.alphaTime)
         setOption("betaInertia", float)
+        if not 0.0 <= self.betaInertia <= 1.0:
+            raise RuntimeError('--betaInertia (%f) must be >= 0.0 and <= 1.0.' % self.betaInertia)
         setOption("scaleInterval", float)
         setOption("metrics")
         setOption("preemptableCompensation", float)
@@ -407,9 +409,10 @@ def _addOptions(addGroupFn, config):
                       "seconds. default=%s" % config.alphaTime))
     addOptionFn("--betaInertia", dest="betaInertia", default=None,
                 help=("A smoothing parameter to prevent unnecessary oscillations in the "
-                      "number of provisioned nodes. If the number of nodes is within the beta "
-                      "inertia of the currently provisioned number of nodes then no change is made "
-                      "to the number of requested nodes. default=%s" % config.betaInertia))
+                      "number of provisioned nodes. This controls an exponentially weighted "
+                      "moving average of the estimated number of nodes. A value of 0.0 "
+                      "disables any smoothing, and a value of 1.0 will smooth so much that "
+                      "no change will ever be made. default=%s" % config.betaInertia))
     addOptionFn("--scaleInterval", dest="scaleInterval", default=None,
                 help=("The interval (seconds) between assessing if the scale of"
                       " the cluster needs to change. default=%s" % config.scaleInterval))

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -46,7 +46,7 @@ from threading import Thread, Semaphore, Event
 from six.moves.queue import Empty, Queue
 from six.moves import xrange
 
-from bd2k.util.humanize import bytes2human
+from toil.lib.humanize import bytes2human
 from toil.common import cacheDirName, getDirSizeRecursively, getFileSystemSize
 from toil.lib.bioio import makePublicDir
 from toil.resource import ModuleDescriptor

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -43,7 +43,7 @@ from io import BytesIO
 from six import iteritems, string_types
 
 from bd2k.util.expando import Expando
-from bd2k.util.humanize import human2bytes
+from toil.lib.humanize import human2bytes
 
 from toil.common import Toil, addOptions, safeUnpickleFromStream
 from toil.fileStore import DeferredFunction

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -24,19 +24,14 @@ from builtins import str
 from builtins import object
 from past.utils import old_div
 import logging
-import gzip
-import os
 import time
-from collections import namedtuple
 
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
 
-from bd2k.util.expando import Expando
-from bd2k.util.humanize import bytes2human
-
+from toil.lib.humanize import bytes2human
 from toil import resolveEntryPoint
 try:
     from toil.cwl.cwltoil import CWL_INTERNAL_JOBS

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -39,7 +39,7 @@ except ImportError:
     # CWL extra not installed
     CWL_INTERNAL_JOBS = ()
 from toil.jobStores.abstractJobStore import NoSuchJobException
-from toil.provisioners.clusterScaler import ClusterScaler, ScalerThread
+from toil.provisioners.clusterScaler import ScalerThread
 from toil.serviceManager import ServiceManager
 from toil.statsAndLogging import StatsAndLogging
 from toil.job import JobNode, ServiceJobNode

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -44,7 +44,7 @@ except ImportError:
     # CWL extra not installed
     CWL_INTERNAL_JOBS = ()
 from toil.jobStores.abstractJobStore import NoSuchJobException
-from toil.provisioners.clusterScaler import ClusterScaler
+from toil.provisioners.clusterScaler import ScalerThread
 from toil.serviceManager import ServiceManager
 from toil.statsAndLogging import StatsAndLogging
 from toil.job import JobNode, ServiceJobNode
@@ -167,7 +167,7 @@ class Leader(object):
         # Create cluster scaling thread if the provisioner is not None
         self.clusterScaler = None
         if self.provisioner is not None and len(self.provisioner.nodeTypes) > 0:
-            self.clusterScaler = ClusterScaler(self.provisioner, self, self.config)
+            self.clusterScaler = ScalerThread(self.provisioner, self, self.config)
 
         # A service manager thread to start and terminate services
         self.serviceManager = ServiceManager(jobStore, self.toilState)

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -39,7 +39,7 @@ except ImportError:
     # CWL extra not installed
     CWL_INTERNAL_JOBS = ()
 from toil.jobStores.abstractJobStore import NoSuchJobException
-from toil.provisioners.clusterScaler import ScalerThread
+from toil.provisioners.clusterScaler import ClusterScaler
 from toil.serviceManager import ServiceManager
 from toil.statsAndLogging import StatsAndLogging
 from toil.job import JobNode, ServiceJobNode
@@ -162,7 +162,7 @@ class Leader(object):
         # Create cluster scaling thread if the provisioner is not None
         self.clusterScaler = None
         if self.provisioner is not None and len(self.provisioner.nodeTypes) > 0:
-            self.clusterScaler = ScalerThread(self.provisioner, self, self.config)
+            self.clusterScaler = ClusterScaler(self.provisioner, self, self.config)
 
         # A service manager thread to start and terminate services
         self.serviceManager = ServiceManager(jobStore, self.toilState)

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -39,7 +39,7 @@ except ImportError:
     # CWL extra not installed
     CWL_INTERNAL_JOBS = ()
 from toil.jobStores.abstractJobStore import NoSuchJobException
-from toil.provisioners.clusterScaler import ClusterScaler
+from toil.provisioners.clusterScaler import ClusterScaler, ScalerThread
 from toil.serviceManager import ServiceManager
 from toil.statsAndLogging import StatsAndLogging
 from toil.job import JobNode, ServiceJobNode
@@ -162,7 +162,7 @@ class Leader(object):
         # Create cluster scaling thread if the provisioner is not None
         self.clusterScaler = None
         if self.provisioner is not None and len(self.provisioner.nodeTypes) > 0:
-            self.clusterScaler = ClusterScaler(self.provisioner, self, self.config)
+            self.clusterScaler = ScalerThread(self.provisioner, self, self.config)
 
         # A service manager thread to start and terminate services
         self.serviceManager = ServiceManager(jobStore, self.toilState)

--- a/src/toil/lib/humanize.py
+++ b/src/toil/lib/humanize.py
@@ -1,0 +1,69 @@
+# http://code.activestate.com/recipes/578019-bytes-to-human-human-to-bytes-converter/
+
+"""
+Bytes-to-human / human-to-bytes converter.
+Based on: http://goo.gl/kTQMs
+Working with Python 2.x and 3.x.
+
+Author: Giampaolo Rodola' <g.rodola [AT] gmail [DOT] com>
+License: MIT
+"""
+
+from __future__ import division
+
+# see: http://goo.gl/kTQMs
+from past.utils import old_div
+SYMBOLS = {
+    'customary'     : ('', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'),
+    'customary_ext' : ('byte', 'kilo', 'mega', 'giga', 'tera', 'peta', 'exa', 'zetta', 'iotta'),
+    'iec'           : ('Bi', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi'),
+    'iec_ext'       : ('byte', 'kibi', 'mebi', 'gibi', 'tebi', 'pebi', 'exbi', 'zebi', 'yobi'),
+}
+
+def bytes2human(n, fmt='%(value).1f %(symbol)s', symbols='customary'):
+    """
+    Convert n bytes into a human readable string based on format.
+    symbols can be either "customary", "customary_ext", "iec" or "iec_ext",
+    see: http://goo.gl/kTQMs
+    """
+    n = int(n)
+    if n < 0:
+        raise ValueError("n < 0")
+    symbols = SYMBOLS[symbols]
+    prefix = {}
+    for i, s in enumerate(symbols[1:]):
+        prefix[s] = 1 << (i+1)*10
+    for symbol in reversed(symbols[1:]):
+        if n >= prefix[symbol]:
+            value = old_div(float(n), prefix[symbol])
+            return fmt % locals()
+    return fmt % dict(symbol=symbols[0], value=n)
+
+def human2bytes(s):
+    """
+    Attempts to guess the string format based on default symbols
+    set and return the corresponding bytes as an integer.
+
+    When unable to recognize the format ValueError is raised.
+    """
+    init = s
+    num = ""
+    while s and s[0:1].isdigit() or s[0:1] == '.':
+        num += s[0]
+        s = s[1:]
+    num = float(num)
+    letter = s.strip()
+    for name, sset in list(SYMBOLS.items()):
+        if letter in sset:
+            break
+    else:
+        if letter == 'k':
+            # treat 'k' as an alias for 'K' as per: http://goo.gl/kTQMs
+            sset = SYMBOLS['customary']
+            letter = letter.upper()
+        else:
+            raise ValueError("can't interpret %r" % init)
+    prefix = {sset[0]:1}
+    for i, s in enumerate(sset[1:]):
+        prefix[s] = 1 << (i+1)*10
+    return int(num * prefix[letter])

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -55,10 +55,10 @@ class Shape(object):
                 self.disk == other.disk and
                 self.preemptable == other.preemptable)
 
-    def __lt__(self, other):
-        if self.preemptable > other.preemptable:
+    def __gt__(self, other):
+        if self.preemptable < other.preemptable:
             return True
-        elif self.preemptable < other.preemptable:
+        elif self.preemptable > other.preemptable:
             return False
         elif self.memory > other.memory:
             return True
@@ -78,6 +78,19 @@ class Shape(object):
             return False
         else:
             return False
+
+    def __str__(self):
+        return "\nShape wallTime: %s\n" \
+               "Shape memory: %s\n" \
+               "Shape cores: %s\n" \
+               "Shape disk: %s\n" \
+               "Shape preemptable: %s\n" \
+               "\n" % \
+               (self.wallTime,
+                self.memory,
+                self.cores,
+                self.disk,
+                self.preemptable)
 
 class AbstractProvisioner(with_metaclass(ABCMeta, object)):
     """

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -138,7 +138,7 @@ class AbstractProvisioner(with_metaclass(ABCMeta, object)):
                 self._spotBidsMap[nodeType] = bid
             else:
                 self.nodeTypes.append(nodeTypeStr)
-                self.nodeShapes.append(self.getNodeShape(nodeType, preemptable=False))
+                self.nodeShapes.append(self.getNodeShape(nodeTypeStr, preemptable=False))
 
     @staticmethod
     def retryPredicate(e):

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from abc import ABCMeta, abstractmethod
 from builtins import object
-from collections import namedtuple
 from functools import total_ordering
 from itertools import count
 import logging
@@ -29,28 +28,9 @@ a_short_time = 5
 
 log = logging.getLogger(__name__)
 
+
 @total_ordering
-class ShapeOrdering(object):
-    """Provides the sort ordering for Shape. Preemptability is first,
-    followed by memory, etc."""
-    def __eq__(self, other):
-        return (self.wallTime == other.wallTime and
-                self.memory == other.memory and
-                self.cores == other.cores and
-                self.disk == other.disk and
-                self.preemptable == other.preemptable)
-
-    def __lt__(self, other):
-        return (self.preemptable > other.preemptable or
-                self.memory < other.memory or
-                self.cores < other.cores or
-                self.disk < other.disk or
-                self.wallTime < other.wallTime)
-
-# This convoluted multiple-inheritance business is so that
-# ShapeOrdering overrides the default tuple comparison methods without
-# having to manually specify all seven comparison methods.
-class Shape(ShapeOrdering, namedtuple("_Shape", "wallTime memory cores disk preemptable")):
+class Shape(object):
     """
     Represents a job or a node's "shape", in terms of the dimensions of memory, cores, disk and
     wall-time allocation.
@@ -61,7 +41,43 @@ class Shape(ShapeOrdering, namedtuple("_Shape", "wallTime memory cores disk pree
     The memory and disk attributes store the number of bytes required by a job (or provided by a
     node) in RAM or on disk (SSD or HDD), respectively.
     """
-    pass
+    def __init__(self, wallTime, memory, cores, disk, preemptable):
+        self.wallTime = wallTime
+        self.memory = memory
+        self.cores = cores
+        self.disk = disk
+        self.preemptable = preemptable
+
+    def __eq__(self, other):
+        return (self.wallTime == other.wallTime and
+                self.memory == other.memory and
+                self.cores == other.cores and
+                self.disk == other.disk and
+                self.preemptable == other.preemptable)
+
+    def __lt__(self, other):
+        if self.preemptable > other.preemptable:
+            return True
+        elif self.preemptable < other.preemptable:
+            return False
+        elif self.memory > other.memory:
+            return True
+        elif self.memory < other.memory:
+            return False
+        elif self.cores > other.cores:
+            return True
+        elif self.cores < other.cores:
+            return False
+        elif self.disk > other.disk:
+            return True
+        elif self.disk < other.disk:
+            return False
+        elif self.wallTime > other.wallTime:
+            return True
+        elif self.wallTime < other.wallTime:
+            return False
+        else:
+            return False
 
 class AbstractProvisioner(with_metaclass(ABCMeta, object)):
     """

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -42,10 +42,17 @@ class ShapeOrdering(object):
 
     def __lt__(self, other):
         return self.preemptable > other.preemptable or \
-            self.memory < other.memory or \
-            self.cores < other.cores or \
-            self.disk < other.disk or \
-            self.wallTime < other.wallTime
+               self.memory < other.memory or \
+               self.cores < other.cores or \
+               self.disk < other.disk or \
+               self.wallTime < other.wallTime
+
+    def __gt__(self, other):
+        return self.preemptable < other.preemptable or \
+               self.memory > other.memory or \
+               self.cores > other.cores or \
+               self.disk > other.disk or \
+               self.wallTime > other.wallTime
 
 # This convoluted multiple-inheritance business is so that
 # ShapeOrdering overrides the default tuple comparison methods without

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -330,7 +330,7 @@ coreos:
     LEADER_DOCKER_ARGS = '--registry=in_memory --cluster={name}'
     # --no-systemd_enable_support is necessary in Ubuntu 16.04 (otherwise,
     # Mesos attempts to contact systemd but can't find its run file)
-    WORKER_DOCKER_ARGS = '--work_dir=/var/lib/mesos --master={ip}:5050 --attributes=preemptable:{preemptable} --no-systemd_enable_support'
+    WORKER_DOCKER_ARGS = '--work_dir=/var/lib/mesos --master={ip}:5050 --attributes=preemptable:{preemptable} --no-hostname_lookup --no-systemd_enable_support'
     def _getCloudConfigUserData(self, role, masterPublicKey=None, keyPath=None, preemptable=False):
         if role == 'leader':
             entryPoint = 'mesos-master'

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -125,24 +125,20 @@ class AbstractProvisioner(with_metaclass(ABCMeta, object)):
         Set node types, shapes and spot bids. Preemptable nodes will have the form "type:spotBid".
         :param nodeTypes: A list of node types
         """
-        spotBids = []
-        nonPreemptableNodeTypes = []
-        preemptableNodeTypes = []
+        self._spotBidsMap = {}
+        self.nodeShapes = []
+        self.nodeTypes = []
         for nodeTypeStr in nodeTypes:
             nodeBidTuple = nodeTypeStr.split(":")
             if len(nodeBidTuple) == 2:
                 #This is a preemptable node type, with a spot bid
-                preemptableNodeTypes.append(nodeBidTuple[0])
-                spotBids.append(nodeBidTuple[1])
+                nodeType, bid = nodeBidTuple
+                self.nodeTypes.append(nodeType)
+                self.nodeShapes.append(self.getNodeShape(nodeType, preemptable=True))
+                self._spotBidsMap[nodeType] = bid
             else:
-                nonPreemptableNodeTypes.append(nodeTypeStr)
-        preemptableNodeShapes = [self.getNodeShape(nodeType=nodeType, preemptable=True)
-                                      for nodeType in preemptableNodeTypes]
-        nonPreemptableNodeShapes = [self.getNodeShape(nodeType=nodeType, preemptable=False)
-                                         for nodeType in nonPreemptableNodeTypes]
-        self.nodeShapes = nonPreemptableNodeShapes + preemptableNodeShapes
-        self.nodeTypes = nonPreemptableNodeTypes + preemptableNodeTypes
-        self._spotBidsMap = dict(zip(preemptableNodeTypes, spotBids))
+                self.nodeTypes.append(nodeTypeStr)
+                self.nodeShapes.append(self.getNodeShape(nodeType, preemptable=False))
 
     @staticmethod
     def retryPredicate(e):

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -328,7 +328,9 @@ coreos:
 
     MESOS_LOG_DIR = '--log_dir=/var/lib/mesos '
     LEADER_DOCKER_ARGS = '--registry=in_memory --cluster={name}'
-    WORKER_DOCKER_ARGS = '--work_dir=/var/lib/mesos --master={ip}:5050 --attributes=preemptable:{preemptable}'
+    # --no-systemd_enable_support is necessary in Ubuntu 16.04 (otherwise,
+    # Mesos attempts to contact systemd but can't find its run file)
+    WORKER_DOCKER_ARGS = '--work_dir=/var/lib/mesos --master={ip}:5050 --attributes=preemptable:{preemptable} --no-systemd_enable_support'
     def _getCloudConfigUserData(self, role, masterPublicKey=None, keyPath=None, preemptable=False):
         if role == 'leader':
             entryPoint = 'mesos-master'

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -34,25 +34,18 @@ class ShapeOrdering(object):
     """Provides the sort ordering for Shape. Preemptability is first,
     followed by memory, etc."""
     def __eq__(self, other):
-        return self.wallTime == other.wallTime \
-            and self.memory == other.memory \
-            and self.cores == other.cores \
-            and self.disk == other.disk \
-            and self.preemptable == other.preemptable
+        return (self.wallTime == other.wallTime and
+                self.memory == other.memory and
+                self.cores == other.cores and
+                self.disk == other.disk and
+                self.preemptable == other.preemptable)
 
     def __lt__(self, other):
-        return self.preemptable > other.preemptable or \
-               self.memory < other.memory or \
-               self.cores < other.cores or \
-               self.disk < other.disk or \
-               self.wallTime < other.wallTime
-
-    def __gt__(self, other):
-        return self.preemptable < other.preemptable or \
-               self.memory > other.memory or \
-               self.cores > other.cores or \
-               self.disk > other.disk or \
-               self.wallTime > other.wallTime
+        return (self.preemptable > other.preemptable or
+                self.memory < other.memory or
+                self.cores < other.cores or
+                self.disk < other.disk or
+                self.wallTime < other.wallTime)
 
 # This convoluted multiple-inheritance business is so that
 # ShapeOrdering overrides the default tuple comparison methods without

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -237,8 +237,7 @@ class NodeReservation(object):
                     endingReservation.nReservation = NodeReservation(nodeShape)
             # can't run the job with the current resources
             else:
-                # will always hit at least once
-                if startingReservationTime + availableTime <= targetTime:
+                if startingReservationTime + availableTime + endingReservation.shape.wallTime <= targetTime:
                     startingReservation = endingReservation.nReservation
                     startingReservationTime += availableTime + endingReservation.shape.wallTime
                     availableTime = 0

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -66,7 +66,7 @@ class BinPackedFit(object):
               the jobs in jobShapes.
     """
     def __init__(self, nodeShapes, targetTime=defaultTargetTime):
-        self.nodeShapes = nodeShapes
+        self.nodeShapes = sorted(nodeShapes)
         self.targetTime = targetTime
 
         # {_Shape(wallTime=3600, memory=1073741824, cores=1, disk=8589934592, preemptable=False): []}

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -19,7 +19,6 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import str
 from builtins import map
-from past.utils import old_div
 from builtins import object
 import json
 import logging
@@ -98,9 +97,6 @@ class BinPackedFit(object):
     def __init__(self, nodeShapes, targetTime=3600):
         self.nodeShapes = nodeShapes
         self.targetTime = targetTime
-        # Prioritize preemptable node shapes with the lowest memory
-        self.nodeShapes.sort(key=lambda nS: not nS.preemptable)
-        self.nodeShapes.sort(key=lambda nS: nS.memory)
         self.nodeReservations = {nodeShape:[] for nodeShape in nodeShapes}  # The list of node reservations
 
     def binPack(self, jobShapes):

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -254,7 +254,7 @@ class NodeReservation(object):
 
 def adjustEndingReservationForJob(reservation, jobShape, wallTime):
     """
-    Add a job to an ending reservation that ends at time t, splitting
+    Add a job to an ending reservation that ends at wallTime, splitting
     the reservation if the job doesn't fill the entire timeslice.
     """
     if jobShape.wallTime - wallTime < reservation.shape.wallTime:

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -44,7 +44,7 @@ formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(messag
 ch.setFormatter(formatter)
 logging.getLogger().addHandler(ch)
 
-defaultTargetTime = 3600
+defaultTargetTime = 1800
 
 
 class BinPackedFit(object):

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -35,6 +35,7 @@ from itertools import islice
 from toil.batchSystems.abstractBatchSystem import AbstractScalableBatchSystem, NodeInfo
 from toil.provisioners.abstractProvisioner import Shape
 from toil.job import ServiceJobNode
+from toil.common import defaultTargetTime
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -43,8 +44,6 @@ ch.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 ch.setFormatter(formatter)
 logging.getLogger().addHandler(ch)
-
-defaultTargetTime = 1800
 
 
 class BinPackedFit(object):

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -365,7 +365,7 @@ class ClusterScaler(object):
                     totalNodes[nodeShape] += len(nodes_thisType)
                     nodes.extend(nodes_thisType)
 
-                provisioner.setStaticNodes(nodes, preemptable)
+                self.setStaticNodes(nodes, preemptable)
 
         logger.info('Starting with the following nodes in the cluster: %s' % totalNodes)
 
@@ -688,7 +688,7 @@ class ClusterScaler(object):
             if node is None:
                 logger.info("Node with info %s was not found in our node list", nodeInfo)
                 continue
-            staticNodes = self.scaler.getStaticNodes(preemptable)
+            staticNodes = self.getStaticNodes(preemptable)
             prefix = 'non-' if not preemptable else ''
             if node.privateIP in staticNodes:
                 # we don't want to automatically terminate any statically

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -310,7 +310,11 @@ class ClusterScaler(object):
         self.totalJobsCompleted = 0
 
         self.targetTime = config.targetTime
+        if self.targetTime <= 0:
+            raise RuntimeError('targetTime (%s) must be a positive integer!' % self.targetTime)
         self.betaInertia = config.betaInertia
+        if not 0.1 <= self.betaInertia <= 0.9:
+            raise RuntimeError('betaInertia (%f) must be between 0.1 and 0.9!' % self.betaInertia)
 
         self.nodeTypes = provisioner.nodeTypes
         self.nodeShapes = provisioner.nodeShapes

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -76,9 +76,10 @@ class BinPackedFit(object):
         """Pack a list of jobShapes into the fewest nodes reasonable. Can be run multiple times."""
         logger.debug('Running bin packing for node shapes %s and %s job(s).',
                      self.nodeShapes, len(jobShapes))
-        # Sorts preemptables first, then highest memory, highest cores, highest disk,
-        # and finally highest wallTime.
+        # Sort in descending order from largest to smallest. The FFD like-strategy will pack the
+        # jobs in order from longest to shortest.
         jobShapes.sort()
+        jobShapes.reverse()
         assert len(jobShapes) == 0 or jobShapes[0] >= jobShapes[-1]
         for jS in jobShapes:
             self.addJobShape(jS)
@@ -316,10 +317,7 @@ class ClusterScaler(object):
             raise RuntimeError('betaInertia (%f) must be between 0.0 and 0.9!' % self.betaInertia)
 
         self.nodeTypes = provisioner.nodeTypes
-        # Sorts preemptables first, then highest memory, highest cores, highest disk,
-        # and finally highest wallTime.  Then reverses this.
-        # TODO: Sort by cost
-        self.nodeShapes = sorted(provisioner.nodeShapes, reverse=True)
+        self.nodeShapes = provisioner.nodeShapes
 
         self.nodeShapeToType = dict(zip(self.nodeShapes, self.nodeTypes))
 
@@ -354,10 +352,7 @@ class ClusterScaler(object):
         self.minNodes = dict(zip(self.nodeShapes, minNodes))
         self.maxNodes = dict(zip(self.nodeShapes, maxNodes))
 
-        # Sorts preemptables first, then highest memory, highest cores, highest disk,
-        # and finally highest wallTime.  Then reverses this.
-        # TODO: Sort by cost.
-        self.nodeShapes.sort(reverse=True)
+        self.nodeShapes.sort()
 
         #Node shape to number of currently provisioned nodes
         totalNodes = defaultdict(int)

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -76,10 +76,9 @@ class BinPackedFit(object):
         """Pack a list of jobShapes into the fewest nodes reasonable. Can be run multiple times."""
         logger.debug('Running bin packing for node shapes %s and %s job(s).',
                      self.nodeShapes, len(jobShapes))
-        # Sort in descending order from largest to smallest. The FFD like-strategy will pack the
-        # jobs in order from longest to shortest.
+        # Sorts preemptables first, then highest memory, highest cores, highest disk,
+        # and finally highest wallTime.
         jobShapes.sort()
-        jobShapes.reverse()
         assert len(jobShapes) == 0 or jobShapes[0] >= jobShapes[-1]
         for jS in jobShapes:
             self.addJobShape(jS)
@@ -317,7 +316,10 @@ class ClusterScaler(object):
             raise RuntimeError('betaInertia (%f) must be between 0.0 and 0.9!' % self.betaInertia)
 
         self.nodeTypes = provisioner.nodeTypes
-        self.nodeShapes = provisioner.nodeShapes
+        # Sorts preemptables first, then highest memory, highest cores, highest disk,
+        # and finally highest wallTime.  Then reverses this.
+        # TODO: Sort by cost
+        self.nodeShapes = sorted(provisioner.nodeShapes, reverse=True)
 
         self.nodeShapeToType = dict(zip(self.nodeShapes, self.nodeTypes))
 
@@ -352,7 +354,10 @@ class ClusterScaler(object):
         self.minNodes = dict(zip(self.nodeShapes, minNodes))
         self.maxNodes = dict(zip(self.nodeShapes, maxNodes))
 
-        self.nodeShapes.sort()
+        # Sorts preemptables first, then highest memory, highest cores, highest disk,
+        # and finally highest wallTime.  Then reverses this.
+        # TODO: Sort by cost.
+        self.nodeShapes.sort(reverse=True)
 
         #Node shape to number of currently provisioned nodes
         totalNodes = defaultdict(int)

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -540,9 +540,9 @@ class ScalerThread(ExceptionalThread):
                     if self.stats:
                         self.stats.checkStats()
             except:
-                log.exception("Exception encountered in scaler thread. Making a "
-                              "best-effort attempt to keep going, but things may "
-                              "go wrong from now on.")
+                logger.exception("Exception encountered in scaler thread. Making a "
+                                 "best-effort attempt to keep going, but things may "
+                                 "go wrong from now on.")
         self.shutDown()
 
     def setNodeCount(self, nodeType, numNodes, preemptable=False, force=False):

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -313,8 +313,8 @@ class ClusterScaler(object):
         if self.targetTime <= 0:
             raise RuntimeError('targetTime (%s) must be a positive integer!' % self.targetTime)
         self.betaInertia = config.betaInertia
-        if not 0.1 <= self.betaInertia <= 0.9:
-            raise RuntimeError('betaInertia (%f) must be between 0.1 and 0.9!' % self.betaInertia)
+        if not 0.0 <= self.betaInertia <= 0.9:
+            raise RuntimeError('betaInertia (%f) must be between 0.0 and 0.9!' % self.betaInertia)
 
         self.nodeTypes = provisioner.nodeTypes
         self.nodeShapes = provisioner.nodeShapes

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -470,9 +470,6 @@ class ScalerThread(ExceptionalThread):
             try:
                 with throttle(self.scaler.config.scaleInterval):
                     queuedJobs = self.scaler.leader.getJobs()
-                    logger.info("avg runtime dict: %s" % repr(self.scaler.jobNameToAvgRuntime))
-                    for job in set(job for job in queuedJobs):
-                        logger.info("Got avg runtime %s for job %s." % (self.scaler.getAverageRuntime(job.jobName, service=isinstance(job, ServiceJobNode)), job.jobName))
                     queuedJobShapes = [Shape(wallTime=self.scaler.getAverageRuntime(jobName=job.jobName, service=isinstance(job, ServiceJobNode)), memory=job.memory, cores=job.cores, disk=job.disk, preemptable=job.preemptable) for job in queuedJobs]
                     logger.info("job shapes: %s" % (repr(set(queuedJobShapes))))
                     nodesToRunQueuedJobs = binPacking(jobShapes=queuedJobShapes, nodeShapes=self.nodeShapes)

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -471,7 +471,7 @@ class ScalerThread(ExceptionalThread):
                 with throttle(self.scaler.config.scaleInterval):
                     queuedJobs = self.scaler.leader.getJobs()
                     queuedJobShapes = [Shape(wallTime=self.scaler.getAverageRuntime(jobName=job.jobName, service=isinstance(job, ServiceJobNode)), memory=job.memory, cores=job.cores, disk=job.disk, preemptable=job.preemptable) for job in queuedJobs]
-                    logger.info("job shapes: %s" % (repr(set(queuedJobShapes))))
+                    logger.debug("job shapes: %s" % (repr(set(queuedJobShapes))))
                     nodesToRunQueuedJobs = binPacking(jobShapes=queuedJobShapes, nodeShapes=self.nodeShapes)
                     for nodeShape in self.nodeShapes:
                         nodeType = self.nodeShapeToType[nodeShape]

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -417,7 +417,7 @@ class ClusterScaler(object):
             estimatedNodeCounts[nodeShape] = estimatedNodeCount
         return estimatedNodeCounts
 
-    def updateClusterSize(self, estimatedNodeCounts, currentNodeCounts):
+    def updateClusterSize(self, estimatedNodeCounts):
         """
         Given the desired and current size of the cluster, attempts to
         launch/remove instances to get to the desired size. Also
@@ -743,7 +743,7 @@ class ScalerThread(ExceptionalThread):
                         nodeType = self.scaler.nodeShapeToType[nodeShape]
                         currentNodeCounts[nodeShape] = len(self.scaler.leader.provisioner.getProvisionedWorkers(nodeType=nodeType, preemptable=nodeShape.preemptable))
                     estimatedNodeCounts = self.scaler.getEstimatedNodeCounts(queuedJobShapes, currentNodeCounts)
-                    self.scaler.updateClusterSize(estimatedNodeCounts, currentNodeCounts)
+                    self.scaler.updateClusterSize(estimatedNodeCounts)
                     if self.stats:
                         self.stats.checkStats()
             except:

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -27,15 +27,15 @@ import sys
 import time
 from collections import defaultdict
 
-from bd2k.util.throttle import throttle
 from bd2k.util.retry import retry
 from bd2k.util.threading import ExceptionalThread
+from bd2k.util.throttle import throttle
 from itertools import islice
 
 from toil.batchSystems.abstractBatchSystem import AbstractScalableBatchSystem, NodeInfo
 from toil.provisioners.abstractProvisioner import Shape
-from toil.common import defaultTargetTime
 from toil.job import ServiceJobNode
+from toil.common import defaultTargetTime
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -50,7 +50,7 @@ class BinPackedFit(object):
     """
     If jobShapes is a set of tasks with run requirements (mem/disk/cpu), and nodeShapes is a sorted
     list of available computers to run these jobs on, this function attempts to return a dictionary
-    representing the minimum set of nodeShape computers needed to run the tasks in jobShapes.
+    representing the minimum set of computerNode computers needed to run the tasks in jobShapes.
 
     Uses a first fit decreasing (FFD) bin packing like algorithm to calculate an approximate minimum
     number of nodes that will fit the given list of jobs.  BinPackingFit assumes the ordered list,
@@ -298,21 +298,10 @@ class ClusterScaler(object):
         :param toil.leader.Leader leader:
         :param Config config: Config object from which to draw parameters.
         """
-        super(ClusterScaler, self).__init__()
-
         self.provisioner = provisioner
         self.leader = leader
         self.config = config
         self.static = {}
-
-        self.stats = None
-        if config.clusterStats:
-            self.stats = ClusterStats(leader.config.clusterStats,
-                                      leader.batchSystem,
-                                      provisioner.clusterName)
-            for preemptable in [True, False]:
-                self.stats.startStats(preemptable=preemptable)
-            logger.debug("Cluster stats started.")
 
         # Dictionary of job names to their average runtime, used to estimate wall time of queued
         # jobs for bin-packing
@@ -512,10 +501,10 @@ class ClusterScaler(object):
                              self.maxNodes[nodeShape])
                 estimatedNodeCount = self.maxNodes[nodeShape]
             elif estimatedNodeCount < self.minNodes[nodeShape]:
-                logger.debug('Raising the estimated number of necessary %s (%s) to the '
-                             'configured minimum (%s).', nodeType,
-                             estimatedNodeCount,
-                             self.minNodes[nodeShape])
+                logger.info('Raising the estimated number of necessary %s (%s) to the '
+                            'configured minimum (%s).', nodeType,
+                            estimatedNodeCount,
+                            self.minNodes[nodeShape])
                 estimatedNodeCount = self.minNodes[nodeShape]
             estimatedNodeCounts[nodeShape] = estimatedNodeCount
         return estimatedNodeCounts
@@ -539,8 +528,7 @@ class ClusterScaler(object):
             if nodeShape.preemptable:
                 if newNodeCount < estimatedNodeCount:
                     deficit = estimatedNodeCount - newNodeCount
-                    logger.info('Preemptable scaler detected deficit of '
-                                '%d nodes of type %s.' % (deficit, nodeType))
+                    logger.info('Preemptable scaler detected deficit of %d nodes of type %s.' % (deficit, nodeType))
                     self.preemptableNodeDeficit[nodeType] = deficit
                 else:
                     self.preemptableNodeDeficit[nodeType] = 0
@@ -605,10 +593,7 @@ class ClusterScaler(object):
                     numNodes = numCurrentNodes + self._addNodes(nodeType, numNodes=delta,
                                                                 preemptable=preemptable)
                 elif delta < 0:
-                    logger.info('Removing %i %s nodes to get to desired cluster size of %i.',
-                                -delta,
-                                'preemptable' if preemptable else 'non-preemptable',
-                                numNodes)
+                    logger.info('Removing %i %s nodes to get to desired cluster size of %i.', -delta, 'preemptable' if preemptable else 'non-preemptable', numNodes)
                     numNodes = numCurrentNodes - self._removeNodes(workerInstances,
                                                                    nodeType = nodeType,
                                                                    numNodes=-delta,
@@ -616,11 +601,9 @@ class ClusterScaler(object):
                                                                    force=force)
                 else:
                     if not force:
-                        logger.info('Cluster (minus ignored nodes) already at desired size of %i. '
-                                    'Nothing to do.', numNodes)
+                        logger.info('Cluster (minus ignored nodes) already at desired size of %i. Nothing to do.', numNodes)
                     else:
-                        logger.info('Cluster already at desired size of %i. '
-                                    'Nothing to do.', numNodes)
+                        logger.info('Cluster already at desired size of %i. Nothing to do.', numNodes)
         return numNodes
 
     def _addNodes(self, nodeType, numNodes, preemptable):
@@ -790,24 +773,18 @@ class ClusterScaler(object):
             nodeType = self.nodeShapeToType[nodeShape]
             self.setNodeCount(nodeType=nodeType, numNodes=0, preemptable=preemptable, force=True)
 
-
 class ScalerThread(ExceptionalThread):
     """
     A thread that automatically scales the number of either preemptable or non-preemptable worker
     nodes according to the resource requirements of the queued jobs.
-
     The scaling calculation is essentially as follows: start with 0 estimated worker nodes. For
     each queued job, check if we expect it can be scheduled into a worker node before a certain time
     (currently one hour). Otherwise, attempt to add a single new node of the smallest type that
     can fit that job.
-
     At each scaling decision point a comparison between the current, C, and newly estimated
     number of nodes is made. If the absolute difference is less than beta * C then no change
     is made, else the size of the cluster is adapted. The beta factor is an inertia parameter
     that prevents continual fluctuations in the number of nodes.
-
-    Called with ".start()" inherited from threading.Thread, which then runs the tryRun() overriding
-    ExceptionalThread's ".tryRun()".
     """
     def __init__(self, provisioner, leader, config):
         """
@@ -818,6 +795,16 @@ class ScalerThread(ExceptionalThread):
 
         # Indicates that the scaling thread should shutdown
         self.stop = False
+
+        self.stats = None
+        if config.clusterStats:
+            logger.debug("Starting up cluster statistics...")
+            self.stats = ClusterStats(leader.config.clusterStats,
+                                      leader.batchSystem,
+                                      provisioner.clusterName)
+            for preemptable in [True, False]:
+                self.stats.startStats(preemptable=preemptable)
+            logger.debug("...Cluster stats started.")
 
     def check(self):
         """
@@ -847,17 +834,22 @@ class ScalerThread(ExceptionalThread):
             try:
                 with throttle(self.scaler.config.scaleInterval):
                     queuedJobs = self.scaler.leader.getJobs()
-                    queuedJobShapes = [Shape(wallTime=self.scaler.getAverageRuntime(jobName=job.jobName,
-                                                                                    service=isinstance(job, ServiceJobNode)),
-                                             memory=job.memory,
-                                             cores=job.cores,
-                                             disk=job.disk,
-                                             preemptable=job.preemptable) for job in queuedJobs]
+                    queuedJobShapes = [
+                        Shape(wallTime=self.scaler.getAverageRuntime(
+                            jobName=job.jobName,
+                            service=isinstance(job, ServiceJobNode)),
+                            memory=job.memory,
+                            cores=job.cores,
+                            disk=job.disk,
+                            preemptable=job.preemptable) for job in queuedJobs]
                     currentNodeCounts = {}
                     for nodeShape in self.scaler.nodeShapes:
                         nodeType = self.scaler.nodeShapeToType[nodeShape]
-                        currentNodeCounts[nodeShape] = len(self.scaler.leader.provisioner.getProvisionedWorkers(nodeType=nodeType, preemptable=nodeShape.preemptable))
-                    estimatedNodeCounts = self.scaler.getEstimatedNodeCounts(queuedJobShapes, currentNodeCounts)
+                        currentNodeCounts[nodeShape] = len(
+                            self.scaler.leader.provisioner.getProvisionedWorkers(nodeType=nodeType,
+                                                                                 preemptable=nodeShape.preemptable))
+                    estimatedNodeCounts = self.scaler.getEstimatedNodeCounts(queuedJobShapes,
+                                                                             currentNodeCounts)
                     self.scaler.updateClusterSize(estimatedNodeCounts)
                     if self.stats:
                         self.stats.checkStats()
@@ -865,7 +857,6 @@ class ScalerThread(ExceptionalThread):
                 logger.exception("Exception encountered in scaler thread. Making a best-effort "
                                  "attempt to keep going, but things may go wrong from now on.")
         self.scaler.shutDown()
-
 
 class ClusterStats(object):
     def __init__(self, path, batchSystem, clusterName):

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -721,9 +721,9 @@ class ScalerThread(ExceptionalThread):
         self.stats = None
         if config.clusterStats:
             logger.debug("Starting up cluster statistics...")
-            self.stats = ClusterStats(self.leader.config.clusterStats,
-                                      self.leader.batchSystem,
-                                      self.provisioner.clusterName)
+            self.stats = ClusterStats(leader.config.clusterStats,
+                                      leader.batchSystem,
+                                      provisioner.clusterName)
             for preemptable in [True, False]:
                 self.stats.startStats(preemptable=preemptable)
             logger.debug("...Cluster stats started.")

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -466,8 +466,8 @@ class ScalerThread(ExceptionalThread):
         self.jobShapes.add(shape)
         
     def tryRun(self):
-        try:
-            while not self.scaler.stop:
+        while not self.scaler.stop:
+            try:
                 with throttle(self.scaler.config.scaleInterval):
                     queuedJobs = self.scaler.leader.getJobs()
                     logger.info("avg runtime dict: %s" % repr(self.scaler.jobNameToAvgRuntime))
@@ -539,8 +539,11 @@ class ScalerThread(ExceptionalThread):
 
                     if self.stats:
                         self.stats.checkStats()
-        finally:
-            self.shutDown()
+            except:
+                log.exception("Exception encountered in scaler thread. Making a "
+                              "best-effort attempt to keep going, but things may "
+                              "go wrong from now on.")
+        self.shutDown()
 
     def setNodeCount(self, nodeType, numNodes, preemptable=False, force=False):
         """

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -32,6 +32,7 @@ from bd2k.util.retry import retry
 from bd2k.util.threading import ExceptionalThread
 from bd2k.util.throttle import throttle
 from itertools import islice
+from six import iteritems
 
 from toil.batchSystems.abstractBatchSystem import AbstractScalableBatchSystem, NodeInfo
 from toil.provisioners.abstractProvisioner import Shape
@@ -83,150 +84,159 @@ class RecentJobShapes(object):
         with self.lock:
             return list(self.jobShapes)
 
-
-def binPacking(jobShapes, nodeShapes):
+class BinPackedFit(object):
     """
-    Use a first fit decreasing (FFD) bin packing like algorithm to calculate an approximate
-    minimum number of nodes that will fit the given list of jobs.
-    :param Shape nodeShape: The properties of an atomic node allocation, in terms of wall-time,
-           memory, cores and local disk.
-    :param list[Shape] jobShapes: A list of shapes, each representing a job.
-    Let a *node reservation* be an interval of time that a node is reserved for, it is defined by
-    an integer number of node-allocations.
-    For a node reservation its *jobs* are the set of jobs that will be run within the node
-    reservation.
-    A minimal node reservation has time equal to one atomic node allocation, or the minimum
-    number node allocations to run the longest running job in its jobs.
-    :rtype: int
-    :returns: The minimum number of minimal node allocations estimated to be required to run all
-              the jobs in jobShapes.
+    Use a first fit decreasing (FFD) bin packing like algorithm to
+    calculate an approximate minimum number of nodes that will fit the
+    given list of jobs. To run the bin-packing algorithm, use the
+    binPack method on a list of job shapes, and use getRequiredNodes
+    to get how many nodes it thinks are required.
+
+    :param Shape nodeShapes: A list of possible types of nodes that can be launched.
+
     """
-    logger.debug('Running bin packing for node shapes %s and %s job(s).', nodeShapes, len(jobShapes))
-    # Sort in descending order from largest to smallest. The FFD like-strategy will pack the jobs in order from longest
-    # to shortest.
-    jobShapes.sort()
-    jobShapes.reverse()
+    def __init__(self, nodeShapes):
+        self.nodeShapes = nodeShapes
+        # Prioritize preemptable node shapes with the lowest memory
+        self.nodeShapes.sort(key=lambda nS: not nS.preemptable)
+        self.nodeShapes.sort(key=lambda nS: nS.memory)
+        self.nodeReservations = {nodeShape:[] for nodeShape in nodeShapes}  # The list of node reservations
 
+    def binPack(self, jobShapes):
+        """Pack a list of jobShapes into the fewest nodes reasonable. Can be run multiple times."""
+        logger.debug('Running bin packing for node shapes %s and %s job(s).', self.nodeShapes, len(jobShapes))
+        # Sort in descending order from largest to smallest. The FFD like-strategy will pack the jobs in order from longest
+        # to shortest.
+        jobShapes.sort()
+        jobShapes.reverse()
+        assert len(jobShapes) == 0 or jobShapes[0] >= jobShapes[-1]
+        for jS in jobShapes:
+            self.addJobShape(jS)
 
-    #Prioritize preemptable node shapes with the lowest memory
-    nodeShapes.sort(key=lambda nS: not nS.preemptable)
-    nodeShapes.sort(key=lambda nS: nS.memory)
-    
-    assert len(jobShapes) == 0 or jobShapes[0] >= jobShapes[-1]
-
-    class NodeReservation(object):
+    def addJobShape(self, jobShape):
         """
-        Represents a node reservation. To represent the resources available in a reservation a
-        node reservation is represented as a sequence of Shapes, each giving the resources free
-        within the given interval of time
+        Function adds the job to the first node reservation in which it will fit (this
+        is the bin-packing aspect)
         """
+        for nodeShape, nodeReservations in iteritems(self.nodeReservations):
+            for nodeReservation in nodeReservations:
+                # Attempt to add the job to node reservation
 
-        def __init__(self, shape):
-            # The wall-time and resource available
-            self.shape = shape
-            # The next portion of the reservation
-            self.nReservation = None
+                # We work with "reservations": just slices
+                # of time and the amount of memory, cpu,
+                # etc. still unreserved during that time slice.
 
-    nodeReservations = {nodeShape:[] for nodeShape in nodeShapes}  # The list of node reservations
+                # starting slice of time that we can fit in so far
+                startingReservation = nodeReservation
+                # current end of the slices we can fit in so far
+                endingReservation = startingReservation
+                # amount of the job covered by slices
+                t = 0
 
-    for jS in jobShapes:
-        def addToReservation():
-            """
-            Function adds the job, jS, to the first node reservation in which it will fit (this
-            is the bin-packing aspect)
-            """
+                while True:
+                    # Considering a new ending reservation.
+                    if endingReservation.fits(jobShape):
+                        t += endingReservation.shape.wallTime
 
-            def fits(nodeShape, jobShape):
-                """
-                Check if a job shape's resource requirements will fit within a given node allocation
-                """
-                return jobShape.memory <= nodeShape.memory and jobShape.cores <= nodeShape.cores and jobShape.disk <= nodeShape.disk and (jobShape.preemptable or not nodeShape.preemptable)
-
-            def subtract(nodeShape, jobShape):
-                """
-                Adjust available resources of a node allocation as a job is scheduled within it.
-                """
-                return Shape(nodeShape.wallTime, nodeShape.memory - jobShape.memory, nodeShape.cores - jobShape.cores, nodeShape.disk - jobShape.disk, nodeShape.preemptable)
-
-            def split(nodeShape, jobShape, t):
-                """
-                Partition a node allocation into two
-                """
-                return (Shape(t, nodeShape.memory - jobShape.memory, nodeShape.cores - jobShape.cores, nodeShape.disk - jobShape.disk, nodeShape.preemptable),
-                        NodeReservation(Shape(nodeShape.wallTime - t, nodeShape.memory, nodeShape.cores, nodeShape.disk, nodeShape.preemptable)))
-
-            for nodeShape in nodeShapes:
-                for nodeReservation in nodeReservations[nodeShape]:
-                    # Attempt to add the job to node reservation
-
-                    # We work with "reservations": just slices
-                    # of time and the amount of memory, cpu,
-                    # etc. still unreserved during that time slice.
-
-                    # starting slice of time that we can fit in so far
-                    startingReservation = nodeReservation
-                    # current end of the slices we can fit in so far
-                    endingReservation = startingReservation
-                    t = 0
-
-                    while True:
-                        if fits(endingReservation.shape, jS):
-                            t += endingReservation.shape.wallTime
-
-                            if t >= jS.wallTime:
-                                # The job fits into all the slices between startingReservation and endingReservation.
-                                t = 0
-                                # Update all the slices, reserving the amount of resources that this job needs.
-                                while startingReservation != endingReservation:
-                                    startingReservation.shape = subtract(startingReservation.shape, jS)
-                                    t += startingReservation.shape.wallTime
-                                    startingReservation = startingReservation.nReservation
-                                assert startingReservation == endingReservation
-                                assert jS.wallTime - t <= startingReservation.shape.wallTime
-
-                                if jS.wallTime - t < startingReservation.shape.wallTime:
-                                    # This job only partially fills one of the slices. Create a new slice.
-                                    startingReservation.shape, nS = split(startingReservation.shape, jS, jS.wallTime - t)
-                                    nS.nReservation = startingReservation.nReservation
-                                    startingReservation.nReservation = nS
-                                else:
-                                    # This job perfectly fits within the boundaries of the slices.
-                                    assert jS.wallTime - t == startingReservation.shape.wallTime
-                                    startingReservation.shape = subtract(startingReservation.shape, jS)
-                                return
-
-                            # If the job would fit, but is longer than the total node allocation
-                            # extend the node allocation
-                            elif endingReservation.nReservation == None and startingReservation == nodeReservation:
-                                # Extend the node reservation to accommodate jS
-                                endingReservation.nReservation = NodeReservation(nodeShape)
-                        else: # Does not fit, reset
-                            startingReservation = endingReservation.nReservation
+                        if t >= jobShape.wallTime:
+                            # The job fits into all the slices between startingReservation and endingReservation.
                             t = 0
+                            # Update all the slices, reserving the amount of resources that this job needs.
+                            while startingReservation != endingReservation:
+                                startingReservation.shape = subtract(startingReservation.shape, jobShape)
+                                t += startingReservation.shape.wallTime
+                                startingReservation = startingReservation.nReservation
+                            assert startingReservation == endingReservation
+                            assert jobShape.wallTime - t <= startingReservation.shape.wallTime
 
-                        endingReservation = endingReservation.nReservation
-                        if endingReservation is None:
-                            # Reached the end of the reservation without success so stop trying to
-                            # add to reservation
-                            break
-            # Case a new node reservation is required. Assign to the smallest node shape
-            # that will fit this job, prioritizing preemptable nodes
-            consideredNodes = [nodeShape for nodeShape in nodeShapes if nodeShape.cores >= jS.cores and nodeShape.memory >= jS.memory and nodeShape.disk >= jS.disk and (jS.preemptable or not nodeShape.preemptable)]
-            if len(consideredNodes) == 0:
-                return
-            nodeShape = consideredNodes[0]
-            x = NodeReservation(subtract(nodeShape, jS))
-            nodeReservations[nodeShape].append(x)
-            t = nodeShape.wallTime
-            while t < jS.wallTime:
-                y = NodeReservation(x.shape)
-                t += nodeShape.wallTime
-                x.nReservation = y
-                x = y
+                            if jobShape.wallTime - t < startingReservation.shape.wallTime:
+                                # This job only partially fills one of the slices. Create a new slice.
+                                startingReservation.shape, nS = split(startingReservation.shape, jobShape, jobShape.wallTime - t)
+                                nS.nReservation = startingReservation.nReservation
+                                startingReservation.nReservation = nS
+                            else:
+                                # This job perfectly fits within the boundaries of the slices.
+                                assert jobShape.wallTime - t == startingReservation.shape.wallTime
+                                startingReservation.shape = subtract(startingReservation.shape, jobShape)
+                            return
 
-        addToReservation()
-    return {nodeShape:len(nodeReservations[nodeShape]) for nodeShape in nodeShapes}
+                        # If the job would fit, but is longer than the total node allocation
+                        # extend the node allocation
+                        elif endingReservation.nReservation == None and startingReservation == nodeReservation:
+                            # Extend the node reservation to accommodate jobShape
+                            endingReservation.nReservation = NodeReservation(nodeShape)
+                    else: # Does not fit, reset
+                        startingReservation = endingReservation.nReservation
+                        t = 0
 
+                    endingReservation = endingReservation.nReservation
+                    if endingReservation is None:
+                        # Reached the end of the reservation without success so stop trying to
+                        # add to reservation
+                        break
+        # Case a new node reservation is required. Assign to the smallest node shape
+        # that will fit this job, prioritizing preemptable nodes
+        consideredNodes = [nodeShape for nodeShape in self.nodeShapes if nodeShape.cores >= jobShape.cores and nodeShape.memory >= jobShape.memory and nodeShape.disk >= jobShape.disk and (jobShape.preemptable or not nodeShape.preemptable)]
+        if len(consideredNodes) == 0:
+            return
+        nodeShape = consideredNodes[0]
+        x = NodeReservation(subtract(nodeShape, jobShape))
+        self.nodeReservations[nodeShape].append(x)
+        t = nodeShape.wallTime
+        while t < jobShape.wallTime:
+            y = NodeReservation(x.shape)
+            t += nodeShape.wallTime
+            x.nReservation = y
+            x = y
+
+    def getRequiredNodes(self):
+        """
+        Returns a dict from node shape to number of nodes required to run the packed jobs.
+        """
+        return {nodeShape:len(self.nodeReservations[nodeShape]) for nodeShape in self.nodeShapes}
+
+class NodeReservation(object):
+    """
+    Represents a node reservation. To represent the resources available in a reservation a
+    node reservation is represented as a sequence of Shapes, each giving the resources free
+    within the given interval of time
+    """
+    def __init__(self, shape):
+        # The wall-time and resource available
+        self.shape = shape
+        # The next portion of the reservation
+        self.nReservation = None
+
+    def fits(self, jobShape):
+        """Check if a job shape's resource requirements will fit within this allocation."""
+        return jobShape.memory <= self.shape.memory and jobShape.cores <= self.shape.cores and jobShape.disk <= self.shape.disk and (jobShape.preemptable or not self.shape.preemptable)
+
+    def shapes(self):
+        """Get all time-slice shapes, in order, from this reservation on."""
+        shapes = []
+        curRes = self
+        while curRes is not None:
+            shapes.append(curRes.shape)
+            curRes = curRes.nReservation
+        return shapes
+
+def subtract(nodeShape, jobShape):
+    """
+    Adjust available resources of a node allocation as a job is scheduled within it.
+    """
+    return Shape(nodeShape.wallTime, nodeShape.memory - jobShape.memory, nodeShape.cores - jobShape.cores, nodeShape.disk - jobShape.disk, nodeShape.preemptable)
+
+def split(nodeShape, jobShape, t):
+    """
+    Partition a node allocation into two
+    """
+    return (Shape(t, nodeShape.memory - jobShape.memory, nodeShape.cores - jobShape.cores, nodeShape.disk - jobShape.disk, nodeShape.preemptable),
+            NodeReservation(Shape(nodeShape.wallTime - t, nodeShape.memory, nodeShape.cores, nodeShape.disk, nodeShape.preemptable)))
+
+def binPacking(nodeShapes, jobShapes):
+    bpf = BinPackedFit(nodeShapes)
+    bpf.binPack(jobShapes)
+    return bpf.getRequiredNodes()
 
 class ClusterScaler(object):
     def __init__(self, provisioner, leader, config):
@@ -433,6 +443,9 @@ class ScalerThread(ExceptionalThread):
                 recentJobShapes = self.jobShapes.get()
                 queuedJobs = self.scaler.leader.getJobs()
                 logger.info("Detected %i queued jobs." % len(queuedJobs))
+                logger.info("avg runtime dict: %s" % repr(self.scaler.jobNameToAvgRuntime))
+                for jobName in set(job.jobName for job in queuedJobs):
+                    logger.info("Got avg runtime %s for job %s." % (self.scaler.getAverageRuntime(jobName), jobName))
                 queuedJobShapes = [Shape(wallTime=self.scaler.getAverageRuntime(jobName=job.jobName), memory=job.memory, cores=job.cores, disk=job.disk, preemptable=job.preemptable) for job in queuedJobs]
                 nodesToRunRecentJobs = binPacking(jobShapes=recentJobShapes, nodeShapes=self.nodeShapes)
                 nodesToRunQueuedJobs = binPacking(jobShapes=queuedJobShapes, nodeShapes=self.nodeShapes)

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -857,7 +857,7 @@ class MesosBatchSystemJobTest(hidden.AbstractBatchSystemJobTest, MesosTestSuppor
         self._stopMesos()
 
 
-def measureConcurrency(filepath, sleep_time=5):
+def measureConcurrency(filepath, sleep_time=1):
     """
     Run in parallel to determine the number of concurrent tasks.
     This code was copied from toil.batchSystemTestMaxCoresSingleMachineBatchSystemTest

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -120,7 +120,8 @@ class ClusterScalerTest(ToilTest):
 
             numberOfJobs = random.choice(list(range(1, 1000)))
             randomJobShapes = [randomJobShape(random.choice(nodeShapes)) for i in range(numberOfJobs)]
-            numberOfBins = binPacking(jobShapes=randomJobShapes, nodeShapes=nodeShapes)
+            numberOfBins = binPacking(jobShapes=randomJobShapes, nodeShapes=nodeShapes,
+                                      goalTime=3600)
             logger.info("Made the following node reservations: %s" % numberOfBins)
 
 
@@ -208,7 +209,7 @@ class ClusterScalerTest(ToilTest):
         config.maxNodes = [10]
 
         # Algorithm parameters
-        config.alphaPacking = 0.0
+        config.alphaTime = 3600
         config.betaInertia = 1.2
         config.scaleInterval = 3
 
@@ -241,7 +242,7 @@ class ClusterScalerTest(ToilTest):
         config.maxNodes = [10, 10] # test expansion of this list
 
         # Algorithm parameters
-        config.alphaPacking = 0.0
+        config.alphaTime = 3600
         config.betaInertia = 1.2
         config.scaleInterval = 3
 
@@ -304,7 +305,7 @@ class ClusterScalerTest(ToilTest):
         config.maxNodes = [10,10]
 
         # Algorithm parameters
-        config.alphaPacking = 0.0
+        config.alphaTime = 3600
         config.betaInertia = 1.2
         config.scaleInterval = 3
 

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -406,7 +406,7 @@ class ScalerThreadTest(ToilTest):
 
         # Algorithm parameters
         config.targetTime = defaultTargetTime
-        config.betaInertia = 1.2
+        config.betaInertia = 1.0
         config.scaleInterval = 3
 
         self._testClusterScaling(config, numJobs=100, numPreemptableJobs=0,
@@ -440,7 +440,7 @@ class ScalerThreadTest(ToilTest):
 
         # Algorithm parameters
         config.targetTime = defaultTargetTime
-        config.betaInertia = 1.2
+        config.betaInertia = 1.0
         config.scaleInterval = 3
 
         mock = MockBatchSystemAndProvisioner(config, secondsPerJob=2.0)
@@ -504,7 +504,7 @@ class ScalerThreadTest(ToilTest):
 
         # Algorithm parameters
         config.targetTime = defaultTargetTime
-        config.betaInertia = 1.2
+        config.betaInertia = 1.0
         config.scaleInterval = 3
 
         self._testClusterScaling(config, numJobs=100, numPreemptableJobs=100, jobShape=jobShape)

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -144,7 +144,7 @@ class BinPackingTest(ToilTest):
                                   disk=h2b('0.1G'),
                                   preemptable=False))
         logger.info(str(bpf1.getRequiredNodes()))
-        self.assertEqual(bpf1.getRequiredNodes(), {t2_micro: 50})
+        self.assertEqual(bpf1.getRequiredNodes(), {t2_micro: 100})
 
         # test high targetTime (3600 seconds)
         nodeShapes2 = [t2_micro]

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -82,6 +82,23 @@ class BinPackingTest(ToilTest):
                          [[Shape(wallTime=1000, memory=59000000000, cores=34, disk=98000000000, preemptable=True),
                            Shape(wallTime=2600, memory=60000000000, cores=36, disk=100000000000, preemptable=True)]])
 
+    def testPathologicalCase(self):
+        """Test a pathological case where only one node can be requested to fit months' worth of jobs.
+
+        If the reservation is extended to fit a long job, and the
+        bin-packer naively searches through all the reservation slices
+        to find the first slice that fits, it will happily assign the
+        first slot that fits the job, even if that slot occurs days in
+        the future.
+        """
+        # Add one job that partially fills an r3.8xlarge for 1000 hours
+        self.bpf.addJobShape(Shape(wallTime=3600000, memory=10000000000, cores=0, disk=10000000000, preemptable=False))
+        for _ in xrange(500):
+            # Add 500 CPU-hours worth of jobs that fill an r3.8xlarge
+            self.bpf.addJobShape(Shape(wallTime=3600, memory=26000000000, cores=32, disk=60000000000, preemptable=False))
+        # Hopefully we didn't assign just one node to cover all those jobs.
+        self.assertNotEqual(self.bpf.getRequiredNodes(), {self.r3_8xlarge: 1, self.c4_8xlarge: 0})
+
 class ClusterScalerTest(ToilTest):
 
     @slow

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -117,10 +117,9 @@ class ClusterScalerTest(ToilTest):
                                              cores=random.choice(list(range(1, x.cores + 1))),
                                              disk=random.choice(list(range(1, x.disk + 1))),
                                              preemptable=False)
-            randomJobShapes = []
-            for nodeShape in nodeShapes:
-                numberOfJobs = random.choice(list(range(1, 1000)))
-                randomJobShapes.extend([randomJobShape(nodeShape) for i in range(numberOfJobs)])
+
+            numberOfJobs = random.choice(list(range(1, 1000)))
+            randomJobShapes = [randomJobShape(random.choice(nodeShapes)) for i in range(numberOfJobs)]
             numberOfBins = binPacking(jobShapes=randomJobShapes, nodeShapes=nodeShapes)
             logger.info("Made the following node reservations: %s" % numberOfBins)
 

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -45,31 +45,35 @@ from toil.provisioners.abstractProvisioner import AbstractProvisioner, Shape
 from toil.provisioners.clusterScaler import (ClusterScaler,
                                              ScalerThread,
                                              BinPackedFit,
-                                             NodeReservation,
-                                             defaultTargetTime)
-from toil.common import Config
+                                             NodeReservation)
+from toil.common import Config, defaultTargetTime
 
 logger = logging.getLogger(__name__)
 
-# simplified preemptable c4.8xlarge
+# simplified c4.8xlarge (preemptable)
 c4_8xlarge = Shape(wallTime=3600,
                    memory=h2b('60G'),
                    cores=36,
                    disk=h2b('100G'),
                    preemptable=True)
-# simplified non-preemptable c4.8xlarge
+# simplified c4.8xlarge (non-preemptable)
 c4_8xlarge_nonpreemptable = Shape(wallTime=3600,
                                   memory=h2b('60G'),
                                   cores=36,
                                   disk=h2b('100G'),
                                   preemptable=False)
-# simplified non-preemptable r3.8xlarge
+# simplified r3.8xlarge (non-preemptable)
 r3_8xlarge = Shape(wallTime=3600,
                    memory=h2b('260G'),
                    cores=32,
                    disk=h2b('600G'),
                    preemptable=False)
-
+# simplified t2.micro (non-preemptable)
+t2_micro = Shape(wallTime=3600,
+                 memory=h2b('1G'),
+                 cores=1,
+                 disk=h2b('8G'),
+                 preemptable=False)
 
 class BinPackingTest(ToilTest):
     def setUp(self):
@@ -116,6 +120,46 @@ class BinPackingTest(ToilTest):
                                  disk=h2b('100G'),
                                  preemptable=True)]])
 
+    def test1000micros(self):
+        """Test packing 1000 t2.micros.  Depending on the targetTime, these should pack differently.
+
+        Ideally, low targetTime means: Start quickly and maximize parallelization.  This should
+        appropriate 1000 instances for 1000 parallel jobs so if each job, for example, takes 5
+        minutes, then the run should complete in around 5 (realistically less than 10) minutes.
+
+        High targetTime means: Maximize packing within the targetTime.  For example, if all 1000
+        jobs take 5 minutes each, and the targetTime is 60 minutes, the bin packing algorithm
+        should appropriate 12 jobs per instance (60 minutes / 5 minutes).  That way, theoretically,
+        """
+
+        # test low targetTime (60 seconds)
+        nodeShapes1 = [t2_micro]
+        bpf1 = BinPackedFit(nodeShapes1)
+        bpf1.targetTime = 0
+
+        for _ in range(1000):
+            bpf1.addJobShape(Shape(wallTime=300,
+                                  memory=h2b('0.1G'),
+                                  cores=0.1,
+                                  disk=h2b('0.1G'),
+                                  preemptable=False))
+        logger.info(str(bpf1.getRequiredNodes()))
+        self.assertEqual(bpf1.getRequiredNodes(), {t2_micro: 50})
+
+        # test high targetTime (3600 seconds)
+        nodeShapes2 = [t2_micro]
+        bpf2 = BinPackedFit(nodeShapes2)
+        bpf2.targetTime = 3600
+
+        for _ in range(1000):
+            bpf2.addJobShape(Shape(wallTime=300,
+                                  memory=h2b('0G'),
+                                  cores=0,
+                                  disk=h2b('0G'),
+                                  preemptable=False))
+        logger.info(str(bpf2.getRequiredNodes()))
+        self.assertEqual(bpf2.getRequiredNodes(), {t2_micro: 1})
+
     def testPathologicalCase(self):
         """Test a pathological case where only one node can be requested to fit months' worth of jobs.
 
@@ -133,12 +177,11 @@ class BinPackingTest(ToilTest):
                                    preemptable=False))
         for _ in range(500):
             # Add 500 CPU-hours worth of jobs that fill an r3.8xlarge
-            self.bpf.addJobShape(
-                Shape(wallTime=3600,
-                      memory=h2b('26G'),
-                      cores=32,
-                      disk=h2b('60G'),
-                      preemptable=False))
+            self.bpf.addJobShape(Shape(wallTime=3600,
+                                       memory=h2b('26G'),
+                                       cores=32,
+                                       disk=h2b('60G'),
+                                       preemptable=False))
         # Hopefully we didn't assign just one node to cover all those jobs.
         self.assertNotEqual(self.bpf.getRequiredNodes(), {r3_8xlarge: 1, c4_8xlarge: 0})
 

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -99,6 +99,19 @@ class BinPackingTest(ToilTest):
                                  disk=h2b('100G'),
                                  preemptable=True)]])
 
+    def testSorting(self):
+        """
+        Test that sorting is correct: preemptable, then memory, then cores, then disk,
+        then wallTime.
+        """
+        # TODO: Rename intuitively.  All shapes are non-preempt, except for c4_8xlarge
+        shapeList = [c4_8xlarge, r3_8xlarge, c4_8xlarge_nonpreemptable, c4_8xlarge_nonpreemptable,
+                     t2_micro, t2_micro, c4_8xlarge_nonpreemptable, r3_8xlarge, r3_8xlarge, t2_micro]
+        shapeList.sort()
+        assert shapeList == [c4_8xlarge, r3_8xlarge, r3_8xlarge, r3_8xlarge,
+                             c4_8xlarge_nonpreemptable, c4_8xlarge_nonpreemptable,
+                             c4_8xlarge_nonpreemptable, t2_micro, t2_micro, t2_micro]
+
     def testAddingInitialNode(self):
         """Pack one shape when no nodes are available and confirm that we fit one node properly."""
         self.bpf.addJobShape(Shape(wallTime=1000,

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -31,8 +31,6 @@ from six.moves.queue import Empty, Queue
 from six.moves import xrange
 from six import iteritems
 
-from bd2k.util.objects import InnerClass
-
 from toil.job import JobNode, Job
 
 from toil.test import ToilTest, slow
@@ -41,7 +39,7 @@ from toil.batchSystems.abstractBatchSystem import (AbstractScalableBatchSystem,
                                                    AbstractBatchSystem)
 from toil.provisioners.node import Node
 from toil.provisioners.abstractProvisioner import AbstractProvisioner, Shape
-from toil.provisioners.clusterScaler import ClusterScaler, binPacking
+from toil.provisioners.clusterScaler import ClusterScaler, binPacking, BinPackedFit, NodeReservation
 from toil.common import Config
 
 
@@ -59,6 +57,30 @@ if False:
     ch.setFormatter(formatter)
     logging.getLogger().addHandler(ch)
 
+class BinPackingTest(ToilTest):
+    def setUp(self):
+        # simplified preemptable c4.8xlarge
+        self.c4_8xlarge = Shape(wallTime=3600, memory=60000000000, cores=36, disk=100000000000, preemptable=True)
+        # simplified r3.8xlarge
+        self.r3_8xlarge = Shape(wallTime=3600, memory=260000000000, cores=32, disk=600000000000, preemptable=False)
+        self.nodeShapes = [self.c4_8xlarge, self.r3_8xlarge]
+        self.bpf = BinPackedFit(self.nodeShapes)
+
+    def testPackingOneShape(self):
+        """Pack one shape and check that the resulting reservations look sane."""
+        self.bpf.nodeReservations[self.c4_8xlarge] = [NodeReservation(self.c4_8xlarge)]
+        self.bpf.addJobShape(Shape(wallTime=1000, cores=2, memory=1000000000, disk=2000000000, preemptable=True))
+        self.assertEqual(self.bpf.nodeReservations[self.r3_8xlarge], [])
+        self.assertEqual([x.shapes() for x in self.bpf.nodeReservations[self.c4_8xlarge]],
+                         [[Shape(wallTime=1000, memory=59000000000, cores=34, disk=98000000000, preemptable=True),
+                           Shape(wallTime=2600, memory=60000000000, cores=36, disk=100000000000, preemptable=True)]])
+
+    def testAddingInitialNode(self):
+        """Pack one shape when no nodes are available and confirm that we fit one node properly."""
+        self.bpf.addJobShape(Shape(wallTime=1000, cores=2, memory=1000000000, disk=2000000000, preemptable=True))
+        self.assertEqual([x.shapes() for x in self.bpf.nodeReservations[self.c4_8xlarge]],
+                         [[Shape(wallTime=1000, memory=59000000000, cores=34, disk=98000000000, preemptable=True),
+                           Shape(wallTime=2600, memory=60000000000, cores=36, disk=100000000000, preemptable=True)]])
 
 class ClusterScalerTest(ToilTest):
 
@@ -82,7 +104,6 @@ class ClusterScalerTest(ToilTest):
             for nodeShape in nodeShapes:
                 numberOfJobs = random.choice(list(range(1, 1000)))
                 randomJobShapes.extend([randomJobShape(nodeShape) for i in range(numberOfJobs)])
-            startTime = time.time()
             numberOfBins = binPacking(jobShapes=randomJobShapes, nodeShapes=nodeShapes)
             logger.info("Made the following node reservations: %s" % numberOfBins)
 

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -321,11 +321,201 @@ class ClusterScalerTest(ToilTest):
         self.assertEqual(scaler.smoothEstimate(c4_8xlarge, 100), 100)
 
 
+class ScalerThreadTest(ToilTest):
+    def _testClusterScaling(self, config, numJobs, numPreemptableJobs, jobShape):
+        """
+        Test the ClusterScaler class with different patterns of job creation. Tests ascertain that
+        autoscaling occurs and that all the jobs are run.
+        """
+        # First do simple test of creating 100 preemptable and non-premptable jobs and check the
+        # jobs are completed okay, then print the amount of worker time expended and the total
+        # number of worker nodes used.
+
+        mock = MockBatchSystemAndProvisioner(config, secondsPerJob=2.0)
+        mock.start()
+        clusterScaler = ScalerThread(mock, mock, config)
+        clusterScaler.start()
+        try:
+            # Add 100 jobs to complete
+            list(map(lambda x: mock.addJob(jobShape=jobShape),
+                     list(range(numJobs))))
+            list(map(lambda x: mock.addJob(jobShape=jobShape, preemptable=True),
+                     list(range(numPreemptableJobs))))
+
+            # Add some completed jobs
+            for preemptable in (True, False):
+                if preemptable and numPreemptableJobs > 0 or not preemptable and numJobs > 0:
+                    # Add 1000 random jobs
+                    for i in range(1000):
+                        x = mock.getNodeShape(nodeType=jobShape)
+                        iJ = JobNode(jobStoreID=1,
+                                     requirements=dict(
+                                         memory=random.choice(list(range(1, x.memory))),
+                                         cores=random.choice(list(range(1, x.cores))),
+                                         disk=random.choice(list(range(1, x.disk))),
+                                         preemptable=preemptable),
+                                     command=None,
+                                     jobName='testClusterScaling', unitName='')
+                        clusterScaler.addCompletedJob(iJ, random.choice(list(range(1, x.wallTime))))
+
+            startTime = time.time()
+            # Wait while the cluster processes the jobs
+            while (mock.getNumberOfJobsIssued(preemptable=False) > 0
+                   or mock.getNumberOfJobsIssued(preemptable=True) > 0
+                   or mock.getNumberOfNodes() > 0 or mock.getNumberOfNodes(preemptable=True) > 0):
+                logger.debug("Running, non-preemptable queue size: %s, non-preemptable workers: %s, "
+                            "preemptable queue size: %s, preemptable workers: %s" %
+                            (mock.getNumberOfJobsIssued(preemptable=False),
+                             mock.getNumberOfNodes(preemptable=False),
+                             mock.getNumberOfJobsIssued(preemptable=True),
+                             mock.getNumberOfNodes(preemptable=True)))
+                clusterScaler.check()
+                time.sleep(0.5)
+            logger.debug("We waited %s for cluster to finish" % (time.time() - startTime))
+        finally:
+            clusterScaler.shutdown()
+            mock.shutDown()
+
+        # Print some info about the autoscaling
+        logger.debug("Total-jobs: %s: Max-workers: %s, "
+                     "Total-worker-time: %s, Worker-time-per-job: %s" %
+                    (mock.totalJobs, sum(mock.maxWorkers.values()),
+                     mock.totalWorkerTime,
+                     old_div(mock.totalWorkerTime, mock.totalJobs) if mock.totalJobs > 0 else 0.0))
+
+    @slow
+    def testClusterScaling(self):
+        """
+        Test scaling for a batch of non-preemptable jobs and no preemptable jobs (makes debugging
+        easier).
+        """
+        config = Config()
+
+        # Make defaults dummy values
+        config.defaultMemory = 1
+        config.defaultCores = 1
+        config.defaultDisk = 1
+
+        # No preemptable nodes/jobs
+        config.maxPreemptableNodes = []  # No preemptable nodes
+
+        # Non-preemptable parameters
+        config.nodeTypes = [Shape(20, 10, 10, 10, False)]
+        config.minNodes = [0]
+        config.maxNodes = [10]
+
+        # Algorithm parameters
+        config.targetTime = defaultTargetTime
+        config.betaInertia = 1.2
+        config.scaleInterval = 3
+
+        self._testClusterScaling(config, numJobs=100, numPreemptableJobs=0,
+                                 jobShape=config.nodeTypes[0])
+
+    @slow
+    def testClusterScalingMultipleNodeTypes(self):
+
+        smallNode = Shape(20, 5, 10, 10, False)
+        mediumNode = Shape(20, 10, 10, 10, False)
+        largeNode = Shape(20, 20, 10, 10, False)
+
+        numJobs = 100
+
+        config = Config()
+
+        # Make defaults dummy values
+        config.defaultMemory = 1
+        config.defaultCores = 1
+        config.defaultDisk = 1
+
+        # No preemptable nodes/jobs
+        config.preemptableNodeTypes = []
+        config.minPreemptableNodes = []
+        config.maxPreemptableNodes = []  # No preemptable nodes
+
+        # Make sure the node types don't have to be ordered
+        config.nodeTypes = [largeNode, smallNode, mediumNode]
+        config.minNodes = [0, 0, 0]
+        config.maxNodes = [10, 10]  # test expansion of this list
+
+        # Algorithm parameters
+        config.targetTime = defaultTargetTime
+        config.betaInertia = 1.2
+        config.scaleInterval = 3
+
+        mock = MockBatchSystemAndProvisioner(config, secondsPerJob=2.0)
+        clusterScaler = ScalerThread(mock, mock, config)
+        clusterScaler.start()
+        mock.start()
+
+        try:
+            # Add small jobs
+            list(map(lambda x: mock.addJob(jobShape=smallNode), list(range(numJobs))))
+            list(map(lambda x: mock.addJob(jobShape=mediumNode), list(range(numJobs))))
+
+            # Add medium completed jobs
+            for i in range(1000):
+                iJ = JobNode(jobStoreID=1,
+                             requirements=dict(
+                                 memory=random.choice(range(smallNode.memory, mediumNode.memory)),
+                                 cores=mediumNode.cores,
+                                 disk=largeNode.cores,
+                                 preemptable=False),
+                             command=None,
+                             jobName='testClusterScaling', unitName='')
+                clusterScaler.addCompletedJob(iJ, random.choice(range(1, 10)))
+
+            while mock.getNumberOfJobsIssued() > 0 or mock.getNumberOfNodes() > 0:
+                logger.info("%i nodes currently provisioned" % mock.getNumberOfNodes())
+                # Make sure there are no large nodes
+                self.assertEqual(mock.getNumberOfNodes(nodeType=largeNode), 0)
+                clusterScaler.check()
+                time.sleep(0.5)
+        finally:
+            clusterScaler.shutdown()
+            mock.shutDown()
+
+        # Make sure jobs ran on both the small and medium node types
+        self.assertTrue(mock.totalJobs > 0)
+        self.assertTrue(mock.maxWorkers[smallNode] > 0)
+        self.assertTrue(mock.maxWorkers[mediumNode] > 0)
+
+        self.assertEqual(mock.maxWorkers[largeNode], 0)
+
+    @slow
+    def testClusterScalingWithPreemptableJobs(self):
+        """
+        Test scaling simultaneously for a batch of preemptable and non-preemptable jobs.
+        """
+        config = Config()
+
+        jobShape = Shape(20, 10, 10, 10, False)
+        preemptableJobShape = Shape(20, 10, 10, 10, True)
+
+        # Make defaults dummy values
+        config.defaultMemory = 1
+        config.defaultCores = 1
+        config.defaultDisk = 1
+
+        # non-preemptable node parameters
+        config.nodeTypes = [jobShape, preemptableJobShape]
+        config.minNodes = [0, 0]
+        config.maxNodes = [10, 10]
+
+        # Algorithm parameters
+        config.targetTime = defaultTargetTime
+        config.betaInertia = 1.2
+        config.scaleInterval = 3
+
+        self._testClusterScaling(config, numJobs=100, numPreemptableJobs=100, jobShape=jobShape)
+
+
 # noinspection PyAbstractClass
 class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisioner):
     """
     Mimics a job batcher, provisioner and scalable batch system
     """
+
     def __init__(self, config, secondsPerJob):
         super(MockBatchSystemAndProvisioner, self).__init__('clusterName')
         # To mimic parallel preemptable and non-preemptable queues
@@ -365,6 +555,7 @@ class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisi
         self.leaderThread.join()
 
     # Stub out all AbstractBatchSystem methods since they are never called
+
     for name, value in iteritems(AbstractBatchSystem.__dict__):
         if getattr(value, '__isabstractmethod__', False):
             exec('def %s(): pass' % name)
@@ -372,6 +563,7 @@ class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisi
         del name, value
 
     # AbstractScalableBatchSystem methods
+
     def nodeInUse(self, nodeIP):
         return False
 
@@ -389,6 +581,7 @@ class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisi
         yield nodes
 
     # AbstractProvisioner methods
+
     def getProvisionedWorkers(self, nodeType=None, preemptable=None):
         """
         Returns a list of Node objects, each representing a worker node in the cluster
@@ -415,12 +608,12 @@ class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisi
         self.totalJobs += 1
         jobID = uuid.uuid4()
         self.jobBatchSystemIDToIssuedJob[jobID] = Job(memory=jobShape.memory,
-                                                      cores=jobShape.cores,
-                                                      disk=jobShape.disk,
+                                                      cores=jobShape.cores, disk=jobShape.disk,
                                                       preemptable=preemptable)
         self.jobQueue.put(jobID)
 
     # JobBatcher functionality
+
     def getNumberOfJobsIssued(self, preemptable=None):
         if preemptable is not None:
             jobList = [job for job in list(self.jobQueue.queue) if
@@ -433,6 +626,7 @@ class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisi
         return self.jobBatchSystemIDToIssuedJob.values()
 
     # AbstractScalableBatchSystem functionality
+
     def getNodes(self, preemptable=False, timeout=None):
         nodes = dict()
         for node in self.nodesToWorker:
@@ -444,6 +638,7 @@ class MockBatchSystemAndProvisioner(AbstractScalableBatchSystem, AbstractProvisi
         return nodes
 
     # AbstractProvisioner functionality
+
     def addNodes(self, nodeType, numNodes, preemptable):
         self._addNodes(numNodes=numNodes, nodeType=nodeType, preemptable=preemptable)
         return self.getNumberOfNodes(nodeType=nodeType, preemptable=preemptable)

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -139,12 +139,12 @@ class BinPackingTest(ToilTest):
 
         for _ in range(1000):
             bpf1.addJobShape(Shape(wallTime=300,
-                                  memory=h2b('0.1G'),
-                                  cores=0.1,
-                                  disk=h2b('0.1G'),
-                                  preemptable=False))
+                                   memory=h2b('1G'),
+                                   cores=1,
+                                   disk=h2b('1G'),
+                                   preemptable=False))
         logger.info(str(bpf1.getRequiredNodes()))
-        self.assertEqual(bpf1.getRequiredNodes(), {t2_micro: 100})
+        self.assertEqual(bpf1.getRequiredNodes(), {t2_micro: 1000})
 
         # test high targetTime (3600 seconds)
         nodeShapes2 = [t2_micro]
@@ -153,10 +153,10 @@ class BinPackingTest(ToilTest):
 
         for _ in range(1000):
             bpf2.addJobShape(Shape(wallTime=300,
-                                  memory=h2b('0G'),
-                                  cores=0,
-                                  disk=h2b('0G'),
-                                  preemptable=False))
+                                   memory=h2b('0G'),
+                                   cores=0,
+                                   disk=h2b('0G'),
+                                   preemptable=False))
         logger.info(str(bpf2.getRequiredNodes()))
         self.assertEqual(bpf2.getRequiredNodes(), {t2_micro: 1})
 
@@ -406,7 +406,7 @@ class ScalerThreadTest(ToilTest):
 
         # Algorithm parameters
         config.targetTime = defaultTargetTime
-        config.betaInertia = 1.0
+        config.betaInertia = 0.1
         config.scaleInterval = 3
 
         self._testClusterScaling(config, numJobs=100, numPreemptableJobs=0,
@@ -440,7 +440,7 @@ class ScalerThreadTest(ToilTest):
 
         # Algorithm parameters
         config.targetTime = defaultTargetTime
-        config.betaInertia = 1.0
+        config.betaInertia = 0.1
         config.scaleInterval = 3
 
         mock = MockBatchSystemAndProvisioner(config, secondsPerJob=2.0)
@@ -504,7 +504,7 @@ class ScalerThreadTest(ToilTest):
 
         # Algorithm parameters
         config.targetTime = defaultTargetTime
-        config.betaInertia = 1.0
+        config.betaInertia = 0.1
         config.scaleInterval = 3
 
         self._testClusterScaling(config, numJobs=100, numPreemptableJobs=100, jobShape=jobShape)


### PR DESCRIPTION
This is a slight refactoring and retouching of the autoscaler. This fixes several bugs, some of which are blockers for certain niche use-cases. Notably:
- Services weren't being treated specially by the autoscaler. Services are one case where the degree of parallelization really, really matters. If you have multiple services, they may all need to be running simultaneously before any real work can be done. Previously, if your services had a fairly short runtime, the autoscaler would believe that it could pack them serially, one after the other. This would lead to service deadlocks in some situations.
- New node reservations (reservations are sort of like "time-slices" of resource usage at a node, so you can find the projected resource usage at each point in time) weren't split, meaning that a 5-minute job that uses 5 cores would be projected to use 5 cores for the entire 1-hour "wallTime" of the instance. This means in certain situations, more nodes would be created than would be optimal.
- A long-running job, which "extends" a node reservation for a very long time, could end up causing other jobs to be packed into its extended reservations, even though they may be projected to start several hours in the future. This ends up underprovisioning nodes if you have a few long-running jobs and many more short jobs. (I've noticed the old pre-multiple-node-types scaler underestimating the number of needed nodes with Cactus, though I don't know whether that's caused by this particular bug or not.)
- The ignored nodes functionality didn't work at all, or when it did, only rarely, because the ignoredNodes set was based on IP addresses, and the Mesos batch system was checking *hostnames* to see if they were ignored.
- When running services or other long-running jobs, the ignored nodes functionality would rarely lead to deadlocks, where all N nodes were ignored despite wanting to scale up to N nodes. Now the scaler will "unignore" nodes if it changes its mind about scaling up or down.

For context, the original scaler worked like this: take the resource requirements of the last 10000 completed jobs, attempt to figure out how many nodes would be able to run those so that all jobs started within an hour. Then multiply that by the length of the current queue times a constant "alpha packing" factor. This is nice from a performance point of view (because it only needs to pack at most 10000 jobs), but leads to some *really* weird results, because it used the past to predict the future. It also isn't ideal when you absolutely need parallelism (services), because you *never* want to under-provision like you would with an alphaPacking < 1.0. The current scaler is a blend of using "recent" jobs vs. queued jobs, with alphaPacking determining the mix between the two.

This alters the scaler so that it works entirely on the basis of queued jobs, and the "alpha" parameter is a time. The packing attempts to spawn enough nodes that all the queued jobs will be started by that time. Intuitively this is just a parameter which controls the degree of parallelization, without (hopefully) causing deadlocks if it can help it.

Anyway, this has been mangled a bit since I last tested it thoroughly, because it's been through a rebase and now selectively cherry-picked off my fork. So it's not ready to merge just yet, but it should be relatively OK.

Some considerations:
- The scaler basically attempts to set the rate of job completion (assuming homogeneous jobs for simplicity) to n/a, n being the number of jobs and a being the alpha factor. But the scaler will run again in (by default) 60 seconds, and assuming some jobs have been completed, it will try to set the rate of job completion lower (because n is lower). The total number of jobs remaining, n, will decrease from the starting point N as roughly n = N/(t/a + 1). So the end result isn't the local result, that all jobs are started within alpha seconds--quite the contrary, they are almost guaranteed not to unless they can all fit into one node. This isn't a new problem: the old scalers had the exact same behavior, but ironically it didn't really matter because they couldn't scale down very well. We should solve this properly at some point, but for now I recommend increasing the scaler interval.
- The beta parameter has always annoyed me a bit: I like the basic idea, but I think the current behavior is less useful than it could be, and can sometimes lead to problematic under-provisioning. Right now it is basically used to ignore small fluctuations, which is fine. But the problem I usually have with the scaler isn't with small fluctuations, it's with fluctuations that are too large, too fast. Usually this happens when thousands of small jobs are being dumped all at once, right after a series of long jobs, causing the autoscaler to freak out and hit its max -- then it rapidly figures out the jobs are pretty short and adjusts to something smaller than the max within 5 minutes, wasting some money. So I'd prefer the inertia parameter to be something much more like a moving average, which could give the autoscaler a chance to adjust, while still being able to hit the max in a reasonable time. (The moving average could still have some minor fluctuations, so maybe the existing beta parameter behavior would still be needed.)
- How should we order the "preference" of nodes to launch? Currently a sort is used which will do the "right" thing in the vast, vast majority of cases--but not all. Should we use the ordering provided by the user, and trust them to do it right? Or should we sort to prioritize the cheapest instances first, which is probably what the user wants?