### PR TITLE
Suppress boto logs.  Addresses #2140.

### DIFF
--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -44,7 +44,7 @@ from toil.provisioners import (awsRemainingBillingInterval, awsFilterImpairedNod
                                Node, NoSuchClusterException)
 
 logger = logging.getLogger(__name__)
-logging.getLogger("boto").setLevel(logging.WARNING)
+logging.getLogger("boto").setLevel(logging.CRITICAL)
 
 def awsRetryPredicate(e):
     if not isinstance(e, BotoServerError):


### PR DESCRIPTION
Addresses #2140.

`logging.getLogger("boto").setLevel(logging.WARNING)` was added and now it's spamming confusing error messages to the terminal.  This should suppress it enough that it doesn't flood the terminal with errors (which seem to be benign) each time a user launches a cluster.