### PR TITLE
modify message upon successful ssh-cluster <cluster-name>

### DIFF
--- a/docker/Dockerfile.py
+++ b/docker/Dockerfile.py
@@ -41,13 +41,11 @@ def heredoc(s):
 
 motd = heredoc('''
 
-    This is the Toil appliance. You can run your Toil script directly on the appliance, but only
-    in single-machine mode. Alternatively, create a Toil cluster with `toil launch-cluster`,
-    log into the leader of that cluster with `toil ssh-cluster` and run your Toil script there.
-
+    This is the Toil appliance. You can run your Toil script directly on the appliance. 
+    Run toil <workflow>.py --help to see all options for running your workflow.
     For more information see http://toil.readthedocs.io/en/latest/
 
-    Copyright (C) 2015-2016 Regents of the University of California
+    Copyright (C) 2015-2018 Regents of the University of California
 
     Version: {applianceSelf}
 


### PR DESCRIPTION
Previous message upon a successful toil ssh-cluster <cluster-name> stated that the user entered a toil appliance, which 'could only run scripts in single-machine mode.'

Addresses: #2147.