### PR TITLE
Add option not to generate a master public key (resolves #2154)

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -99,7 +99,8 @@ class Config(object):
         self.preemptableCompensation = 0.0
         self.nodeStorage = 50
         self.metrics = False
-        
+        self.noMasterPublicKey = False
+
         # Parameters to limit service jobs, so preventing deadlock scheduling scenarios
         self.maxPreemptableServiceJobs = sys.maxsize
         self.maxServiceJobs = sys.maxsize
@@ -236,6 +237,7 @@ class Config(object):
         if not 0.0 <= self.preemptableCompensation <= 1.0:
             raise Exception('--preemptableCompensation (%f) must be >= 0.0 and <= 1.0.' % self.preemptableCompensation)
         setOption("nodeStorage", int)
+        setOption("noMasterPublicKey")
 
         # Parameters to limit service jobs / detect deadlocks
         setOption("maxServiceJobs", int)
@@ -304,6 +306,13 @@ def _addOptions(addGroupFn, config):
     addOptionFn = addGroupFn("toil core options",
                              "Options to specify the location of the Toil workflow and turn on "
                              "stats collation about the performance of jobs.")
+
+    addOptionFn("--noMasterPublicKey", dest="noMasterPublicKey", action="store_true", default=None,
+                help="Do not create a master public key for the provisioner. "
+                     "This should be used when using autoscaling and "
+                     "running the pipeline from Dockstore (which calls cwl-runner), "
+                     "because cwl-runner locks the file system on the leader and "
+                     "creation of an ssh key is not possible.")
     addOptionFn('jobStore', type=str,
                 help="The location of the job store for the workflow. " + jobStoreLocatorHelp)
     addOptionFn("--workDir", dest="workDir", default=None,

--- a/src/toil/provisioners/aws/awsProvisioner.py
+++ b/src/toil/provisioners/aws/awsProvisioner.py
@@ -111,7 +111,10 @@ class AWSProvisioner(AbstractProvisioner):
             self.leaderIP = self.instanceMetaData['local-ipv4']  # this is PRIVATE IP
             self.keyName = list(self.instanceMetaData['public-keys'].keys())[0]
             self.tags = self._getLeader(self.clusterName).tags
-            self.masterPublicKey = self._setSSH()
+            if config.noMasterPublicKey: 
+                self.masterPublicKey = 'AAAAB3NzaC1yc2Enoauthorizedkeyneeded'
+            else:
+                self.masterPublicKey = self._setSSH()
             self.nodeStorage = config.nodeStorage
             spotBids = []
             self.nonPreemptableNodeTypes = []


### PR DESCRIPTION
Add an option to Toil to not create a master public key for the
provisioner when using autoscaling and running the pipeline from
Dockstore (which calls cwl-runner) where the pipeline is running
as the leader node, because cwl-runner locks the file system on
the leader and creation of an ssh key is not possible. If the
provisioner attempts to create the ssh key an exception will be thrown.
Resolves: #2154