### PR TITLE
Reduce toil clean memory usage for AWS jobStores

### DIFF
--- a/src/toil/jobStores/aws/jobStore.py
+++ b/src/toil/jobStores/aws/jobStore.py
@@ -1284,7 +1284,7 @@ class AWSJobStore(AbstractJobStore):
                 try:
                     for upload in bucket.list_multipart_uploads():
                         upload.cancel_upload()
-                    for key in list(bucket.list_versions()):
+                    for key in bucket.list_versions():
                         bucket.delete_key(key.name, version_id=key.version_id)
                     bucket.delete()
                 except S3ResponseError as e:


### PR DESCRIPTION
If you have a sufficiently large jobStore on AWS, `toil clean` can take hundreds of GB of memory, because it reads in the names of all "versions" before deleting any of them.

This just uses boto's automatic paging to avoid taking up any appreciable amount of memory.