### PR TITLE
Fix new CWL conformance test problems (closes #2161).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def runSetup():
     gcs = 'google-cloud-storage==1.6.0'
     gcs_oauth2_boto_plugin = 'gcs_oauth2_boto_plugin==1.14'
     apacheLibcloud = 'apache-libcloud==2.2.1'
-    cwltool = 'cwltool==1.0.20180330141240'
+    cwltool = 'cwltool==1.0.20180403145700'
     schemaSalad = 'schema-salad >= 2.6, < 3'
     galaxyLib = 'galaxy-lib==17.9.3'
     cwltest = 'cwltest>=1.0.20180209171722'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def runSetup():
     boto = 'boto==2.38.0'
     boto3 = 'boto3==1.4.7'
     futures = 'futures==3.0.5'
-    pycryptodome = 'pycryptodome==3.5.0'
+    pycryptodome = 'pycryptodome==3.5.1'
     psutil = 'psutil==3.0.1'
     protobuf = 'protobuf==3.5.1'
     azure = 'azure==2.0.0'
@@ -35,10 +35,10 @@ def runSetup():
     gcs = 'google-cloud-storage==1.6.0'
     gcs_oauth2_boto_plugin = 'gcs_oauth2_boto_plugin==1.14'
     apacheLibcloud = 'apache-libcloud==2.2.1'
-    cwltool = 'cwltool==1.0.20180306140409'
+    cwltool = 'cwltool==1.0.20180330141240'
     schemaSalad = 'schema-salad >= 2.6, < 3'
     galaxyLib = 'galaxy-lib==17.9.3'
-    cwltest = 'cwltest>=1.0.20180130081614'
+    cwltest = 'cwltest>=1.0.20180209171722'
     htcondor = 'htcondor>=8.6.0'
 
     mesos_reqs = [

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -742,8 +742,9 @@ class CWLWorkflow(Job):
                                         raise validate.ValidationException(
                                             "Unsupported linkMerge '%s'", linkMerge)
                                 else:
-                                    jobobj[key] = (shortname(inp["source"]),
-                                                   promises[inp["source"]].rv())
+                                    inputSource = str(inp["source"][0])
+                                    jobobj[key] = (shortname(inputSource),
+                                                   promises[inputSource].rv())
                             elif "default" in inp:
                                 d = copy.copy(inp["default"])
                                 jobobj[key] = ("default", {"default": d})

--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -45,6 +45,7 @@ from cwltool.software_requirements import (
         DependenciesConfiguration, get_container_from_software_requirements)
 from cwltool.utils import aslist
 import schema_salad.validate as validate
+from ruamel.yaml.comments import CommentedSeq
 import schema_salad.ref_resolver
 import os
 import tempfile
@@ -742,7 +743,11 @@ class CWLWorkflow(Job):
                                         raise validate.ValidationException(
                                             "Unsupported linkMerge '%s'", linkMerge)
                                 else:
-                                    inputSource = str(inp["source"][0])
+                                    inputSource = inp["source"]
+                                    if isinstance(inputSource, CommentedSeq):
+                                        # It seems that an input source with a '#' in the name will be
+                                        # returned as a CommentedSeq list by the yaml parser.
+                                        inputSource = str(inputSource[0])
                                     jobobj[key] = (shortname(inputSource),
                                                    promises[inputSource].rv())
                             elif "default" in inp:

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -128,7 +128,8 @@ class CWLTest(ToilTest):
     def test_run_conformance(self, batchSystem=None):
         rootDir = self._projectRootPath()
         cwlSpec = os.path.join(rootDir, 'src/toil/test/cwl/spec')
-        testhash = "91f108df4d4ca567e567fc65f61feb0674467a84"
+        # The latest cwl git hash. Update it to get the latest tests.
+        testhash = "f96bca6911b6688ff614c02dbefe819bed260a13"
         url = "https://github.com/common-workflow-language/common-workflow-language/archive/%s.zip" % testhash
         if not os.path.exists(cwlSpec):
             urlretrieve(url, "spec.zip")


### PR DESCRIPTION
This PR addresses two failing CWL conformance tests:
"Test that no MultipleInputFeatureRequirement is necessary when..."
and
"Test valueFrom with constant value overriding provided array inputs"

The test in issue #2161 is not failing when run locally.