### PR TITLE
Fix cPickle deadlock when unpickling Job objects

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -932,7 +932,7 @@ class Toil(object):
             from toil.jobStores.abstractJobStore import NoSuchFileException
             try:
                 with self._jobStore.readSharedFileStream('userScript') as f:
-                    userScript = pickle.load(f)
+                    userScript = safeUnpickleFromStream(f)
             except NoSuchFileException:
                 logger.info('User script neither set explicitly nor present in the job store.')
                 userScript = None
@@ -1323,3 +1323,7 @@ def getFileSystemSize(dirPath):
     freeSpace = diskStats.f_frsize * diskStats.f_bavail
     diskSize = diskStats.f_frsize * diskStats.f_blocks
     return freeSpace, diskSize
+
+def safeUnpickleFromStream(stream):
+    string = stream.read()
+    return pickle.loads(string)

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -25,9 +25,7 @@ import importlib
 import inspect
 import logging
 import os
-import sys
 import time
-import uuid
 import dill
 import tempfile
 
@@ -47,7 +45,7 @@ from six import iteritems, string_types
 from bd2k.util.expando import Expando
 from bd2k.util.humanize import human2bytes
 
-from toil.common import Toil, addOptions
+from toil.common import Toil, addOptions, safeUnpickleFromStream
 from toil.fileStore import DeferredFunction
 from toil.lib.bioio import (setLoggingFromOptions,
                             getTotalCpuTimeAndMemoryUsage,
@@ -1750,7 +1748,7 @@ class Promise(object):
         with cls._jobstore.readFileStream(jobStoreFileID) as fileHandle:
             # If this doesn't work then the file containing the promise may not exist or be
             # corrupted
-            value = pickle.load(fileHandle)
+            value = safeUnpickleFromStream(fileHandle)
             return value
 
 

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -29,6 +29,7 @@ import sys
 import time
 import uuid
 import dill
+import tempfile
 
 try:
     import cPickle as pickle
@@ -898,13 +899,14 @@ class Job(JobLikeObject):
         logger.debug('Loading user module %s.', userModule)
         userModule = cls._loadUserModule(userModule)
         pickleFile = commandTokens[1]
-        if pickleFile == "firstJob":
-            openFileStream = jobStore.readSharedFileStream(pickleFile)
-        else:
-            openFileStream = jobStore.readFileStream(pickleFile)
-        with openFileStream as fileHandle:
-            return cls._unpickle(userModule, fileHandle, jobStore.config)
-
+        with tempfile.NamedTemporaryFile() as f:
+            filename = f.name
+            if pickleFile == "firstJob":
+                jobStore.readSharedFile(pickleFile, filename)
+            else:
+                jobStore.readFile(pickleFile, filename)
+            with open(filename) as fileHandle:
+                return cls._unpickle(userModule, fileHandle, jobStore.config)
 
     @classmethod
     def _unpickle(cls, userModule, fileHandle, config):

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -33,6 +33,7 @@ import six.moves.urllib.parse as urlparse
 
 from bd2k.util.retry import retry_http
 
+from toil.common import safeUnpickleFromStream
 from toil.fileStore import FileID
 from toil.job import JobException
 from bd2k.util import memoize
@@ -153,7 +154,7 @@ class AbstractJobStore(with_metaclass(ABCMeta, object)):
         :raises NoSuchJobStoreException: if the physical storage for this job store doesn't exist
         """
         with self.readSharedFileStream('config.pickle') as fileHandle:
-            config = pickle.load(fileHandle)
+            config = safeUnpickleFromStream(fileHandle)
             assert config.workflowID is not None
             self.__config = config
 
@@ -216,7 +217,7 @@ class AbstractJobStore(with_metaclass(ABCMeta, object)):
         """
         # Parse out the return value from the root job
         with self.readSharedFileStream('rootJobReturnValue') as fH:
-            return pickle.load(fH)
+            return safeUnpickleFromStream(fH)
 
     @property
     @memoize

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -38,7 +38,7 @@ except ImportError:
     import pickle
 
 from bd2k.util.expando import MagicExpando
-from toil.common import Toil
+from toil.common import Toil, safeUnpickleFromStream
 from toil.fileStore import FileStore
 from toil import logProcessContext
 from toil.job import Job
@@ -145,7 +145,7 @@ def workerScript(jobStore, config, jobName, jobStoreID, redirectOutputToLogFile=
     
     #First load the environment for the jobGraph.
     with jobStore.readSharedFileStream("environment.pickle") as fileHandle:
-        environment = pickle.load(fileHandle)
+        environment = safeUnpickleFromStream(fileHandle)
     for i in environment:
         if i not in ("TMPDIR", "TMP", "HOSTNAME", "HOSTTYPE"):
             os.environ[i] = environment[i]


### PR DESCRIPTION
This is relevant to earlier issues like #1503. The root cause is that cPickle sometimes doesn't release the GIL when reading. When reading using the `read_file` function, cPickle correctly releases the GIL before performing a potentially-blocking operation:

https://github.com/python/cpython/blob/a61f5da54772b0ea6a7eccf21df08e61585ef712/Modules/cPickle.c#L552

But in the `readline_file` function, it doesn't:

https://github.com/python/cpython/blob/a61f5da54772b0ea6a7eccf21df08e61585ef712/Modules/cPickle.c#L591

This means that anytime the "file-like-object" that cPickle is reading from is a pipe filled from a different Python thread (i.e. in remote jobStores), we have to avoid using `readline_file` at all costs. Otherwise, the unpickling thread will stall waiting for data, but the thread that fills the other end of the pipe will never run, because the GIL is still held by the reading thread. We originally thought we worked around this by enforcing `cPickle.HIGHEST_PROTOCOL` on all pickle dumps. Pickle's protocol version 2 dumps most things in a binary format and not a line-based one, which means `readline_file` is almost never used (we thought it was never used). But unfortunately, `load_global` opcodes always cause `readline_file` to be used, even in the higher protocol versions:

https://github.com/python/cpython/blob/a61f5da54772b0ea6a7eccf21df08e61585ef712/Modules/cPickle.c#L4039

So sometimes, if you're unlucky, a load_global opcode will happen to be right on the end of the pipe-buffer (I believe that's 4KB on Linux), and there's a race between one thread reading past the end of the pipe, and the other writing more data into it. In my tests, this race gets lost roughly once in every 10K to 100K jobs for me, but it may depend heavily on the size of your Job objects and even the length of the names of the files/classes you use.


Basically, this PR solves the problem by never actually streaming the file when unpickling. Instead, it's fed into a special function which just reads all the data and calls `pickle.loads` on it, which can't stall because all the data is already in memory. (Why not avoid using readFileStream entirely and just use readFile?: Because this way we don't have to worry about cleaning up temporary files if there's an unpickling error.)

Unpickling the job objects is a special case, because it uses a custom unpickler, which doesn't have the `loads` method: in that case, we just read it into a temporary file and delete it after we're done or an exception is raised.