### PR TITLE
Make sure apiDockerCall returns the container when detatching

### DIFF
--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -220,6 +220,11 @@ def apiDockerCall(job,
                       image='quay.io/ucgc_cgl/samtools:latest',
                       working_dir=working_dir,
                       parameters=parameters)
+                      
+    Note that when run with detatch=False, or with detatch=True and stdout=True
+    or stderr=True, this is a blocking call. When run with detatch=True and
+    without output capture, the container is started and returned without
+    waiting for it to finish.
 
     :param toil.Job.job job: The Job instance for the calling function.
     :param str image: Name of the Docker image to be used.
@@ -243,15 +248,15 @@ def apiDockerCall(job,
                       https://docker-py.readthedocs.io/en/stable/containers.html
     :param bool detach: Run the container in detached mode. (equivalent to '-d')
     :param bool stdout: Return logs from STDOUT when detach=False (default: True).
-                        Stream stdout to a file when detach=True (default: False).
-                        Streaming defaults to output.log, and can be specified with
-                        the "streamfile" kwarg.
+                        Block and capture stdout to a file when detach=True
+                        (default: False). Output capture defaults to output.log,
+                        and can be specified with the "streamfile" kwarg.
     :param bool stderr: Return logs from STDERR when detach=False (default: False).
-                        Stream stderr to a file when detach=True (default: False).
-                        Streaming defaults to output.log, and can be specified with
-                        the "streamfile" kwarg.
-    :param str streamfile: Stream to a file if stderr and/or stdout are True.
-                           Must set detach=True to enable.  Defaults to "output.log".
+                        Block and capture stderr to a file when detach=True
+                        (default: False). Output capture defaults to output.log,
+                        and can be specified with the "streamfile" kwarg.
+    :param str streamfile: Collect container output to this file if detach=True and 
+                        stderr and/or stdout are True. Defaults to "output.log".
     :param dict log_config: Specify the logs to return from the container.  See:
                       https://docker-py.readthedocs.io/en/stable/containers.html
     :param bool remove: Remove the container on exit or not.
@@ -269,6 +274,11 @@ def apiDockerCall(job,
                    run command.  The list is 75 keywords total, for examples
                    and full documentation see:
                    https://docker-py.readthedocs.io/en/stable/containers.html
+                   
+    :returns: Returns the standard output/standard error text, as requested, when 
+              detatch=False. Returns the underlying
+              docker.models.containers.Container object from the Docker API when
+              detatch=True.
     """
 
     # make certain that files have the correct permissions
@@ -395,8 +405,16 @@ def apiDockerCall(job,
                 if streamfile is None:
                     streamfile = 'output.log'
                 for line in container.logs(stdout=stdout, stderr=stderr, stream=True):
+                    # stream=True makes this loop blocking; we will loop until
+                    # the container stops and there is no more output.
                     with open(streamfile, 'w') as f:
                         f.write(line)
+                        
+            # If we didn't capture output, the caller will need to .wait() on
+            # the container to know when it is done. Even if we did capture
+            # output, the caller needs the container to get at the exit code.
+            return container
+            
     except ContainerError:
         logger.error("Docker had non-zero exit.  Check your command: " + \
                       repr(command))


### PR DESCRIPTION
Otherwise there's no way to check the exit code or wait on the container.

This should fix https://github.com/vgteam/toil-vg/issues/475