### PR TITLE
Investigate cause of CWL conformance timeout

### DIFF
--- a/src/toil/cwl/cwltoil.py
+++ b/src/toil/cwl/cwltoil.py
@@ -865,7 +865,7 @@ def main(args=None, stdout=sys.stdout):
     # user to select jobStore or get a default from logic one below.
     parser.add_argument("--jobStore", type=str)
     parser.add_argument("--not-strict", action="store_true")
-    parser.add_argument("--quiet", dest="logLevel", action="store_const", const="ERROR")
+    parser.add_argument("--quiet", dest="logLevel", action="store_const", const="DEBUG")
     parser.add_argument("--basedir", type=str)
     parser.add_argument("--outdir", type=str, default=os.getcwd())
     parser.add_argument("--version", action='version', version=baseVersion)

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -41,11 +41,11 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 import sys
 
-ch = logging.StreamHandler(sys.stdout)
-ch.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-ch.setFormatter(formatter)
-logging.getLogger().addHandler(ch)
+# ch = logging.StreamHandler(sys.stdout)
+# ch.setLevel(logging.DEBUG)
+# formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+# ch.setFormatter(formatter)
+# logging.getLogger().addHandler(ch)
 
 
 class RecentJobShapes(object):

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -142,7 +142,7 @@ class CWLTest(ToilTest):
         with NamedTemporaryFile() as f:
             try:
                 cmd = ["bash", "run_test.sh", "RUNNER=toil-cwl-runner",
-                       "DRAFT=v1.0", "-j4", "EXTRA=--logDebug", "--junit-xml=" + f.name]
+                       "DRAFT=v1.0", "-j4", "EXTRA=--logDebug", "--verbose", "--junit-xml=" + f.name]
                 if batchSystem:
                     cmd.extend(["--batchSystem", batchSystem])
                 subprocess.check_output(cmd, cwd=cwlSpec, stderr=subprocess.STDOUT)

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -19,6 +19,7 @@ from toil import subprocess
 import unittest
 import re
 import shutil
+import sys
 import pytest
 from future.moves.urllib.request import urlretrieve
 import zipfile
@@ -137,25 +138,29 @@ class CWLTest(ToilTest):
                 z.extractall()
             shutil.move("common-workflow-language-%s" % testhash, cwlSpec)
             os.remove("spec.zip")
-        try:
-            cmd = ["bash", "run_test.sh", "RUNNER=toil-cwl-runner",
-                   "DRAFT=v1.0", "-j4"]
-            if batchSystem:
-                cmd.extend(["--batchSystem", batchSystem])
-            subprocess.check_output(cmd, cwd=cwlSpec, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            only_unsupported = False
-            # check output -- if we failed but only have unsupported features, we're okay
-            p = re.compile(r"(?P<failures>\d+) failures, (?P<unsupported>\d+) unsupported features")
-            for line in e.output.split("\n"):
-                m = p.search(line)
-                if m:
-                    if int(m.group("failures")) == 0 and int(m.group("unsupported")) > 0:
-                        only_unsupported = True
-                        break
-            if not only_unsupported:
-                print(e.output)
-                raise e
+        from tempfile import NamedTemporaryFile
+        with NamedTemporaryFile() as f:
+            try:
+                cmd = ["bash", "run_test.sh", "RUNNER=toil-cwl-runner",
+                       "DRAFT=v1.0", "-j4", "EXTRA=--logDebug", "--junit-xml=" + f.name]
+                if batchSystem:
+                    cmd.extend(["--batchSystem", batchSystem])
+                subprocess.check_output(cmd, cwd=cwlSpec, stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as e:
+                sys.stderr.write("Contents of JUnit XML:\n")
+                sys.stderr.write(open(f.name).read())
+                only_unsupported = False
+                # check output -- if we failed but only have unsupported features, we're okay
+                p = re.compile(r"(?P<failures>\d+) failures, (?P<unsupported>\d+) unsupported features")
+                for line in e.output.split("\n"):
+                    m = p.search(line)
+                    if m:
+                        if int(m.group("failures")) == 0 and int(m.group("unsupported")) > 0:
+                            only_unsupported = True
+                            break
+                if not only_unsupported:
+                    print(e.output)
+                    raise e
 
     @slow
     def test_bioconda(self):


### PR DESCRIPTION
The CWL conformance tests keep failing due to timeouts (though they should be very quick), and in the back of my mind I've sort of been wondering why. This PR is just meant to get Jenkins to run and output *actual* debug information. Please don't merge this as-is, because right now it breaks the cwltoil `--quiet` flag.

I suspect it's something to do with the singleMachine batch system running out of resources (disk space?) and deadlocking. But we'll see: these commits will show the toil debug output so we can see what's happening in the timed-out tests.