### PR TITLE
Extend sleep on measureConcurrency.  Addresses #2219.

### DIFF
--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -857,7 +857,7 @@ class MesosBatchSystemJobTest(hidden.AbstractBatchSystemJobTest, MesosTestSuppor
         self._stopMesos()
 
 
-def measureConcurrency(filepath, sleep_time=1):
+def measureConcurrency(filepath, sleep_time=3):
     """
     Run in parallel to determine the number of concurrent tasks.
     This code was copied from toil.batchSystemTestMaxCoresSingleMachineBatchSystemTest


### PR DESCRIPTION
Addresses #2219.

Should fix some flakiness in two tests.