### PR TITLE
Fix a crash if job is larger than all available node types (resolves #2237)

### DIFF
--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -90,6 +90,14 @@ class Shape(object):
                 self.disk,
                 self.preemptable)
 
+    def __repr__(self):
+        return "Shape(wallTime=%s, memory=%s, cores=%s, disk=%s, preemptable=%s)" % \
+               (self.wallTime,
+                self.memory,
+                self.cores,
+                self.disk,
+                self.preemptable)
+
 class AbstractProvisioner(with_metaclass(ABCMeta, object)):
     """
     An abstract base class to represent the interface for provisioning worker nodes to use in a

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -835,8 +835,8 @@ class ScalerThread(ExceptionalThread):
 
     def tryRun(self):
         while not self.stop:
-            try:
-                with throttle(self.scaler.config.scaleInterval):
+            with throttle(self.scaler.config.scaleInterval):
+                try:
                     queuedJobs = self.scaler.leader.getJobs()
                     queuedJobShapes = [
                         Shape(wallTime=self.scaler.getAverageRuntime(
@@ -857,9 +857,9 @@ class ScalerThread(ExceptionalThread):
                     self.scaler.updateClusterSize(estimatedNodeCounts)
                     if self.stats:
                         self.stats.checkStats()
-            except:
-                logger.exception("Exception encountered in scaler thread. Making a best-effort "
-                                 "attempt to keep going, but things may go wrong from now on.")
+                except:
+                    logger.exception("Exception encountered in scaler thread. Making a best-effort "
+                                     "attempt to keep going, but things may go wrong from now on.")
         self.scaler.shutDown()
 
 class ClusterStats(object):

--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -68,8 +68,6 @@ class BinPackedFit(object):
     def __init__(self, nodeShapes, targetTime=defaultTargetTime):
         self.nodeShapes = sorted(nodeShapes)
         self.targetTime = targetTime
-
-        # {_Shape(wallTime=3600, memory=1073741824, cores=1, disk=8589934592, preemptable=False): []}
         self.nodeReservations = {nodeShape:[] for nodeShape in nodeShapes}
 
     def binPack(self, jobShapes):
@@ -99,6 +97,7 @@ class BinPackedFit(object):
         if chosenNodeShape is None:
             logger.warning("Couldn't fit job with requirements %r into any nodes in the nodeTypes "
                            "list." % jobShape)
+            return
 
         # grab current list of job objects appended to this nodeType
         nodeReservations = self.nodeReservations[chosenNodeShape]

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -248,6 +248,19 @@ class BinPackingTest(ToilTest):
         # Hopefully we didn't assign just one node to cover all those jobs.
         self.assertNotEqual(self.bpf.getRequiredNodes(), {r3_8xlarge: 1, c4_8xlarge_preemptable: 0})
 
+    def testJobTooLargeForAllNodes(self):
+        """
+        If a job is too large for all node types, the scaler should print a
+        warning, but definitely not crash.
+        """
+        # Takes more RAM than an r3.8xlarge
+        largerThanR3 = Shape(wallTime=3600,
+                             memory=h2b('360G'),
+                             cores=32,
+                             disk=h2b('600G'),
+                             preemptable=False)
+        self.bpf.addJobShape(largerThanR3)
+        # If we got here we didn't crash.
 
 class ClusterScalerTest(ToilTest):
     def setUp(self):


### PR DESCRIPTION
Also some miscellaneous crap to add a `__repr__` to Shape and ensure throttling still works if an exception is raised inside the scaler loop body.