### PR TITLE
Report why a Docker manifest might be unavailable

### DIFF
--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -184,29 +184,29 @@ def checkDockerImageExists(appliance):
         return requestCheckDockerIo(registryName=registryName, tag=tag)
 
 
-def makeApplianceImageNotFound(name, tag, url, statusCode):
+class ApplianceImageNotFound(ImageNotFound):
     """
-    Compose an ImageNotFound error complaining that the given name and tag
-    for TOIL_APPLIANCE_SELF specify an image manifest which could not be
+    Compose an ApplianceImageNotFound error complaining that the given name and
+    tag for TOIL_APPLIANCE_SELF specify an image manifest which could not be
     retrieved from the given URL, because it produced the given HTTP error
     code.
     
-    :param str registryName: The url of a docker image's registry.  e.g. "quay.io/ucsc_cgl/toil"
+    :param str name: The name of a docker image.  e.g. "quay.io/ucsc_cgl/toil"
     :param str tag: The tag used at that docker image's registry.  e.g. "latest"
-    :param str url: The URL at which the image's manifewst is supposed to appear
+    :param str url: The URL at which the image's manifest is supposed to appear
     :param int statusCode: the failing HTTP status code returned by the URL
-    :return: Return an ImageNotFound error containing an informative message.
     """
-    
-    return ImageNotFound("The docker image that TOIL_APPLIANCE_SELF specifies (%s) produced "
-                         "a nonfunctional manifest URL (%s). The HTTP status returned was %s. "
-                         "The specifier is most likely unsupported or malformed.  "
-                         "Please supply a docker image with the "
-                         "format: '<websitehost>.io/<repo_path>:<tag>' or '<repo_path>:<tag>' "
-                         "(for official docker.io images).  Examples: "
-                         "'quay.io/ucsc_cgl/toil:latest', 'ubuntu:latest', or "
-                         "'broadinstitute/genomes-in-the-cloud:2.0.0'."
-                         "" % (name + ':' + tag, url, str(statusCode)))
+    def __init__(self, name, tag, url, statusCode):
+        msg = ("The docker image that TOIL_APPLIANCE_SELF specifies (%s) produced "
+               "a nonfunctional manifest URL (%s). The HTTP status returned was %s. "
+               "The specifier is most likely unsupported or malformed.  "
+               "Please supply a docker image with the format: "
+               "'<websitehost>.io/<repo_path>:<tag>' or '<repo_path>:<tag>' "
+               "(for official docker.io images).  Examples: "
+               "'quay.io/ucsc_cgl/toil:latest', 'ubuntu:latest', or "
+               "'broadinstitute/genomes-in-the-cloud:2.0.0'."
+               "" % (name + ':' + tag, url, str(statusCode)))
+        super(ApplianceImageNotFound, self).__init__(msg)
 
 def requestCheckRegularIo(registryName, tag):
     """
@@ -237,7 +237,7 @@ def requestCheckRegularIo(registryName, tag):
               ''.format(pathName=pathName, webhost=webhostName, tag=tag)
     response = requests.head(ioURL)
     if not response.ok:
-        raise makeApplianceImageNotFound(registryName, tag, ioURL, response.status_code)
+        raise ApplianceImageNotFound(registryName, tag, ioURL, response.status_code)
     else:
         return registryName + ':' + tag
 
@@ -268,7 +268,7 @@ def requestCheckDockerIo(registryName, tag):
     bearer = jsonToken["token"]
     response = requests.head(requests_url, headers={'Authorization': 'Bearer {}'.format(bearer)})
     if not response.ok:
-        raise makeApplianceImageNotFound(registryName, tag, requests_url, response.status_code)
+        raise ApplianceImageNotFound(registryName, tag, requests_url, response.status_code)
     else:
         return registryName + ':' + tag
 

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -213,13 +213,15 @@ def requestCheckRegularIo(registryName, tag):
               ''.format(pathName=pathName, webhost=webhostName, tag=tag)
     response = requests.head(ioURL)
     if not response.ok:
-        raise ImageNotFound("The docker image that TOIL_APPLIANCE_SELF specifies (%s) is "
-                            "unsupported (or malformed).  Please supply a docker image with the "
+        raise ImageNotFound("The docker image that TOIL_APPLIANCE_SELF specifies (%s) produced "
+                            "a nonfunctional manifest URL (%s). The HTTP status returned was %s. "
+                            "The specifier is most likely unsupported or malformed.  "
+                            "Please supply a docker image with the "
                             "format: '<websitehost>.io/<repo_path>:<tag>' or '<repo_path>:<tag>' "
                             "(for official docker.io images).  Examples: "
                             "'quay.io/ucsc_cgl/toil:latest', 'ubuntu:latest', or "
                             "'broadinstitute/genomes-in-the-cloud:2.0.0'."
-                            "" % (registryName + ':' + tag))
+                            "" % (registryName + ':' + tag, ioURL, str(response.status_code)))
     else:
         return registryName + ':' + tag
 

--- a/src/toil/__init__.py
+++ b/src/toil/__init__.py
@@ -184,6 +184,30 @@ def checkDockerImageExists(appliance):
         return requestCheckDockerIo(registryName=registryName, tag=tag)
 
 
+def makeApplianceImageNotFound(name, tag, url, statusCode):
+    """
+    Compose an ImageNotFound error complaining that the given name and tag
+    for TOIL_APPLIANCE_SELF specify an image manifest which could not be
+    retrieved from the given URL, because it produced the given HTTP error
+    code.
+    
+    :param str registryName: The url of a docker image's registry.  e.g. "quay.io/ucsc_cgl/toil"
+    :param str tag: The tag used at that docker image's registry.  e.g. "latest"
+    :param str url: The URL at which the image's manifewst is supposed to appear
+    :param int statusCode: the failing HTTP status code returned by the URL
+    :return: Return an ImageNotFound error containing an informative message.
+    """
+    
+    return ImageNotFound("The docker image that TOIL_APPLIANCE_SELF specifies (%s) produced "
+                         "a nonfunctional manifest URL (%s). The HTTP status returned was %s. "
+                         "The specifier is most likely unsupported or malformed.  "
+                         "Please supply a docker image with the "
+                         "format: '<websitehost>.io/<repo_path>:<tag>' or '<repo_path>:<tag>' "
+                         "(for official docker.io images).  Examples: "
+                         "'quay.io/ucsc_cgl/toil:latest', 'ubuntu:latest', or "
+                         "'broadinstitute/genomes-in-the-cloud:2.0.0'."
+                         "" % (name + ':' + tag, url, str(statusCode)))
+
 def requestCheckRegularIo(registryName, tag):
     """
     Checks to see if an image exists using the requests library.
@@ -213,15 +237,7 @@ def requestCheckRegularIo(registryName, tag):
               ''.format(pathName=pathName, webhost=webhostName, tag=tag)
     response = requests.head(ioURL)
     if not response.ok:
-        raise ImageNotFound("The docker image that TOIL_APPLIANCE_SELF specifies (%s) produced "
-                            "a nonfunctional manifest URL (%s). The HTTP status returned was %s. "
-                            "The specifier is most likely unsupported or malformed.  "
-                            "Please supply a docker image with the "
-                            "format: '<websitehost>.io/<repo_path>:<tag>' or '<repo_path>:<tag>' "
-                            "(for official docker.io images).  Examples: "
-                            "'quay.io/ucsc_cgl/toil:latest', 'ubuntu:latest', or "
-                            "'broadinstitute/genomes-in-the-cloud:2.0.0'."
-                            "" % (registryName + ':' + tag, ioURL, str(response.status_code)))
+        raise makeApplianceImageNotFound(registryName, tag, ioURL, response.status_code)
     else:
         return registryName + ':' + tag
 
@@ -252,13 +268,7 @@ def requestCheckDockerIo(registryName, tag):
     bearer = jsonToken["token"]
     response = requests.head(requests_url, headers={'Authorization': 'Bearer {}'.format(bearer)})
     if not response.ok:
-        raise ImageNotFound("The docker image that TOIL_APPLIANCE_SELF specifies (%s) is "
-                            "unsupported (or malformed).  Please supply a docker image with the "
-                            "format: '<websitehost>.io/<repo_path>:<tag>' or '<repo_path>:<tag>' "
-                            "(for official docker.io images).  Examples: "
-                            "'quay.io/ucsc_cgl/toil:latest', 'ubuntu:latest', or "
-                            "'broadinstitute/genomes-in-the-cloud:2.0.0'."
-                            "" % (registryName + ':' + tag))
+        raise makeApplianceImageNotFound(registryName, tag, requests_url, response.status_code)
     else:
         return registryName + ':' + tag
 


### PR DESCRIPTION
Right now, if you give a non-working Docker container specifier as TOIL_APPLIANCE_SELF, you get no feedback. This adds code to show you the manifest URL that didn't work and the HTTP status code that describes the problem (for example, 401 if you forgot to make your Quay repo public).