### PR TITLE
Fix docker daemon detection depending on terminal size

### DIFF
--- a/src/toil/provisioners/node.py
+++ b/src/toil/provisioners/node.py
@@ -130,7 +130,7 @@ class Node(object):
             if time.time() - startTime > self.maxWaitTime:
                 raise RuntimeError("Docker daemon failed to start on machine with ip %s" % self.publicIP)
             try:
-                output = self.sshInstance('/usr/bin/ps', 'aux', sshOptions=['-oBatchMode=yes'], user=keyName)
+                output = self.sshInstance('/usr/bin/ps', 'auxww', sshOptions=['-oBatchMode=yes'], user=keyName)
                 if 'dockerd' in output:
                     # docker daemon has started
                     logger.info('Docker daemon running')


### PR DESCRIPTION
I could've sworn I fixed this before, but here is a fix for a thorny issue: whether `toil launch-cluster` succeeds depends on the width of your terminal. Worse yet, it fails if your terminal is the standard size of 80x24. (Your mileage may vary, because the length of ps output may depend on the size of the PIDs, etc.)

The core problem is that toil is using `ps aux` to try to find the dockerd entry, which looks something like this:
```
root       953 37.7  3.3 729624 68156 ?        Ssl  02:06   0:12 /run/torcx/bin/dockerd blah blah blah
```

But `ps` truncates its output to the size of the terminal by default. If your window is 80 characters, for example, you get:
```
root       953 37.7  3.3 729624 68156 ?        Ssl  02:06   0:12 /run/torcx/bin/
```

The terminal size is forwarded through the pipe even though Python is capturing the stdout, because the tty size detection happens over *stdin*.

This changes the `ps` invocation to use `ww`, which tells it to never truncate.