### PR TITLE
Avoid overwriting NVMe root volumes on current-gen AWS instances (addresses #2252)

### DIFF
--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -269,13 +269,17 @@ write_files:
         ephemeral_count=0
         drives=""
         directories="toil mesos docker cwl"
-        for drive in /dev/xvd{{b..z}} /dev/nvme*n*; do
+        for drive in /dev/xvd{{a..z}} /dev/nvme{{0..26}}n1; do
             echo checking for $drive
             if [ -b $drive ]; then
                 echo found it
-                ephemeral_count=$((ephemeral_count + 1 ))
-                drives="$drives $drive"
-                echo increased ephemeral count by one
+                if mount | grep $drive; then
+                    echo "already mounted, likely a root device"
+                else
+                    ephemeral_count=$((ephemeral_count + 1 ))
+                    drives="$drives $drive"
+                    echo increased ephemeral count by one
+                fi
             fi
         done
         if (("$ephemeral_count" == "0" )); then


### PR DESCRIPTION
c5, i3.metal, c5d, m5, and m5d instances all have their EBS volumes
show up as NVMe devices. Previously toil assumed that all NVMe devices
were ephemeral, so it formed a RAID device from them. On these
instance types, though, the root volume would be reformatted,
corrupted, and then remounted as readonly, causing failures.