### PR TITLE
Don't call addNodes if the delta was met by unignoring nodes

### DIFF
--- a/src/toil/provisioners/clusterScaler.py
+++ b/src/toil/provisioners/clusterScaler.py
@@ -579,8 +579,7 @@ class ClusterScaler(object):
                     delta = numNodes - (numCurrentNodes - numIgnoredNodes)
                 else:
                     delta = numNodes - numCurrentNodes
-                if delta > 0:
-                    if numIgnoredNodes > 0:
+                if delta > 0 and numIgnoredNodes > 0:
                         # We can un-ignore a few nodes to compensate for the additional nodes we want.
                         numNodesToUnignore = min(delta, numIgnoredNodes)
                         logger.info('Unignoring %i nodes because we want to scale back up again.' % numNodesToUnignore)
@@ -588,6 +587,7 @@ class ClusterScaler(object):
                         for node in ignoredNodes[:numNodesToUnignore]:
                             self.ignoredNodes.remove(node.privateIP)
                             self.leader.batchSystem.unignoreNode(node.privateIP)
+                if delta > 0:
                     logger.info('Adding %i %s nodes to get to desired cluster size of %i.',
                                 delta,
                                 'preemptable' if preemptable else 'non-preemptable',

--- a/src/toil/test/provisioners/clusterScalerTest.py
+++ b/src/toil/test/provisioners/clusterScalerTest.py
@@ -383,6 +383,30 @@ class ClusterScalerTest(ToilTest):
         scaler.updateClusterSize(estimatedNodeCounts)
         self.assertEqual(scaler.preemptableNodeDeficit['c4.8xlarge'], 0)
 
+    def testNoLaunchingIfDeltaAlreadyMet(self):
+        """
+        Check that the scaler doesn't try to launch "0" more instances if
+        the delta was able to be met by unignoring nodes.
+        """
+        # We have only one node type for simplicity
+        self.provisioner.nodeTypes = ['c4.8xlarge']
+        self.provisioner.nodeShapes = [c4_8xlarge]
+        scaler = ClusterScaler(self.provisioner, self.leader, self.config)
+        # Pretend there is one ignored worker in the cluster
+        self.provisioner.getProvisionedWorkers = MagicMock(
+            return_value=[Node('127.0.0.1', '127.0.0.1', 'testNode',
+                               datetime.datetime.now().isoformat(),
+                               nodeType='c4.8xlarge', preemptable=True)])
+        scaler.ignoredNodes.add('127.0.0.1')
+        # Exercise the updateClusterSize logic
+        self.provisioner.addNodes = MagicMock()
+        scaler.updateClusterSize({c4_8xlarge: 1})
+        self.assertFalse(self.provisioner.addNodes.called,
+                         "addNodes was called when no new nodes were needed")
+        self.assertEqual(len(scaler.ignoredNodes), 0,
+                         "The scaler didn't unignore an ignored node when "
+                         "scaling up")
+
     def testBetaInertia(self):
         # This is really high, but makes things easy to calculate.
         self.config.betaInertia = 0.5


### PR DESCRIPTION
Fixes #2256. Adds a unit test which covers this, but more importantly that unignoring actually happens as it should.