### PR TITLE
Add examples of running prexisting workflows with Toil scripts.

### DIFF
--- a/docs/running/cwl.rst
+++ b/docs/running/cwl.rst
@@ -32,8 +32,8 @@ To run a CWL workflow in AWS with toil see :ref:`awscwl`.
 Running CWL with Toil Scripts
 ------------------------------------
 
-CWL workflows can be evoked in native Toil scripts. For example, if you wanted to run a CWL workflow, with 3 YML files
-specifying different samples inputs, it could look something like::
+CWL workflows can be run indirectly in native Toil scripts. For example, if you wanted to run a CWL workflow, with
+3 YML files specifying different samples inputs, it could look something like::
 
     from toil.job import Job
     from toil.common import Toil

--- a/docs/running/cwl.rst
+++ b/docs/running/cwl.rst
@@ -29,11 +29,13 @@ To run a CWL workflow in AWS with toil see :ref:`awscwl`.
 .. _secondaryFiles: http://www.commonwl.org/v1.0/CommandLineTool.html#CommandInputParameter
 .. _InitialWorkDirRequirement: http://www.commonwl.org/v1.0/CommandLineTool.html#InitialWorkDirRequirement
 
-Running CWL with Toil Scripts
+Running CWL within Toil Scripts
 ------------------------------------
 
-CWL workflows can be run indirectly in native Toil scripts. For example, if you wanted to run a CWL workflow, with
-3 YML files specifying different samples inputs, it could look something like::
+A CWL workflow can be run indirectly in a native Toil script. However, this is not the :ref:`standard <cwl>` way to run
+CWL workflows with Toil and doing so comes at the cost of job efficency. For some use cases, such as running one process on
+multiple files, it may be useful. For example, if you want to run a CWL workflow with 3 YML files specifying different
+samples inputs, it could look something like::
 
     from toil.job import Job
     from toil.common import Toil

--- a/docs/running/cwl.rst
+++ b/docs/running/cwl.rst
@@ -28,3 +28,62 @@ To run a CWL workflow in AWS with toil see :ref:`awscwl`.
 .. _Directory: http://www.commonwl.org/v1.0/CommandLineTool.html#Directory
 .. _secondaryFiles: http://www.commonwl.org/v1.0/CommandLineTool.html#CommandInputParameter
 .. _InitialWorkDirRequirement: http://www.commonwl.org/v1.0/CommandLineTool.html#InitialWorkDirRequirement
+
+Running CWL with Toil Scripts
+------------------------------------
+
+CWL workflows can be evoked in native Toil scripts. For example, if you wanted to run a CWL workflow, with 3 YML files
+specifying different samples inputs, it could look something like::
+
+    from toil.job import Job
+    from toil.common import Toil
+    import subprocess
+    import os
+
+
+    def initialize_jobs(job):
+        job.fileStore.logToMaster('initialize_jobs')
+
+
+    def runQC(job, cwl_file, cwl_filename, yml_file, yml_filename, outputs_dir, output_num):
+        job.fileStore.logToMaster("runQC")
+        tempDir = job.fileStore.getLocalTempDir()
+
+        cwl = job.fileStore.readGlobalFile(cwl_file, userPath=os.path.join(tempDir, cwl_filename))
+        yml = job.fileStore.readGlobalFile(yml_file, userPath=os.path.join(tempDir, yml_filename))
+
+        subprocess.check_call(["cwltool", cwl, yml])
+
+        output_filename = "output.txt"
+        output_file = job.fileStore.writeGlobalFile(output_filename)
+        job.fileStore.readGlobalFile(output_file, userPath=os.path.join(outputs_dir, "sample_" + output_num + "_" + output_filename))
+        return output_file
+
+
+    if __name__ == "__main__":
+        options = Job.Runner.getDefaultOptions("./toilWorkflowRun")
+        options.logLevel = "DEBUG"
+        with Toil(options) as toil:
+
+            # specify the folder where the cwl and yml files live
+            inputs_dir = "/tmp/"
+            # specify where you wish the outputs to be written
+            outputs_dir = "/tmp/"
+
+            job0 = Job.wrapJobFn(initialize_jobs)
+
+            cwl_filename = "hello.cwl"
+            cwl_file = toil.importFile("file://" + os.path.join(inputs_dir, cwl_filename))
+
+            # add list of yml config inputs here or import and construct from file
+            yml_files = ["hello1.yml", "hello2.yml", "hello3.yml"]
+            i = 0
+            for yml in yml_files:
+                i = i + 1
+                yml_file = toil.importFile("file://" + os.path.join(inputs_dir, yml))
+                yml_filename = yml
+                job = Job.wrapJobFn(runQC, cwl_file, cwl_filename, yml_file, yml_filename, outputs_dir, output_num=str(i))
+                job0.addChild(job)
+
+            toil.start(job0)
+

--- a/docs/running/wdl.rst
+++ b/docs/running/wdl.rst
@@ -113,8 +113,11 @@ http://toil.readthedocs.io/en/3.12.0/running/cli.html
 Running WDL with Toil Scripts
 ------------------------------------
 
-WDL workflows can be evoked in native Toil scripts. For example, if you wanted to run a WDL workflow, with 3 JSON
-files specifying different samples inputs, it could look something like::
+.. note::
+        A cromwell.jar file is needed in order to run a WDL workflow.
+
+WDL workflows can be run indirectly in native Toil scripts. For example, if you wanted to run a WDL workflow, with
+3 JSON files specifying different samples inputs, it could look something like::
 
     from toil.job import Job
     from toil.common import Toil

--- a/docs/running/wdl.rst
+++ b/docs/running/wdl.rst
@@ -110,6 +110,69 @@ Any number of arbitrary options may also be specified.  These options will not b
 as toil options once the wdl/json files are processed.  For valid toil options, see the documentation:
 http://toil.readthedocs.io/en/3.12.0/running/cli.html
 
+Running WDL with Toil Scripts
+------------------------------------
+
+WDL workflows can be evoked in native Toil scripts. For example, if you wanted to run a WDL workflow, with 3 JSON
+files specifying different samples inputs, it could look something like::
+
+    from toil.job import Job
+    from toil.common import Toil
+    import subprocess
+    import os
+
+
+    def initialize_jobs(job):
+        job.fileStore.logToMaster("initialize_jobs")
+
+
+    def runQC(job, wdl_file, wdl_filename, json_file, json_filename, outputs_dir, jar_loc,output_num):
+        job.fileStore.logToMaster("runQC")
+        tempDir = job.fileStore.getLocalTempDir()
+
+        wdl = job.fileStore.readGlobalFile(wdl_file, userPath=os.path.join(tempDir, wdl_filename))
+        json = job.fileStore.readGlobalFile(json_file, userPath=os.path.join(tempDir, json_filename))
+
+        subprocess.check_call(["java","-jar",jar_loc,"run",wdl,"--inputs",json])
+
+        output_filename = "output.txt"
+        output_file = job.fileStore.writeGlobalFile(outputs_dir + output_filename)
+        job.fileStore.readGlobalFile(output_file, userPath=os.path.join(outputs_dir, "sample_" + output_num + "_" + output_filename))
+        return output_file
+
+
+    if __name__ == "__main__":
+        options = Job.Runner.getDefaultOptions("./toilWorkflowRun")
+        options.logLevel = "DEBUG"
+
+        with Toil(options) as toil:
+
+            # specify the folder where the cwl and yml files live
+            inputs_dir = "/tmp/"
+            # specify where you wish the outputs to be written
+            outputs_dir = "/tmp/"
+            # specify the location of your cromwell jar
+            jar_loc = "cromwell.jar"
+
+            job0 = Job.wrapJobFn(initialize_jobs)
+
+            wdl_filename = "hello.wdl"
+            wdl_file = toil.importFile("file://" + os.path.join(inputs_dir, wdl_filename))
+
+
+            # add list of yml config inputs here or import and construct from file
+            json_files = ["hello1.json", "hello2.json", "hello3.json"]
+            i = 0
+            for json in json_files:
+                i = i + 1
+                json_file = toil.importFile("file://" + os.path.join(inputs_dir, json))
+                json_filename = json
+                job = Job.wrapJobFn(runQC, wdl_file, wdl_filename, json_file, json_filename, outputs_dir, jar_loc,output_num=str(i))
+                job0.addChild(job)
+
+            toil.start(job0)
+
+
 WDL Specifications
 ------------------
 WDL language specifications can be found here: https://github.com/broadinstitute/wdl/blob/develop/SPEC.md

--- a/docs/running/wdl.rst
+++ b/docs/running/wdl.rst
@@ -110,14 +110,16 @@ Any number of arbitrary options may also be specified.  These options will not b
 as toil options once the wdl/json files are processed.  For valid toil options, see the documentation:
 http://toil.readthedocs.io/en/3.12.0/running/cli.html
 
-Running WDL with Toil Scripts
+Running WDL within Toil Scripts
 ------------------------------------
 
 .. note::
         A cromwell.jar file is needed in order to run a WDL workflow.
 
-WDL workflows can be run indirectly in native Toil scripts. For example, if you wanted to run a WDL workflow, with
-3 JSON files specifying different samples inputs, it could look something like::
+A WDL workflow can be run indirectly in a native Toil script. However, this is not the :ref:`standard <wdl>` way to run
+WDL workflows with Toil and doing so comes at the cost of job efficency. For some use cases, such as running one process on
+multiple files, it may be useful. For example, if you want to run a WDL workflow with 3 JSON files specifying different
+samples inputs, it could look something like::
 
     from toil.job import Job
     from toil.common import Toil


### PR DESCRIPTION
Addresses #2260. Provides examples of executing CWL and WDL workflows from a Toil script.